### PR TITLE
Fix missing `pkl eval` subcommand in documentation examples

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -2584,7 +2584,7 @@ This behavior is similar to the behavior of Bash with `shopt -s dotglob` enabled
 
 === Security Checks
 
-When attempting to directly evaluate a module, as in `pkl myModule.pkl`,
+When attempting to directly evaluate a module, as in `pkl eval myModule.pkl`,
 the following security checks are performed:
 
 * The module URI is checked against the module allowlist (`--allowed-modules`).
@@ -2637,7 +2637,7 @@ b {
 }
 ----
 
-`pkl config.pkl`, which is shorthand for `pkl --format pcf config.pkl`, renders the module as Pcf:
+`pkl eval config.pkl`, which is shorthand for `pkl eval --format pcf config.pkl`, renders the module as Pcf:
 
 [source,{pkl}]
 ----
@@ -2647,7 +2647,7 @@ b {
 }
 ----
 
-`pkl --format yaml config.pkl` renders the module as YAML:
+`pkl eval --format yaml config.pkl` renders the module as YAML:
 
 [source,yaml]
 ----
@@ -2656,7 +2656,7 @@ b:
   c: 20
 ----
 
-Likewise, `pkl --format json config.pkl` renders the module as JSON.
+Likewise, `pkl eval --format json config.pkl` renders the module as JSON.
 
 [[in-language]]
 ==== In-language
@@ -2812,7 +2812,7 @@ output {
 }
 ----
 
-Running `pkl -m output/ pigeon.pkl` produces the following output files:
+Running `pkl eval -m output/ pigeon.pkl` produces the following output files:
 
 .output/birds/pigeon.json
 [source,json]

--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -342,7 +342,7 @@ The following command prints `Pigeon` to the console:
 
 [source,shell]
 ----
-pkl eval -x metadata.name pigeon.pkl
+pkl eval -x metadata.species pigeon.pkl
 # => Pigeon
 ----
 
@@ -356,7 +356,7 @@ metadata {
 }
 
 output {
-  text = metadata.name.toString()
+  text = metadata.species.toString()
 }
 ----
 ====

--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -342,7 +342,7 @@ The following command prints `Pigeon` to the console:
 
 [source,shell]
 ----
-pkl -x metadata.name pigeon.pkl
+pkl eval -x metadata.name pigeon.pkl
 # => Pigeon
 ----
 


### PR DESCRIPTION
A bunch of examples were trying to invoke `pkl` on a file directly without using a subcommand.

Also fix the docs for `pkl eval -x` that used the wrong key.
