### PR TITLE
Skip POM validation for unpublished projects

### DIFF
--- a/buildSrc/src/main/kotlin/pklPublishLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklPublishLibrary.gradle.kts
@@ -50,6 +50,9 @@ publishing {
 }
 
 val validatePom by tasks.registering {
+  if (tasks.findByName("generatePomFileForLibraryPublication") == null) {
+    return@registering
+  }
   val generatePomFileForLibraryPublication by tasks.existing(GenerateMavenPom::class)
   val outputFile = file("$buildDir/validatePom") // dummy output to satisfy up-to-date check
 


### PR DESCRIPTION
## Summary

This small change fixes a bug introduced by the `validatePom` task within the `pklPublishLibrary` plugin. When running project-wide tasks like `./gradle tasks`, projects which don't provide a POM fail the build, because the `generatePomFileForLibraryPublication` cannot be found, but it is expected to be present.

With this change applied, `validatePom` only runs if the task `generatePomFileForLibraryPublication` is present in a given project.

Fixes and closes apple/pkl#215
