### PR TITLE
Fix documentation homepage

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/PklInfo.java
+++ b/pkl-core/src/main/java/org/pkl/core/PklInfo.java
@@ -17,7 +17,7 @@ package org.pkl.core;
 
 /** Information about the Pkl package index. */
 public final class PklInfo {
-  private static final String PACKAGE_INDEX_HOMEPAGE = "https://pkl-lang.org/package-docs";
+  private static final String PACKAGE_INDEX_HOMEPAGE = "https://pkl-lang.org/package-docs/";
 
   private static final PklInfo CURRENT;
   private final PackageIndex packageIndex;


### PR DESCRIPTION
This adds a trailing slash that was missing from the documentation homepage.