### PR TITLE
Update 02_filling_out_a_template.adoc

### DIFF
--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -220,7 +220,7 @@ import "pigeon.pkl" // <1>
 parrot = (pigeon) {
   name = "Great green macaw"
   diet = "Berries"
-  species {
+  taxonomy {
     species = "Ara ambiguus"
   }
 }


### PR DESCRIPTION
fix wrong key being used, which would cause pkl eval to fail:
```
➜  pkl_poc pkl eval -f json ./parrot.pkl
–– Pkl Error ––
Cannot find property `species` in module `pigeon`.

6 | species {
    ^^^^^^^
at parrot#parrot (file:///Users/ricardoambrogi/Projects/pkl_poc/parrot.pkl, line 6)

Available properties in module `pigeon`:
diet
name
output
taxonomy

106 | text = renderer.renderDocument(value)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
at pkl.base#Module.output.text (https://github.com/apple/pkl/blob/0.25.1/stdlib/base.pkl#L106)

```