### PR TITLE
Fix dropped `implementSerializable` flag

### DIFF
--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
@@ -39,5 +39,5 @@ data class CliKotlinCodeGeneratorOptions(
   val implementSerializable: Boolean = false
 ) {
   fun toKotlinCodegenOptions(): KotlinCodegenOptions =
-    KotlinCodegenOptions(indent, generateKdoc, generateSpringBootConfig)
+    KotlinCodegenOptions(indent, generateKdoc, generateSpringBootConfig, implementSerializable)
 }


### PR DESCRIPTION
Fixes and closes apple/pkl#191:

> In [CliKotlinCodeGeneratorOptions](https://github.com/apple/pkl/blob/3b2feb45cf47ef97c6db38b2cb5af4ecc713f447/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt#L41-L42), the implementSerializable property is not copied to the KotlinCodegenOptions, in effect meaning it cannot be toggled to true.
