### PR TITLE
Fix macOS download URL mismatch

### DIFF
--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -88,22 +88,22 @@ Development and release versions can be downloaded and installed manually.
 
 === macOS Executable
 
-On amd64:
-
-[source,shell]
-[subs="+attributes"]
-----
-curl -L -o pkl {uri-pkl-macos-amd64-download}
-chmod +x pkl
-./pkl --version
-----
-
 On aarch64:
 
 [source,shell]
 [subs="+attributes"]
 ----
 curl -L -o pkl {uri-pkl-macos-aarch64-download}
+chmod +x pkl
+./pkl --version
+----
+
+On amd64:
+
+[source,shell]
+[subs="+attributes"]
+----
+curl -L -o pkl {uri-pkl-macos-amd64-download}
 chmod +x pkl
 ./pkl --version
 ----

--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -93,7 +93,7 @@ On amd64:
 [source,shell]
 [subs="+attributes"]
 ----
-curl -L -o pkl {uri-pkl-macos-aarch64-download}
+curl -L -o pkl {uri-pkl-macos-amd64-download}
 chmod +x pkl
 ./pkl --version
 ----
@@ -103,7 +103,7 @@ On aarch64:
 [source,shell]
 [subs="+attributes"]
 ----
-curl -L -o pkl {uri-pkl-macos-amd64-download}
+curl -L -o pkl {uri-pkl-macos-aarch64-download}
 chmod +x pkl
 ./pkl --version
 ----


### PR DESCRIPTION
The download URL mismatched with the architecture for macOS builds.