### PR TITLE
Fix multiple output example code

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -2813,7 +2813,7 @@ output {
 }
 ----
 
-Running `pkl eval -m output/ pigeon.pkl` produces the following output files:
+Running `pkl eval -m output/ birds.pkl` produces the following output files:
 
 .output/birds/pigeon.json
 [source,json]


### PR DESCRIPTION
Example given on pkl docs for `-m` is incorrect.

```sh
pkl eval -m output/ pigeon.pkl
–– Pkl Error ––
Cannot find module `../pkl_schemas/pigeon.pkl`.
```

Should be

```sh
pkl eval -m output/ birds.pkl
output/birds/pigeon.json
output/birds/parrot.yaml
```