### PR TITLE
Introduce Typed objects before referring to them

### DIFF
--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -58,11 +58,11 @@ parrot {
 }
 ----
 
-[IMPORTANT]
+[NOTE]
 ====
-_Amending_ does not allow us to _add_ properties to the (typed) object we are amending.
+So far, we have only worked with link:{uri-stdlib-Dynamic}[Dynamic] objects. The other type available to us is link:{uri-stdlib-Typed}[Typed] objects. _Amending_ allows us to override, amend, and add new properties to a dynamic object, but a typed object will only let us amend or override existing properties, not add entirely new ones.
 The xref:03_writing_a_template.adoc[next part of the tutorial] discusses types in more detail.
-There, you see that amending _never changes the type_ of the object.
+There, you see that amending _never changes the type_ of a typed object.
 ====
 
 You can also amend nested objects.

--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -62,7 +62,7 @@ parrot {
 ====
 So far, we have only worked with link:{uri-stdlib-Dynamic}[Dynamic] objects. The other type available to us is link:{uri-stdlib-Typed}[Typed] objects. _Amending_ allows us to override, amend, and add new properties to a dynamic object, but a typed object will only let us amend or override existing properties, not add entirely new ones.
 The xref:03_writing_a_template.adoc[next part of the tutorial] discusses types in more detail.
-There, you see that amending _never changes the type_ of a typed object.
+There, you see that amending _never changes the type_ of the object.
 ====
 
 You can also amend nested objects.

--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -60,7 +60,10 @@ parrot {
 
 [NOTE]
 ====
-So far, we have only worked with link:{uri-stdlib-Dynamic}[Dynamic] objects. The other type available to us is link:{uri-stdlib-Typed}[Typed] objects. _Amending_ allows us to override, amend, and add new properties to a dynamic object, but a typed object will only let us amend or override existing properties, not add entirely new ones.
+So far, you have only worked with link:{uri-stdlib-Dynamic}[Dynamic] objects.
+Pkl also offers link:{uri-stdlib-Typed}[Typed] objects.
+_Amending_ allows you to override, amend, and add new properties to a dynamic object.
+Typed objects will only let you amend or override existing properties, not add entirely new ones.
 The xref:03_writing_a_template.adoc[next part of the tutorial] discusses types in more detail.
 There, you see that amending _never changes the type_ of the object.
 ====


### PR DESCRIPTION
Currently, typed objects are only briefly mentioned in the sentence stating that (typed) objects cannot be amended with new properties, only existing ones. This is unnecessarily confusing since all examples up until that point have been concerned with dynamic objects. Since the tutorial goes on to amend a dynamic object with a new property in the next section, a reader who isn't yet aware there are two types of objects might be confused by what seems to be a contradiction.