### PR TITLE
Use Gradle typed project accessors

### DIFF
--- a/bench/bench.gradle.kts
+++ b/bench/bench.gradle.kts
@@ -10,7 +10,7 @@ val graal: Configuration by configurations.creating
 
 @Suppress("UnstableApiUsage")
 dependencies {
-  jmh(project(":pkl-core"))
+  jmh(projects.pklCore)
   // necessary because antlr4-runtime is declared as implementation dependency in pkl-core.gradle
   jmh(libs.antlrRuntime)
   truffle(libs.truffleApi)

--- a/docs/docs.gradle.kts
+++ b/docs/docs.gradle.kts
@@ -20,10 +20,10 @@ sourceSets {
 }
 
 dependencies {
-  testImplementation(project(":pkl-core"))
-  testImplementation(project(":pkl-config-java"))
-  testImplementation(project(":pkl-config-kotlin"))
-  testImplementation(project(":pkl-commons-test"))
+  testImplementation(projects.pklCore)
+  testImplementation(projects.pklConfigJava)
+  testImplementation(projects.pklConfigKotlin)
+  testImplementation(projects.pklCommonsTest)
   testImplementation(libs.junitEngine)
   testImplementation(libs.antlrRuntime)
 }

--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -38,23 +38,23 @@ dependencies {
   compileOnly(libs.svm)
 
   // CliEvaluator exposes PClass
-  api(project(":pkl-core"))
+  api(projects.pklCore)
   // CliEvaluatorOptions exposes CliBaseOptions
-  api(project(":pkl-commons-cli"))
+  api(projects.pklCommonsCli)
 
-  implementation(project(":pkl-commons"))
+  implementation(projects.pklCommons)
   implementation(libs.jansi)
   implementation(libs.jlineReader)
   implementation(libs.jlineTerminal)
   implementation(libs.jlineTerminalJansi)
-  implementation(project(":pkl-server"))
+  implementation(projects.pklServer)
   implementation(libs.clikt) {
     // force clikt to use our version of the kotlin stdlib
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
   }
 
-  testImplementation(project(":pkl-commons-test"))
+  testImplementation(projects.pklCommonsTest)
 
   stagedMacAmd64Executable(files("$buildDir/executable/pkl-macos-amd64"))
   stagedMacAarch64Executable(files("$buildDir/executable/pkl-macos-aarch64"))

--- a/pkl-codegen-java/pkl-codegen-java.gradle.kts
+++ b/pkl-codegen-java/pkl-codegen-java.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 
 dependencies {
   // CliJavaCodeGeneratorOptions exposes CliBaseOptions
-  api(project(":pkl-commons-cli"))
+  api(projects.pklCommonsCli)
 
-  implementation(project(":pkl-commons"))
-  implementation(project(":pkl-core"))
+  implementation(projects.pklCommons)
+  implementation(projects.pklCore)
   implementation(libs.javaPoet)
 
-  testImplementation(project(":pkl-config-java"))
-  testImplementation(project(":pkl-commons-test"))
+  testImplementation(projects.pklConfigJava)
+  testImplementation(projects.pklCommonsTest)
 }
 
 // with `org.gradle.parallel=true` and without the line below, `test` strangely runs into:

--- a/pkl-codegen-kotlin/pkl-codegen-kotlin.gradle.kts
+++ b/pkl-codegen-kotlin/pkl-codegen-kotlin.gradle.kts
@@ -25,15 +25,15 @@ tasks.jar {
 }
 
 dependencies {
-  implementation(project(":pkl-commons"))
-  api(project(":pkl-commons-cli"))
-  api(project(":pkl-core"))
+  implementation(projects.pklCommons)
+  api(projects.pklCommonsCli)
+  api(projects.pklCore)
   
   implementation(libs.kotlinPoet)
   implementation(libs.kotlinReflect)
 
-  testImplementation(project(":pkl-config-kotlin"))
-  testImplementation(project(":pkl-commons-test"))
+  testImplementation(projects.pklConfigKotlin)
+  testImplementation(projects.pklCommonsTest)
   testImplementation(libs.kotlinCompilerEmbeddable)
   testRuntimeOnly(libs.kotlinScriptingCompilerEmbeddable)
   testRuntimeOnly(libs.kotlinScriptUtil)

--- a/pkl-commons-cli/pkl-commons-cli.gradle.kts
+++ b/pkl-commons-cli/pkl-commons-cli.gradle.kts
@@ -5,15 +5,15 @@ plugins {
 }
 
 dependencies {
-  api(project(":pkl-core"))
+  api(projects.pklCore)
   api(libs.clikt) {
     // force clikt to use our version of the kotlin stdlib
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
   }
 
-  implementation(project(":pkl-commons"))
-  testImplementation(project(":pkl-commons-test"))
+  implementation(projects.pklCommons)
+  testImplementation(projects.pklCommonsTest)
 }
 
 publishing {

--- a/pkl-commons-test/pkl-commons-test.gradle.kts
+++ b/pkl-commons-test/pkl-commons-test.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   api(libs.junitApi)
   api(libs.junitEngine)
   api(libs.junitParams)
-  api(project(":pkl-commons")) // for convenience
+  api(projects.pklCommons) // for convenience
   implementation(libs.assertj)
 }
 

--- a/pkl-config-java/pkl-config-java.gradle.kts
+++ b/pkl-config-java/pkl-config-java.gradle.kts
@@ -62,7 +62,7 @@ sourceSets.getByName("test") {
 
 dependencies {
   // "api" because ConfigEvaluator extends Evaluator
-  api(project(":pkl-core"))
+  api(projects.pklCore)
 
   implementation(libs.geantyref)
 
@@ -70,7 +70,7 @@ dependencies {
 
   firstPartySourcesJars(project(":pkl-core", "sourcesJar"))
 
-  pklCodegenJava(project(":pkl-codegen-java"))
+  pklCodegenJava(projects.pklCodegenJava)
 }
 
 tasks.shadowJar {

--- a/pkl-config-kotlin/pkl-config-kotlin.gradle.kts
+++ b/pkl-config-kotlin/pkl-config-kotlin.gradle.kts
@@ -16,11 +16,11 @@ val pklCodegenKotlin: Configuration by configurations.creating
 configurations.api.get().extendsFrom(pklConfigJava)
 
 dependencies {
-  pklConfigJava(project(":pkl-config-java"))
+  pklConfigJava(projects.pklConfigJava)
 
   pklConfigJavaAll(project(":pkl-config-java", "fatJar"))
 
-  pklCodegenKotlin(project(":pkl-codegen-kotlin"))
+  pklCodegenKotlin(projects.pklCodegenKotlin)
 
   implementation(libs.kotlinReflect)
   

--- a/pkl-core/pkl-core.gradle.kts
+++ b/pkl-core/pkl-core.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 
   compileOnly(libs.jsr305)
   // pkl-core implements pkl-executor's ExecutorSpi, but the SPI doesn't ship with pkl-core
-  compileOnly(project(":pkl-executor"))
+  compileOnly(projects.pklExecutor)
 
   implementation(libs.antlrRuntime)
   implementation(libs.truffleApi)
@@ -57,7 +57,7 @@ dependencies {
 
   implementation(libs.snakeYaml)
 
-  testImplementation(project(":pkl-commons-test"))
+  testImplementation(projects.pklCommonsTest)
 
   add("generatorImplementation", libs.javaPoet)
   add("generatorImplementation", libs.truffleApi)

--- a/pkl-doc/pkl-doc.gradle.kts
+++ b/pkl-doc/pkl-doc.gradle.kts
@@ -12,9 +12,9 @@ plugins {
 val graalVmBaseDir = buildInfo.graalVm.baseDir
 
 dependencies {
-  implementation(project(":pkl-core"))
-  implementation(project(":pkl-commons-cli"))
-  implementation(project(":pkl-commons"))
+  implementation(projects.pklCore)
+  implementation(projects.pklCommonsCli)
+  implementation(projects.pklCommons)
   implementation(libs.commonMark)
   implementation(libs.commonMarkTables)
   implementation(libs.kotlinxHtml)
@@ -24,7 +24,7 @@ dependencies {
     exclude(group = "org.jetbrains.kotlin")
   }
 
-  testImplementation(project(":pkl-commons-test"))
+  testImplementation(projects.pklCommonsTest)
   testImplementation(libs.jimfs)
 
   // Graal.JS

--- a/pkl-executor/pkl-executor.gradle.kts
+++ b/pkl-executor/pkl-executor.gradle.kts
@@ -16,8 +16,8 @@ dependencies {
 
   implementation(libs.slf4jApi)
 
-  testImplementation(project(":pkl-commons-test"))
-  testImplementation(project(":pkl-core"))
+  testImplementation(projects.pklCommonsTest)
+  testImplementation(projects.pklCore)
   testImplementation(libs.slf4jSimple)
 }
 

--- a/pkl-gradle/pkl-gradle.gradle.kts
+++ b/pkl-gradle/pkl-gradle.gradle.kts
@@ -12,9 +12,9 @@ plugins {
 }
 
 dependencies {
-  // Declare a `compileOnly` dependency on `project(":pkl-tools")`
+  // Declare a `compileOnly` dependency on `projects.pklTools`
   // to ensure correct code navigation in IntelliJ.
-  compileOnly(project(":pkl-tools"))
+  compileOnly(projects.pklTools)
 
   // Declare a `runtimeOnly` dependency on `project(":pkl-tools", "fatJar")`
   // to ensure that the published plugin 
@@ -31,7 +31,7 @@ dependencies {
     runtimeOnly(project(":pkl-tools", "fatJar"))
   }
 
-  testImplementation(project(":pkl-commons-test"))
+  testImplementation(projects.pklCommonsTest)
 }
 
 publishing {

--- a/pkl-server/pkl-server.gradle.kts
+++ b/pkl-server/pkl-server.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":pkl-core"))
+  implementation(projects.pklCore)
   implementation(libs.msgpack)
   implementation(libs.truffleApi)
   implementation(libs.antlrRuntime)
 
-  testImplementation(project(":pkl-commons-test"))
+  testImplementation(projects.pklCommonsTest)
 }
 
 tasks.test {

--- a/pkl-tools/pkl-tools.gradle.kts
+++ b/pkl-tools/pkl-tools.gradle.kts
@@ -18,12 +18,12 @@ dependencies {
   // can declare a normal project dependency on this project, 
   // which is desirable for IntelliJ integration.
   // The published fat JAR doesn't declare any dependencies.
-  api(project(":pkl-cli"))
-  api(project(":pkl-codegen-java"))
-  api(project(":pkl-codegen-kotlin"))
-  api(project(":pkl-config-java"))
-  api(project(":pkl-core"))
-  api(project(":pkl-doc"))
+  api(projects.pklCli)
+  api(projects.pklCodegenJava)
+  api(projects.pklCodegenKotlin)
+  api(projects.pklConfigJava)
+  api(projects.pklCore)
+  api(projects.pklDoc)
   
   // used by `pklFatJar` plugin (ideally this would be inferred automatically)
   firstPartySourcesJars(project(":pkl-cli", "sourcesJar"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,3 +47,5 @@ if (gradle.startParameter.taskNames.contains("updateDependencyLocks") ||
 for (prj in rootProject.children) {
   prj.buildFileName = "${prj.name}.gradle.kts"
 }
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
## Summary

This change activates the `TYPESAFE_PROJECT_ACCESSORS` feature preview in Gradle, and switches to such accessors instead of string-based project references, where possible

Originally previewed in apple/pkl#204

## Changelog

- chore: activate `TYPESAFE_PROJECT_ACCESSORS` feature
- chore: switch to using project references instead of `project(":<...>")` in most circumstances
