### PR TITLE
Rename some CLI classes for consistency

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliPackageDownloader.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliPackageDownloader.kt
@@ -21,7 +21,7 @@ import org.pkl.commons.cli.CliException
 import org.pkl.core.packages.PackageResolver
 import org.pkl.core.packages.PackageUri
 
-class CliDownloadPackageCommand(
+class CliPackageDownloader(
   baseOptions: CliBaseOptions,
   private val packageUris: List<PackageUri>,
   private val noTransitive: Boolean

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliProjectCommand.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliProjectCommand.kt
@@ -23,10 +23,8 @@ import org.pkl.commons.cli.CliCommand
 import org.pkl.commons.cli.CliException
 import org.pkl.core.module.ProjectDependenciesManager.PKL_PROJECT_FILENAME
 
-abstract class CliAbstractProjectCommand(
-  cliOptions: CliBaseOptions,
-  private val projectDirs: List<Path>
-) : CliCommand(cliOptions) {
+abstract class CliProjectCommand(cliOptions: CliBaseOptions, private val projectDirs: List<Path>) :
+  CliCommand(cliOptions) {
 
   protected val normalizedProjectFiles: List<Path> by lazy {
     if (projectDirs.isEmpty()) {

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliProjectPackager.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliProjectPackager.kt
@@ -33,7 +33,7 @@ class CliProjectPackager(
   private val skipPublishCheck: Boolean,
   private val consoleWriter: Writer = System.out.writer(),
   private val errWriter: Writer = System.err.writer()
-) : CliAbstractProjectCommand(baseOptions, projectDirs) {
+) : CliProjectCommand(baseOptions, projectDirs) {
 
   private fun runApiTests(project: Project) {
     val apiTests = project.`package`!!.apiTests

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliProjectResolver.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliProjectResolver.kt
@@ -28,7 +28,7 @@ class CliProjectResolver(
   projectDirs: List<Path>,
   private val consoleWriter: Writer = System.out.writer(),
   private val errWriter: Writer = System.err.writer()
-) : CliAbstractProjectCommand(baseOptions, projectDirs) {
+) : CliProjectCommand(baseOptions, projectDirs) {
   override fun doRun() {
     for (projectFile in normalizedProjectFiles) {
       val project = loadProject(projectFile)

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/commands/DownloadPackageCommand.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/commands/DownloadPackageCommand.kt
@@ -21,7 +21,7 @@ import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.groups.provideDelegate
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
-import org.pkl.cli.CliDownloadPackageCommand
+import org.pkl.cli.CliPackageDownloader
 import org.pkl.commons.cli.commands.BaseCommand
 import org.pkl.commons.cli.commands.ProjectOptions
 import org.pkl.commons.cli.commands.single
@@ -62,7 +62,7 @@ class DownloadPackageCommand(helpLink: String) :
       .flag()
 
   override fun run() {
-    CliDownloadPackageCommand(
+    CliPackageDownloader(
         baseOptions.baseOptions(emptyList(), projectOptions),
         packageUris,
         noTransitive

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliPackageDownloaderTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliPackageDownloaderTest.kt
@@ -26,7 +26,7 @@ import org.pkl.commons.test.FileTestUtils
 import org.pkl.commons.test.PackageServer
 import org.pkl.core.packages.PackageUri
 
-class CliDownloadPackageCommandTest {
+class CliPackageDownloaderTest {
   companion object {
     @BeforeAll
     @JvmStatic
@@ -38,7 +38,7 @@ class CliDownloadPackageCommandTest {
   @Test
   fun `download packages`(@TempDir tempDir: Path) {
     val cmd =
-      CliDownloadPackageCommand(
+      CliPackageDownloader(
         baseOptions =
           CliBaseOptions(
             moduleCacheDir = tempDir,
@@ -76,7 +76,7 @@ class CliDownloadPackageCommandTest {
     )
 
     val cmd =
-      CliDownloadPackageCommand(
+      CliPackageDownloader(
         baseOptions =
           CliBaseOptions(
             workingDir = tempDir,
@@ -95,7 +95,7 @@ class CliDownloadPackageCommandTest {
   @Test
   fun `download package while specifying checksum`(@TempDir tempDir: Path) {
     val cmd =
-      CliDownloadPackageCommand(
+      CliPackageDownloader(
         baseOptions =
           CliBaseOptions(
             moduleCacheDir = tempDir,
@@ -117,7 +117,7 @@ class CliDownloadPackageCommandTest {
   @Test
   fun `download package with invalid checksum`(@TempDir tempDir: Path) {
     val cmd =
-      CliDownloadPackageCommand(
+      CliPackageDownloader(
         baseOptions =
           CliBaseOptions(
             moduleCacheDir = tempDir,
@@ -145,7 +145,7 @@ class CliDownloadPackageCommandTest {
   @Test
   fun `disabling caching is an error`(@TempDir tempDir: Path) {
     val cmd =
-      CliDownloadPackageCommand(
+      CliPackageDownloader(
         baseOptions = CliBaseOptions(workingDir = tempDir, noCache = true),
         packageUris = listOf(PackageUri("package://localhost:12110/birds@0.5.0")),
         noTransitive = true
@@ -157,7 +157,7 @@ class CliDownloadPackageCommandTest {
   @Test
   fun `download packages with bad checksum`(@TempDir tempDir: Path) {
     val cmd =
-      CliDownloadPackageCommand(
+      CliPackageDownloader(
         baseOptions =
           CliBaseOptions(
             moduleCacheDir = tempDir,
@@ -175,7 +175,7 @@ class CliDownloadPackageCommandTest {
   @Test
   fun `download multiple failing packages`(@TempDir tempDir: Path) {
     val cmd =
-      CliDownloadPackageCommand(
+      CliPackageDownloader(
         baseOptions =
           CliBaseOptions(
             moduleCacheDir = tempDir,
@@ -211,7 +211,7 @@ class CliDownloadPackageCommandTest {
 
   @Test
   fun `download package, including transitive dependencies`(@TempDir tempDir: Path) {
-    CliDownloadPackageCommand(
+    CliPackageDownloader(
         baseOptions =
           CliBaseOptions(
             moduleCacheDir = tempDir,


### PR DESCRIPTION
CliDownloadPackageCommand -> CliPackageDownloader (consistent with CliProjectPackager/CliProjectResolver) CliAbstractProjectCommand -> CliProjectCommand (consistent with CliCommand)

As I learned yesterday, I'm touching a public API here. Let me know if this is acceptable.