### PR TITLE
Fix almost-bug in PackageResolvers

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
+++ b/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
@@ -447,13 +447,12 @@ class PackageResolvers {
       return path.substring(lastSep + 1);
     }
 
-    private byte[] downloadUriToPathAndComputeChecksum(URI downloadUri, Path relativePath)
+    private byte[] downloadUriToPathAndComputeChecksum(URI downloadUri, Path path)
         throws IOException, SecurityManagerException {
-      var tmpPath = tmpDir.resolve(relativePath);
-      Files.createDirectories(tmpPath.getParent());
+      Files.createDirectories(path.getParent());
       var inputStream = openExternalUri(downloadUri);
       try (var digestInputStream = newDigestInputStream(inputStream)) {
-        Files.copy(digestInputStream, tmpPath);
+        Files.copy(digestInputStream, path);
         return digestInputStream.getMessageDigest().digest();
       }
     }


### PR DESCRIPTION
The only call site already resolved the path against tmpDir.