### PR TITLE
update 'Loading Modules' example to match config contents

### DIFF
--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -654,7 +654,7 @@ To evaluate the `bird.species` property, run:
 
 [source,shell]
 ----
-pkl> bird.name
+pkl> bird.species
 "Pigeon"
 ----
 
@@ -716,7 +716,7 @@ pkl> hello
 pkl> function double(n) = 2 * n
 pkl> double(5)
 10
-pkl> class Bird { name: String }
+pkl> class Bird { species: String }
 pkl> new Bird { species = "Pigeon" }
 {
   name = ?
@@ -748,7 +748,7 @@ Due to Pkl's late binding semantics, redefining a member affects dependent membe
 [source,shell]
 ----
 pkl> name = "Barn"
-pkl> species = "$name Owl"
+pkl> species = "\(name) Owl"
 pkl> species
 "Barn owl"
 pkl> name = "Elf"

--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -650,7 +650,7 @@ To load <<config.pkl,`config.pkl`>> into the REPL, run:
 pkl> :load config.pkl
 ----
 
-To evaluate the `bird.name` property, run:
+To evaluate the `bird.species` property, run:
 
 [source,shell]
 ----


### PR DESCRIPTION
The example config content:
bird {
  species = "Pigeon"
  diet = "Seeds"
}
parrot {
  species = "Parrot"
  diet = "Berries"
}

But in the 'Loading Modules' example, 'bird.name' was used which in most cases will return an error for those following;
–– Pkl Error ––
Cannot find property name in object of type Dynamic.

1 | bird.name
    ^^^^^^^^^
at  (repl:pkl1)

Available properties:
default
diet
species
