### PR TITLE
Fix Gradle test tasks in pkl-server

### DIFF
--- a/pkl-server/pkl-server.gradle.kts
+++ b/pkl-server/pkl-server.gradle.kts
@@ -16,14 +16,4 @@ dependencies {
 tasks.test {
   inputs.dir("src/test/files/SnippetTests/input")
   inputs.dir("src/test/files/SnippetTests/output")
-  dependsOn(unitTests)
-
-  useJUnitPlatform {
-    includeEngines("SnippetTestEngine")
-  }
-}
-
-val unitTests by tasks.registering(Test::class) {
-  testClassesDirs = files(tasks.test.get().testClassesDirs)
-  classpath = tasks.test.get().classpath
 }


### PR DESCRIPTION
Before: "test" runs no tests, "unitTests" runs all tests
After : "test" runs all tests