### PR TITLE
Revert "Add setting for Kotlin package to codegen (#194)"

### DIFF
--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
@@ -29,9 +29,6 @@ data class CliKotlinCodeGeneratorOptions(
   /** The characters to use for indenting generated source code. */
   val indent: String = "  ",
 
-  /** Kotlin package to use for generated code; if none is provided, the root package is used. */
-  val kotlinPackage: String = "",
-
   /** Whether to generate Kdoc based on doc comments for Pkl modules, classes, and properties. */
   val generateKdoc: Boolean = false,
 
@@ -42,11 +39,5 @@ data class CliKotlinCodeGeneratorOptions(
   val implementSerializable: Boolean = false
 ) {
   fun toKotlinCodegenOptions(): KotlinCodegenOptions =
-    KotlinCodegenOptions(
-      indent = indent,
-      generateKdoc = generateKdoc,
-      generateSpringBootConfig = generateSpringBootConfig,
-      implementSerializable = implementSerializable,
-      kotlinPackage = kotlinPackage,
-    )
+    KotlinCodegenOptions(indent, generateKdoc, generateSpringBootConfig, implementSerializable)
 }

--- a/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
+++ b/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
@@ -133,8 +133,7 @@ class KotlinCodeGeneratorTest {
       pklCode: String,
       generateKdoc: Boolean = false,
       generateSpringBootConfig: Boolean = false,
-      implementSerializable: Boolean = false,
-      kotlinPackage: String? = null,
+      implementSerializable: Boolean = false
     ): String {
 
       val module = Evaluator.preconfigured().evaluateSchema(ModuleSource.text(pklCode))
@@ -145,8 +144,7 @@ class KotlinCodeGeneratorTest {
           KotlinCodegenOptions(
             generateKdoc = generateKdoc,
             generateSpringBootConfig = generateSpringBootConfig,
-            implementSerializable = implementSerializable,
-            kotlinPackage = kotlinPackage ?: "",
+            implementSerializable = implementSerializable
           )
         )
       return generator.kotlinFile
@@ -528,92 +526,6 @@ class KotlinCodeGeneratorTest {
         sibling: Person?
       }
     """
-      )
-
-    assertEqualTo(
-      """
-      package my
-
-      import kotlin.Long
-      import kotlin.String
-      import kotlin.collections.List
-      import kotlin.collections.Map
-
-      object Mod {
-        data class Person(
-          val name: String,
-          val age: Long,
-          val hobbies: List<String>,
-          val friends: Map<String, Person>,
-          val sibling: Person?
-        )
-      }
-    """,
-      kotlinCode
-    )
-
-    assertCompilesSuccessfully(kotlinCode)
-  }
-
-  @Test
-  fun `custom kotlin package prefix`() {
-    val kotlinCode =
-      generateKotlinCode(
-        """
-      module my.mod
-
-      class Person {
-        name: String
-        age: Int
-        hobbies: List<String>
-        friends: Map<String, Person>
-        sibling: Person?
-      }
-    """,
-        kotlinPackage = "cool.pkg.path",
-      )
-
-    assertEqualTo(
-      """
-      package cool.pkg.path.my
-
-      import kotlin.Long
-      import kotlin.String
-      import kotlin.collections.List
-      import kotlin.collections.Map
-
-      object Mod {
-        data class Person(
-          val name: String,
-          val age: Long,
-          val hobbies: List<String>,
-          val friends: Map<String, Person>,
-          val sibling: Person?
-        )
-      }
-    """,
-      kotlinCode
-    )
-
-    assertCompilesSuccessfully(kotlinCode)
-  }
-
-  @Test
-  fun `empty kotlin package prefix`() {
-    val kotlinCode =
-      generateKotlinCode(
-        """
-      module my.mod
-
-      class Person {
-        name: String
-        age: Int
-        hobbies: List<String>
-        friends: Map<String, Person>
-        sibling: Person?
-      }
-    """,
-        kotlinPackage = "",
       )
 
     assertEqualTo(

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -196,15 +196,12 @@ public class PklPlugin implements Plugin<Project> {
           configureCodeGenSpec(spec);
 
           spec.getGenerateKdoc().convention(false);
-          spec.getKotlinPackage().convention("");
 
           createModulesTask(KotlinCodeGenTask.class, spec)
               .configure(
                   task -> {
                     configureCodeGenTask(task, spec);
                     task.getGenerateKdoc().set(spec.getGenerateKdoc());
-                    task.getIndent().set(spec.getIndent());
-                    task.getKotlinPackage().set(spec.getKotlinPackage());
                   });
         });
 

--- a/pkl-gradle/src/main/java/org/pkl/gradle/spec/KotlinCodeGenSpec.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/spec/KotlinCodeGenSpec.java
@@ -19,9 +19,5 @@ import org.gradle.api.provider.Property;
 
 /** Configuration options for Kotlin code generators. Documented in user manual. */
 public interface KotlinCodeGenSpec extends CodeGenSpec {
-  Property<String> getIndent();
-
-  Property<String> getKotlinPackage();
-
   Property<Boolean> getGenerateKdoc();
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/KotlinCodeGenTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/KotlinCodeGenTask.java
@@ -25,9 +25,6 @@ public abstract class KotlinCodeGenTask extends CodeGenTask {
   @Input
   public abstract Property<Boolean> getGenerateKdoc();
 
-  @Input
-  public abstract Property<String> getKotlinPackage();
-
   @Override
   protected void doRunTask() {
     //noinspection ResultOfMethodCallIgnored
@@ -38,7 +35,6 @@ public abstract class KotlinCodeGenTask extends CodeGenTask {
                 getCliBaseOptions(),
                 getProject().file(getOutputDir()).toPath(),
                 getIndent().get(),
-                getKotlinPackage().get(),
                 getGenerateKdoc().get(),
                 getGenerateSpringBootConfig().get(),
                 getImplementSerializable().get()))

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/KotlinCodeGeneratorsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/KotlinCodeGeneratorsTest.kt
@@ -65,22 +65,7 @@ class KotlinCodeGeneratorsTest : AbstractTest() {
     assertThat(personClassFile).exists()
     assertThat(addressClassFile).exists()
   }
-
-  @Test
-  fun `compile generated code with custom kotlin package`() {
-    writeBuildFile(kotlinPackage = "my.cool.pkl.pkg")
-    writePklFile()
-    runTask("compileKotlin")
-
-    val classesDir = testProjectDir.resolve("build/classes/kotlin/main")
-    val moduleClassFile = classesDir.resolve("my/cool/pkl/pkg/org/Mod.class")
-    val personClassFile = classesDir.resolve("my/cool/pkl/pkg/org/Mod\$Person.class")
-    val addressClassFile = classesDir.resolve("my/cool/pkl/pkg/org/Mod\$Address.class")
-    assertThat(moduleClassFile).exists()
-    assertThat(personClassFile).exists()
-    assertThat(addressClassFile).exists()
-  }
-
+  
   @Test
   fun `no source modules`() {
     writeFile(
@@ -103,7 +88,7 @@ class KotlinCodeGeneratorsTest : AbstractTest() {
     assertThat(result.output).contains("No source modules specified.")
   }
 
-  private fun writeBuildFile(kotlinPackage: String? = null) {
+  private fun writeBuildFile() {
     val kotlinVersion = "1.6.0"
 
     writeFile(
@@ -140,7 +125,6 @@ class KotlinCodeGeneratorsTest : AbstractTest() {
             sourceModules = ["mod.pkl"]
             outputDir = file("build/generated")
             settingsModule = "pkl:settings"
-            ${kotlinPackage?.let { "kotlinPackage = \"$it\"" } ?: ""}
           }
         }
       }


### PR DESCRIPTION
This reverts commit 7f404fff490e2dd883cf9683c21f6fd38fd84518.

The package is derived from the module name.
Having `module com.example.Foo` in Pkl
will create Kotlin `package com.example`.