### PR TITLE
Fix download links for macos and linux builds

### DIFF
--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -1,10 +1,11 @@
 = CLI
 include::ROOT:partial$component-attributes.adoc[]
 :uri-homebrew: https://brew.sh
-:uri-pkl-macos-download: {github-releases}/pkl-cli-macos-{pkl-artifact-version}.bin
-:uri-pkl-linux-amd64-download: {github-releases}/pkl-cli-linux-amd64-{pkl-artifact-version}.bin
-:uri-pkl-linux-aarch64-download: {github-releases}/pkl-cli-linux-aarch64-{pkl-artifact-version}.bin
-:uri-pkl-alpine-download: {github-releases}/pkl-cli-alpine-amd64-{pkl-artifact-version}.bin
+:uri-pkl-macos-amd64-download: {github-releases}/pkl-macos-amd64
+:uri-pkl-macos-aarch64-download: {github-releases}/pkl-macos-aarch64
+:uri-pkl-linux-amd64-download: {github-releases}/pkl-linux-amd64
+:uri-pkl-linux-aarch64-download: {github-releases}/pkl-linux-aarch64
+:uri-pkl-alpine-download: {github-releases}/pkl-alpine-linux-amd64
 :uri-pkl-java-download: {github-releases}/pkl-cli-java-{pkl-artifact-version}.jar
 :uri-pkl-stdlib-docs-settings: {uri-pkl-stdlib-docs}/settings/
 :uri-pkl-cli-main-sources: {uri-github-tree}/pkl-cli/src/main/kotlin/org/pkl/cli
@@ -76,10 +77,22 @@ Development and release versions can be downloaded and installed manually.
 
 === macOS Executable
 
+On amd64:
+
 [source,shell]
 [subs="+attributes"]
 ----
-curl -o pkl {uri-pkl-macos-download}
+curl -o pkl {uri-pkl-macos-amd64-download}
+chmod +x pkl
+./pkl --version
+----
+
+On aarch64:
+
+[source,shell]
+[subs="+attributes"]
+----
+curl -o pkl {uri-pkl-macos-aarch64-download}
 chmod +x pkl
 ./pkl --version
 ----


### PR DESCRIPTION
Update wrong macos and linux download links.

Fix #4