### PR TITLE
Fix: add missing "const" and "fixed" modifiers to reflect API

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/VmModifier.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/VmModifier.java
@@ -164,6 +164,10 @@ public final class VmModifier {
         return "hidden";
       case EXTERNAL:
         return "external";
+      case FIXED:
+        return "fixed";
+      case CONST:
+        return "const";
       default:
         throw new VmExceptionBuilder()
             .bug("Cannot convert internal modifier `%s` to a string.", toString(modifier))
@@ -179,6 +183,8 @@ public final class VmModifier {
     if (isHidden(modifiers)) builder.add(toString(HIDDEN));
     // `external` modifier is part of class contract but not part of property/method contract
     if (isExternal(modifiers) && isClass) builder.add(toString(EXTERNAL));
+    if (isFixed(modifiers)) builder.add(toString(FIXED));
+    if (isConst(modifiers)) builder.add(toString(CONST));
 
     return builder.build();
   }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/api/reflect/BaseModule.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/api/reflect/BaseModule.pkl
@@ -49,6 +49,10 @@ stringLiteral: "yes"
 constrained: String(length.isBetween(3, 10))
 aliased: MyMap<Person>
 
+hidden hiddenProp: String
+const constProp: String = "the const prop"
+fixed fixedProp: String = "the fixed prop"
+
 /// class doc comment
 @MyAnn { text = "class annotation" }
 open class Person {

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/reflect1.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/reflect1.pkl
@@ -152,8 +152,11 @@ examples {
     personClassProperties.keys
     testHelpers.property(personClassProperties["name"], reflect.stringType)
     testHelpers.property(personClassProperties["age"], reflect.intType)
+    modClassProps["hiddenProp"].modifiers
+    modClassProps["constProp"].modifiers
+    modClassProps["fixedProp"].modifiers
   }
-  
+
   ["Reflected class methods metadata"] {
     local personClassMethods = personClass.methods
     personClassMethods.keys
@@ -162,7 +165,7 @@ examples {
         List(reflect.listType.withTypeArgument(reflect.stringType)),
         reflect.stringType)
   }
-  
+
   ["Reflected annotation class properties metadata"] {
     testHelpers.property(myAnnClass.properties["text"], reflect.stringType)
   }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflect1.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflect1.pcf
@@ -67,7 +67,7 @@ facts {
 }
 examples {
   ["Reflected module properties of unknown type metadata"] {
-    Set("int", "float", "string", "boolean", "duration", "dataSize", "pair", "list", "set", "map", "listing", "mapping", "dynamic", "typed", "int2", "float2", "string2", "boolean2", "duration2", "dataSize2", "pair2", "list2", "set2", "map2", "listing2", "mapping2", "dynamic2", "typed2", "any", "noth", "unkn", "union", "nullable", "stringLiteral", "constrained", "aliased")
+    Set("int", "float", "string", "boolean", "duration", "dataSize", "pair", "list", "set", "map", "listing", "mapping", "dynamic", "typed", "int2", "float2", "string2", "boolean2", "duration2", "dataSize2", "pair2", "list2", "set2", "map2", "listing2", "mapping2", "dynamic2", "typed2", "any", "noth", "unkn", "union", "nullable", "stringLiteral", "constrained", "aliased", "hiddenProp", "constProp", "fixedProp")
     new {
       hasExpectedLocation = true
       docComment = "module property doc comment"
@@ -373,6 +373,9 @@ examples {
       defaultValue = 42
       hasExpectedType = true
     }
+    Set("hidden")
+    Set("const")
+    Set("fixed")
   }
   ["Reflected class methods metadata"] {
     Set("sing")

--- a/stdlib/reflect.pkl
+++ b/stdlib/reflect.pkl
@@ -319,7 +319,7 @@ external class TypeParameter {
 }
 
 /// A modifier of a [Declaration].
-typealias Modifier = "abstract"|"external"|"hidden"|"open"
+typealias Modifier = "abstract"|"external"|"hidden"|"open"|"fixed"|"const"
 
 /// The variance of a [TypeParameter].
 ///


### PR DESCRIPTION
This fixes an issue where the reflect API does not show `fixed` or `const` modifiers on a property.