### PR TITLE
Add Gradle toolchain support

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -141,11 +141,11 @@ local buildNativeJobs: Mapping<String, BuildNativeJob> = new {
 
 local gradleCheckJobs: Mapping<String, GradleCheckJob> = new {
   ["gradle-check-jdk11"] {
-    javaVersion = "11.0"
+    javaVersion = "11"
     isRelease = false
   }
   ["gradle-check-jdk17"] {
-    javaVersion = "17.0"
+    javaVersion = "17"
     isRelease = false
   }
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,7 +583,7 @@ jobs:
     steps:
     - checkout
     - run:
-        command: ./gradlew --info --stacktrace check
+        command: ./gradlew --info --stacktrace check -DPKL_JVM_VERSION=11
         name: gradle check
     - run:
         command: |-
@@ -601,7 +601,7 @@ jobs:
     steps:
     - checkout
     - run:
-        command: ./gradlew --info --stacktrace check
+        command: ./gradlew --info --stacktrace check -DPKL_JVM_VERSION=17
         name: gradle check
     - run:
         command: |-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -614,7 +614,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
     docker:
-    - image: cimg/openjdk:17.0
+    - image: cimg/openjdk:11.0
   bench:
     steps:
     - checkout

--- a/.circleci/jobs/GradleCheckJob.pkl
+++ b/.circleci/jobs/GradleCheckJob.pkl
@@ -22,7 +22,7 @@ javaVersion: "11.0"|"17.0"
 steps {
   new Config.RunStep {
     name = "gradle check"
-    command = "./gradlew \(module.gradleArgs) check"
+    command = "./gradlew \(module.gradleArgs) check -DPKL_JVM_VERSION=\(javaVersion.dropLast(2))"
   }
 }
 

--- a/.circleci/jobs/GradleCheckJob.pkl
+++ b/.circleci/jobs/GradleCheckJob.pkl
@@ -17,19 +17,19 @@ extends "GradleJob.pkl"
 
 import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.0#/Config.pkl"
 
-javaVersion: "11.0"|"17.0"
+javaVersion: "11"|"17"
 
 steps {
   new Config.RunStep {
     name = "gradle check"
-    command = "./gradlew \(module.gradleArgs) check -DPKL_JVM_VERSION=\(javaVersion.dropLast(2))"
+    command = "./gradlew \(module.gradleArgs) check -DPKL_JVM_VERSION=\(javaVersion)"
   }
 }
 
 job {
   docker {
     new {
-      image = "cimg/openjdk:\(javaVersion)"
+      image = "cimg/openjdk:11.0"
     }
   }
 }

--- a/DEVELOPMENT.adoc
+++ b/DEVELOPMENT.adoc
@@ -2,11 +2,9 @@
 :uri-gng: https://gng.dsun.org
 :uri-jenv: https://www.jenv.be
 :uri-intellij: https://www.jetbrains.com/idea/download/
-:uri-jdk: https://adoptopenjdk.net/releases.html
 
 == Setup
 
-. (mandatory) Install {uri-jdk}[OpenJDK 11 HotSpot] (as long as we support JDK11)
 . (recommended) Install {uri-intellij}[IntelliJ IDEA 2023.x] +
 To import the project into IntelliJ, go to File->Open and select the project's root directory.
 If the project is opened but not imported, look for a popup in the lower right corner

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.config.JvmTarget
-
 plugins {
   `kotlin-dsl`
 }
@@ -17,17 +15,6 @@ dependencies {
   implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }
 
-java {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
-}
-
 kotlin {
-  target {
-    compilations.configureEach {
-      kotlinOptions {
-        jvmTarget = "11"
-      }
-    }
-  }
+  jvmToolchain(11)
 }

--- a/buildSrc/src/main/kotlin/JvmToolchain.kt
+++ b/buildSrc/src/main/kotlin/JvmToolchain.kt
@@ -1,12 +1,11 @@
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JvmVendorSpec
-import org.gradle.api.Project
 
 private const val JDK_VERSION = 11
 
 val jvmToolchainVersion: JavaLanguageVersion
     get() {
-        val jvmVersion = System.getProperty("PKL_JVM_VERSION", JDK_VERSION.toString()).toInt()
+        val jvmVersion = System.getProperty("PKL_JVM_VERSION")?.toInt() ?: JDK_VERSION
         return JavaLanguageVersion.of(jvmVersion)
     }
 

--- a/buildSrc/src/main/kotlin/JvmToolchain.kt
+++ b/buildSrc/src/main/kotlin/JvmToolchain.kt
@@ -1,0 +1,14 @@
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.gradle.api.Project
+
+private const val JDK_VERSION = 11
+
+val jvmToolchainVersion: JavaLanguageVersion
+    get() {
+        val jvmVersion = System.getProperty("PKL_JVM_VERSION", JDK_VERSION.toString()).toInt()
+        return JavaLanguageVersion.of(jvmVersion)
+    }
+
+val jvmToolchainVendor: JvmVendorSpec 
+    get() = JvmVendorSpec.ADOPTIUM

--- a/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts
@@ -22,15 +22,8 @@ configurations {
   }
 }
 
-plugins.withType(JavaPlugin::class).configureEach {
-  val java = project.extensions.getByType<JavaPluginExtension>()
-  java.sourceCompatibility = JavaVersion.VERSION_11
-  java.targetCompatibility = JavaVersion.VERSION_11
-}
-
 tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
-    jvmTarget = "11"
     freeCompilerArgs = freeCompilerArgs + listOf("-Xjsr305=strict", "-Xjvm-default=all")
   }
 }

