### PR TITLE
fix spell error in language-reference page

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -269,7 +269,7 @@ Floats support the same comparison and arithmetic operators as integers.
 Float literals with zero fractional part can be safely replaced with integer literals.
 For example, it is safe to write `1.3 * 42` instead of `1.3 * 42.0`.
 
-Floats can also include the same underscore separater as integers. For example, `1_000.4_400` is a float whose value is equivalent to `1000.4400`.
+Floats can also include the same underscore separator as integers. For example, `1_000.4_400` is a float whose value is equivalent to `1000.4400`.
 
 TIP: As integers are more convenient to use than floats with zero fractional part, we recommend to require `x: Number` instead of `x: Float` in type annotations.
 
@@ -3836,7 +3836,7 @@ More complex union types can be formed:
 foo: List<Boolean|Number|String>|Bird
 ----
 
-Union types have no implicit default values, but an explicit type can be choosen using a `*` marker:
+Union types have no implicit default values, but an explicit type can be chosen using a `*` marker:
 [source%parsed,{pkl}]
 ----
 foo: "a"|"b"       // undefined. Will throw an error if not amended
@@ -3997,7 +3997,7 @@ pigeon: Bird = new {
 ----
 <1> Restricts `name` to have at least three characters.
 <2> The name of the bird (`this`) should not be the same as the name of the `parent`.
-<3> Note how `parent` is different from `name`. If they were the same, we would be thrown a contraint error.
+<3> Note how `parent` is different from `name`. If they were the same, we would be thrown a constraint error.
 
 In the following example, we define a `Bird` with a name of only two characters.
 
@@ -5024,7 +5024,7 @@ To answer this question, Pkl follows these steps:
   If a match is found, this is the answer.
 . Search the `pkl.base` module for a top-level definition of method `x`.
   If a match is found, this is the answer.
-. Seach the class inheritance chain of `this`, starting with the class of `this`
+. Search the class inheritance chain of `this`, starting with the class of `this`
   and continuing upwards until and including class `Any`, for a method named `x.`
   If a match is found, this is the answer.
 . Throw a "method `x` not found" error.

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -626,7 +626,7 @@ Default: `false` +
 Whether to ignore expected example files and generate them again.
 ====
 
-Common propeties:
+Common properties:
 
 include::../partials/gradle-common-properties.adoc[]
 
@@ -688,6 +688,6 @@ Example: `projectDirectories.from(file("pkl-config/""))` +
 The project directories to create packages for.
 ====
 
-Common propeties:
+Common properties:
 
 include::../partials/gradle-common-properties.adoc[]


### PR DESCRIPTION
thanks for opensource `pkl`, that's awesome.  It is very useful, especially to generate repeating k8s yaml files. It's time to get ride of helm. 


after went through https://pkl-lang.org/main/current/language-reference/index.html, found few spell errors. This PR to fix these errors. 