### PR TITLE
Tweak User-Agent header

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
+++ b/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
@@ -63,7 +63,7 @@ class PackageResolvers {
 
     static {
       var release = Release.current();
-      USER_AGENT = "Pkl/" + release.version() + " (" + release.os() + " " + release.flavor() + ")";
+      USER_AGENT = "Pkl/" + release.version() + " (" + release.os() + "; " + release.flavor() + ")";
     }
 
     @GuardedBy("lock")


### PR DESCRIPTION
It is customary to separate elements with a semicolon.