### PR TITLE
Fix broken search on pkldoc

### DIFF
--- a/pkl-doc/src/main/resources/org/pkl/doc/scripts/search-worker.js
+++ b/pkl-doc/src/main/resources/org/pkl/doc/scripts/search-worker.js
@@ -14,6 +14,7 @@ if (isWorker) {
   const searchIndexUrl = workerName === "main" ?
       '../search-index.js' :
       '../' + workerName + '/search-index.js';
+  importScripts(searchIndexUrl);
   initSearchIndex();
   addEventListener('message', e => {
     const {query, packageName, moduleName, className} = e.data;
@@ -177,12 +178,11 @@ function toWordStarts(characters) {
   return result;
 }
 
-const regexIsUppercase = /\p{Lu}/u
-
-const regexIsNumericCharacter = /\p{N}/u
 
 // Partitions characters into uppercase, digit, dot, and other.
 function toCharClass(ch) {
+  const regexIsUppercase = /\p{Lu}/u
+  const regexIsNumericCharacter = /\p{N}/u
   return regexIsUppercase.test(ch) ? 3 : regexIsNumericCharacter.test(ch) ? 2 : ch === '.' ? 1 : 0;
 }
 

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/scripts/search-worker.js
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/scripts/search-worker.js
@@ -14,6 +14,7 @@ if (isWorker) {
   const searchIndexUrl = workerName === "main" ?
       '../search-index.js' :
       '../' + workerName + '/search-index.js';
+  importScripts(searchIndexUrl);
   initSearchIndex();
   addEventListener('message', e => {
     const {query, packageName, moduleName, className} = e.data;
@@ -177,12 +178,11 @@ function toWordStarts(characters) {
   return result;
 }
 
-const regexIsUppercase = /\p{Lu}/u
-
-const regexIsNumericCharacter = /\p{N}/u
 
 // Partitions characters into uppercase, digit, dot, and other.
 function toCharClass(ch) {
+  const regexIsUppercase = /\p{Lu}/u
+  const regexIsNumericCharacter = /\p{N}/u
   return regexIsUppercase.test(ch) ? 3 : regexIsNumericCharacter.test(ch) ? 2 : ch === '.' ? 1 : 0;
 }
 


### PR DESCRIPTION
Fixes two issues:

1. The search-index.js script doesn't get imported in the docsite
2. The regexes aren't accessible to the function, thanks to hoisting