### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -685,7 +685,7 @@ dodo {
 As you probably guessed, the nested property `class` can be accessed with `dodo.taxonomy.class`.
 
 Like all values, objects are _immutable_, which is just a fancy (and short!) way to say that their properties never change.
-So what happens when Pigeon moves to a different street? Do we have to construct a new object from scratch?
+So what happens when dodo moves to a different street? Do we have to construct a new object from scratch?
 
 [[amending-objects]]
 === Amending Objects

--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -685,7 +685,7 @@ dodo {
 As you probably guessed, the nested property `class` can be accessed with `dodo.taxonomy.class`.
 
 Like all values, objects are _immutable_, which is just a fancy (and short!) way to say that their properties never change.
-So what happens when dodo moves to a different street? Do we have to construct a new object from scratch?
+So what happens when Dodo moves to a different street? Do we have to construct a new object from scratch?
 
 [[amending-objects]]
 === Amending Objects

--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -32,7 +32,7 @@ parrot = (bird) {
 }
 ----
 
-Parrot and Pigeon have nearly identical properties.
+`parrot` and `bird` have nearly identical properties.
 They only differ in their name and taxonomy, so if you have already written out `bird`, you can say that `parrot` is just like `pigeon` except `name` is `"Parrot"`, diet is `"Berries"` the `taxonomy.order` is `"Psittaciformes"`.
 When you run this, Pkl expands everything fully.
 

--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -33,7 +33,7 @@ parrot = (bird) {
 ----
 
 `parrot` and `bird` have nearly identical properties.
-They only differ in their name and taxonomy, so if you have already written out `bird`, you can say that `parrot` is just like `pigeon` except `name` is `"Parrot"`, diet is `"Berries"` the `taxonomy.order` is `"Psittaciformes"`.
+They only differ in their name and taxonomy, so if you have already written out `bird`, you can say that `parrot` is just like `bird` except `name` is `"Parrot"`, diet is `"Berries"` the `taxonomy.order` is `"Psittaciformes"`.
 When you run this, Pkl expands everything fully.
 
 [source,{pkl}]

--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -32,7 +32,7 @@ parrot = (bird) {
 }
 ----
 
-`parrot` and `bird` have nearly identical properties.
+Parrot and Pigeon have nearly identical properties.
 They only differ in their name and taxonomy, so if you have already written out `bird`, you can say that `parrot` is just like `bird` except `name` is `"Parrot"`, diet is `"Berries"` the `taxonomy.order` is `"Psittaciformes"`.
 When you run this, Pkl expands everything fully.
 


### PR DESCRIPTION
At docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc:35, I guess it makes at least some sense to keep it as is (it was prettier before my change), but I believe the proposed change makes it ever so slightly more accurate, making it a tiny bit easier for first-time readers to understand the nomenclature.

(Absolutely love this tool btw! 😍)