--- a/buildSrc/src/main/kotlin/pklFatJar.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklFatJar.gradle.kts
@@ -43,7 +43,7 @@ val relocations = mapOf(
   // pkl-doc dependencies
   "org.commonmark." to "org.pkl.thirdparty.commonmark.",
   "org.jetbrains." to "org.pkl.thirdparty.jetbrains.",
-  
+
   // pkl-config-java dependencies
   "io.leangen.geantyref." to "org.pkl.thirdparty.geantyref.",
 
@@ -53,6 +53,13 @@ val relocations = mapOf(
   // pkl-codegen-kotlin dependencies
   "com.squareup.kotlinpoet." to "org.pkl.thirdparty.kotlinpoet.",
 )
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+    vendor.set(JvmVendorSpec.ADOPTIUM)
+  }
+}
 
 val nonRelocations = listOf("com/oracle/truffle/")
 
@@ -117,7 +124,7 @@ val validateFatJar by tasks.registering {
       val path = fileDetails.relativePath.pathString
       if (!(fileDetails.isDirectory ||
           path.startsWith("org/pkl/") ||
-          path.startsWith("META-INF/") || 
+          path.startsWith("META-INF/") ||
           nonRelocations.any { path.startsWith(it) })) {
         // don't throw exception inside `visit` 
         // as this gives a misleading "Could not expand ZIP" error message

--- a/buildSrc/src/main/kotlin/pklFatJar.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklFatJar.gradle.kts
@@ -56,8 +56,8 @@ val relocations = mapOf(
 
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-    vendor.set(JvmVendorSpec.ADOPTIUM)
+    languageVersion.set(jvmToolchainVersion)
+    vendor.set(jvmToolchainVendor)
   }
 }
 

--- a/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
@@ -24,6 +24,10 @@ java {
   }
 }
 
+tasks.withType<JavaExec>().configureEach {
+  javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
+}
+
 artifacts {
   // make sources Jar available to other subprojects
   add("sourcesJar", tasks["sourcesJar"])

--- a/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
@@ -19,8 +19,8 @@ java {
   withJavadocJar()
 
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-    vendor.set(JvmVendorSpec.ADOPTIUM)
+    languageVersion.set(jvmToolchainVersion)
+    vendor.set(jvmToolchainVendor)
   }
 }
 

--- a/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
@@ -17,6 +17,11 @@ val libs = the<LibrariesForLibs>()
 java {
   withSourcesJar() // creates `sourcesJar` task
   withJavadocJar()
+
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+    vendor.set(JvmVendorSpec.ADOPTIUM)
+  }
 }
 
 artifacts {

--- a/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
@@ -25,8 +25,8 @@ tasks.compileKotlin {
 }
 
 kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.ADOPTIUM)
+  languageVersion.set(jvmToolchainVersion)
+  vendor.set(jvmToolchainVendor)
 }
 
 spotless {

--- a/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
@@ -24,6 +24,11 @@ tasks.compileKotlin {
   enabled = true // disabled by pklJavaLibrary
 }
 
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.ADOPTIUM)
+}
+
 spotless {
   kotlin {
     ktfmt(libs.versions.ktfmt.get()).googleStyle()

--- a/buildSrc/src/main/kotlin/pklKotlinTest.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklKotlinTest.gradle.kts
@@ -17,8 +17,8 @@ dependencies {
 }
 
 kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.ADOPTIUM)
+  languageVersion.set(jvmToolchainVersion)
+  vendor.set(jvmToolchainVendor)
 }
 
 tasks.withType<Test>().configureEach {

--- a/buildSrc/src/main/kotlin/pklKotlinTest.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklKotlinTest.gradle.kts
@@ -16,6 +16,11 @@ dependencies {
   testRuntimeOnly(buildInfo.libs.findLibrary("junitEngine").get())
 }
 
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.ADOPTIUM)
+}
+
 tasks.withType<Test>().configureEach {
   val testTask = this
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,16 +27,15 @@ pluginManagement {
   }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
   repositories {
     mavenCentral()
   }
-}
-
-val javaVersion = JavaVersion.current()
-require(javaVersion.isJava11Compatible) {
-  "Project requires Java 11 or higher, but found ${javaVersion.majorVersion}."
 }
 
 if (gradle.startParameter.taskNames.contains("updateDependencyLocks") ||


### PR DESCRIPTION
fixes #184 

With that we can get rid of the java 11 check and the information around it.
Also, we can "on the fly" update the jdk version the project will build on.
We only need "a" java version installed to start Gradle.

As discussed in the ticket, I also had to update Gradle to version 7.6  which (seems) brings flaky tests.
But we can't use toolchains before that version.
So maybe this PR wil hang here until this is fixed 🙃 

Questions / Todos
* I guess this is not going to work anymore (or has to be adjusted)
👉  https://github.com/apple/pkl/blob/2499e2c4937fc228e49e94e41fdaac065c203168/.circleci/config.pkl#L98C7-L107

* I guess this is not going to work anymore (or has to be adjusted)
👉  https://github.com/apple/pkl/blob/2499e2c4937fc228e49e94e41fdaac065c203168/patches/graalVm23.patch#L25-L30

Let me know if there is more like these 🙃 