### PR TITLE
Only build static executable if musl toolchain is installed

### DIFF
--- a/buildSrc/src/main/kotlin/BuildInfo.kt
+++ b/buildSrc/src/main/kotlin/BuildInfo.kt
@@ -97,7 +97,7 @@ open class BuildInfo(project: Project) {
 
   val hasMuslToolchain: Boolean by lazy {
     // see "install musl" in .circleci/jobs/BuildNativeJob.pkl
-    File(System.getProperty("user.home"), "staticdeps/bin/musl-gcc").exists()
+    File(System.getProperty("user.home"), "staticdeps/bin/x86_64-linux-musl-gcc").exists()
   }
 
   val os: org.gradle.internal.os.OperatingSystem by lazy {

--- a/buildSrc/src/main/kotlin/BuildInfo.kt
+++ b/buildSrc/src/main/kotlin/BuildInfo.kt
@@ -95,6 +95,11 @@ open class BuildInfo(project: Project) {
     java.lang.Boolean.getBoolean("releaseBuild")
   }
 
+  val hasMuslToolchain: Boolean by lazy {
+    // see "install musl" in .circleci/jobs/BuildNativeJob.pkl
+    File(System.getProperty("user.home"), "staticdeps/bin/musl-gcc").exists()
+  }
+
   val os: org.gradle.internal.os.OperatingSystem by lazy {
     org.gradle.internal.os.OperatingSystem.current()
   }

--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -254,7 +254,7 @@ val linuxExecutableAarch64: TaskProvider<Exec> by tasks.registering(Exec::class)
  */
 val alpineExecutableAmd64: TaskProvider<Exec> by tasks.registering(Exec::class) {
   configureExecutable(
-      buildInfo.os.isLinux && buildInfo.arch == "amd64",
+      buildInfo.os.isLinux && buildInfo.arch == "amd64" && buildInfo.hasMuslToolchain,
       file("$buildDir/executable/pkl-alpine-linux-amd64"),
       listOf(
         "--static",

--- a/pkl-core/pkl-core.gradle.kts
+++ b/pkl-core/pkl-core.gradle.kts
@@ -256,7 +256,7 @@ val testLinuxExecutableAarch64 by tasks.registering(Test::class) {
 }
 
 val testAlpineExecutableAmd64 by tasks.registering(Test::class) {
-  enabled = buildInfo.os.isLinux && buildInfo.arch == "amd64"
+  enabled = buildInfo.os.isLinux && buildInfo.arch == "amd64" && buildInfo.hasMuslToolchain
   dependsOn(":pkl-cli:alpineExecutableAmd64")
 
   inputs.dir("src/test/files/LanguageSnippetTests/input")


### PR DESCRIPTION
This improves the development experience for (WSL) Linux users. They can now run "./gradlew buildNative" without having a musl toolchain installed. In this case, only the dynamically linked executable will be built.