### PR TITLE
Update Gradle syntax in docs

### DIFF
--- a/docs/modules/java-binding/pages/codegen.adoc
+++ b/docs/modules/java-binding/pages/codegen.adoc
@@ -42,7 +42,7 @@ Groovy::
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile "org.pkl-lang:pkl-codegen-java:{pkl-artifact-version}"
+  implementation "org.pkl-lang:pkl-codegen-java:{pkl-artifact-version}"
 }
 
 repositories {
@@ -61,7 +61,7 @@ Kotlin::
 [source,kotlin,subs="+attributes"]
 ----
 dependencies {
-  compile("org.pkl-lang:pkl-codegen-java:{pkl-artifact-version}")
+  implementation("org.pkl-lang:pkl-codegen-java:{pkl-artifact-version}")
 }
 
 repositories {

--- a/docs/modules/java-binding/pages/pkl-config-java.adoc
+++ b/docs/modules/java-binding/pages/pkl-config-java.adoc
@@ -37,7 +37,7 @@ Groovy::
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile "org.pkl-lang:pkl-config-java:{pkl-artifact-version}"
+  implementation "org.pkl-lang:pkl-config-java:{pkl-artifact-version}"
 }
 
 ifdef::is-release-version[]
@@ -59,7 +59,7 @@ Kotlin::
 [source,kotlin,subs="+attributes"]
 ----
 dependencies {
-  compile("org.pkl-lang:pkl-config-java:{pkl-artifact-version}")
+  implementation("org.pkl-lang:pkl-config-java:{pkl-artifact-version}")
 }
 
 repositories {

--- a/docs/modules/kotlin-binding/pages/codegen.adoc
+++ b/docs/modules/kotlin-binding/pages/codegen.adoc
@@ -33,7 +33,7 @@ Groovy::
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile "org.pkl-lang:pkl-codegen-kotlin:{pkl-artifact-version}"
+  implementation "org.pkl-lang:pkl-codegen-kotlin:{pkl-artifact-version}"
 }
 
 repositories {
@@ -52,7 +52,7 @@ Kotlin::
 [source,kotlin,subs="+attributes"]
 ----
 dependencies {
-  compile("org.pkl-lang:pkl-codegen-kotlin:{pkl-artifact-version}")
+  implementation("org.pkl-lang:pkl-codegen-kotlin:{pkl-artifact-version}")
 }
 
 repositories {

--- a/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
+++ b/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
@@ -26,7 +26,7 @@ Groovy::
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile "org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}"
+  implementation "org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}"
 }
 
 repositories {
@@ -45,7 +45,7 @@ Kotlin::
 [source,kotlin,subs="+attributes"]
 ----
 dependencies {
-  compile("org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}")
+  implementation("org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}")
 }
 
 repositories {

--- a/docs/modules/pkl-core/pages/index.adoc
+++ b/docs/modules/pkl-core/pages/index.adoc
@@ -36,7 +36,7 @@ Groovy::
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile "org.pkl-lang:pkl-core:{pkl-artifact-version}"
+  implementation "org.pkl-lang:pkl-core:{pkl-artifact-version}"
 }
 
 repositories {
@@ -55,7 +55,7 @@ Kotlin::
 [source,kotlin,subs="+attributes"]
 ----
 dependencies {
-  compile("org.pkl-lang:pkl-core:{pkl-artifact-version}")
+  implementation("org.pkl-lang:pkl-core:{pkl-artifact-version}")
 }
 
 repositories {

--- a/docs/modules/pkl-doc/pages/index.adoc
+++ b/docs/modules/pkl-doc/pages/index.adoc
@@ -92,7 +92,7 @@ Groovy::
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile "org.pkl-lang:pkl-doc:{pkl-artifact-version}"
+  implementation "org.pkl-lang:pkl-doc:{pkl-artifact-version}"
 }
 
 repositories {
@@ -111,7 +111,7 @@ Kotlin::
 [source,kotlin,subs="+attributes"]
 ----
 dependencies {
-  compile("org.pkl-lang:pkl-doc:{pkl-artifact-version}")
+  implementation("org.pkl-lang:pkl-doc:{pkl-artifact-version}")
 }
 
 repositories {


### PR DESCRIPTION
Replace the legacy "compile" scope with "implementation". This matches Maven Central's recommended syntax:
https://central.sonatype.com/artifact/org.pkl-lang/pkl-core