### PR TITLE
Update Reserved keywords list in the Language Reference

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -5120,11 +5120,9 @@ They cannot be used as a regular identifier, and currently do not have any meani
 * `override`
 * `record`
 * `delete`
-* `match`
 * `case`
 * `switch`
 * `vararg`
-* `const`
 
 To use these names in an identifier, <<quoted-identifiers, surround them with backticks>>.
 


### PR DESCRIPTION
`const` is not reserved, it has a meaning already. And `match` is not a keyword at all.
