### PR TITLE
Move tool versions to Version Catalog

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,10 @@ dependencies {
     exclude(module = "kotlin-android-extensions")
   }
   implementation(libs.shadowPlugin)
+
+  // fix from the Gradle team: makes version catalog symbols available in build scripts
+  // see here for more: https://github.com/gradle/gradle/issues/15383
+  implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }
 
 java {

--- a/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("HttpUrlsUsage")
 
+import org.gradle.accessors.dm.LibrariesForLibs
+
 plugins {
   `java-library`
   id("pklKotlinTest")
@@ -8,6 +10,9 @@ plugins {
 
 // make sources Jar available to other subprojects
 val sourcesJarConfiguration = configurations.register("sourcesJar")
+
+// Version Catalog library symbols.
+val libs = the<LibrariesForLibs>()
 
 java {
   withSourcesJar() // creates `sourcesJar` task
@@ -21,7 +26,7 @@ artifacts {
 
 spotless {
   java {
-    googleJavaFormat("1.15.0")
+    googleJavaFormat(libs.versions.googleJavaFormat.get())
     targetExclude("**/generated/**", "**/build/**")
     licenseHeaderFile(rootProject.file("buildSrc/src/main/resources/license-header.star-block.txt"))
   }

--- a/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.accessors.dm.LibrariesForLibs
+
 plugins {
   id("pklJavaLibrary")
 
@@ -5,6 +7,9 @@ plugins {
 }
 
 val buildInfo = project.extensions.getByType<BuildInfo>()
+
+// Version Catalog library symbols.
+val libs = the<LibrariesForLibs>()
 
 dependencies {
   // At least some of our kotlin APIs contain Kotlin stdlib types
@@ -21,7 +26,7 @@ tasks.compileKotlin {
 
 spotless {
   kotlin {
-    ktfmt("0.44").googleStyle()
+    ktfmt(libs.versions.ktfmt.get()).googleStyle()
     targetExclude("**/generated/**", "**/build/**")
     licenseHeaderFile(rootProject.file("buildSrc/src/main/resources/license-header.star-block.txt"))
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ clikt = "3.5.1"
 commonMark = "0.+"
 downloadTaskPlugin = "4.1.2"
 geantyref = "1.+"
+googleJavaFormat = "1.15.0"
 # must not use `+` because used in download URL
 graalVm = "22.3.3"
 # intentionally empty; replaced by patch file when building pkl-cli macos/aarch64
@@ -30,6 +31,7 @@ kotlin = "1.7.10"
 kotlinPoet = "1.6.+" 
 kotlinxHtml = "0.+"
 kotlinxSerialization = "1.+"
+ktfmt = "0.44"
 # replaces nuValidator's log4j dependency
 # something related to log4j-1.2-api is apparently broken in 2.17.2
 log4j = "2.17.1"


### PR DESCRIPTION
## Summary

Add a fix to make Version Catalog symbols visible within the `buildSrc` plugins, and then move tool versions (Google Java Format and ktfmt) into the catalog.

Originally previewed as part of apple/pkl#204.

## Changelog

- fix: make version catalog accessible from `buildSrc` plugins
- chore: declare `googleFormatVersion` in version catalog
- chore: declare `ktfmt` in version catalog