### PR TITLE
Clean up http-client changes

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
@@ -132,11 +132,18 @@ public class ExecutorSpiImpl implements ExecutorSpi {
   private HttpClient getOrCreateHttpClient(ExecutorSpiOptions options) {
     List<Path> certificateFiles;
     List<URI> certificateUris;
-    if (options instanceof ExecutorSpiOptions2) {
-      var options2 = (ExecutorSpiOptions2) options;
-      certificateFiles = options2.getCertificateFiles();
-      certificateUris = options2.getCertificateUris();
-    } else {
+    try {
+      if (options instanceof ExecutorSpiOptions2) {
+        var options2 = (ExecutorSpiOptions2) options;
+        certificateFiles = options2.getCertificateFiles();
+        certificateUris = options2.getCertificateUris();
+      } else {
+        certificateFiles = List.of();
+        certificateUris = List.of();
+      }
+      // host pkl-executor does not have class ExecutorOptions2 defined.
+      // this will happen if the pkl-executor distribution is too old.
+    } catch (NoClassDefFoundError e) {
       certificateFiles = List.of();
       certificateUris = List.of();
     }

--- a/pkl-core/src/main/java/org/pkl/core/util/Exceptions.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/Exceptions.java
@@ -20,10 +20,8 @@ public final class Exceptions {
 
   public static Throwable getRootCause(Throwable t) {
     var result = t;
-    var cause = result.getCause();
-    while (cause != null) {
-      result = cause;
-      cause = cause.getCause();
+    while (result.getCause() != null) {
+      result = result.getCause();
     }
     return result;
   }

--- a/pkl-core/src/test/kotlin/org/pkl/core/util/ExceptionsTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/util/ExceptionsTest.kt
@@ -11,7 +11,7 @@ class ExceptionsTest {
     val e = IOException("io")
     assertThat(Exceptions.getRootCause(e)).isSameAs(e)
   }
-  
+
   @Test
   fun `get root cause of nested exception`() {
     val e = IOException("io")
@@ -29,7 +29,7 @@ class ExceptionsTest {
     e.initCause(e2)
     assertThat(Exceptions.getRootReason(e)).isEqualTo("the root reason")
   }
-  
+
   @Test
   fun `get root reason if null`() {
     val e = IOException("io")

--- a/pkl-executor/pkl-executor.gradle.kts
+++ b/pkl-executor/pkl-executor.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 val pklDistributionCurrent: Configuration by configurations.creating
-val pklDistribution025: Configuration by configurations.creating
+val pklHistoricalDistributions: Configuration by configurations.creating
 
 // Because pkl-executor doesn't depend on other Pkl modules
 // (nor has overlapping dependencies that could cause a version conflict),
@@ -15,7 +15,7 @@ val pklDistribution025: Configuration by configurations.creating
 dependencies {
   pklDistributionCurrent(project(":pkl-config-java", "fatJar"))
   @Suppress("UnstableApiUsage")
-  pklDistribution025(libs.pklConfigJavaAll025)
+  pklHistoricalDistributions(libs.pklConfigJavaAll025)
 
   implementation(libs.slf4jApi)
 
@@ -53,18 +53,14 @@ sourceSets {
 }
 
 val copyHistoricalDistribution by tasks.registering(Copy::class) {
-  from(pklDistribution025)
-  into(layout.buildDirectory.dir("pklDistributions"))
+  from(pklHistoricalDistributions)
+  into(layout.buildDirectory.dir("pklHistoricalDistributions"))
 }
 
-// this task could be folded into tasks.test by switching to IntelliJ's Gradle test runner
 val prepareTest by tasks.registering {
-  // used by EmbeddedExecutorTest
   dependsOn(pklDistributionCurrent, copyHistoricalDistribution)
 }
 
 tasks.test {
   dependsOn(prepareTest)
-  systemProperty("pklDistributionCurrent", pklDistributionCurrent.singleFile)
-  systemProperty("pklDistribution025", pklDistribution025.singleFile)
 }

--- a/pkl-executor/pkl-executor.gradle.kts
+++ b/pkl-executor/pkl-executor.gradle.kts
@@ -52,10 +52,15 @@ sourceSets {
   }
 }
 
+val copyHistoricalDistribution by tasks.registering(Copy::class) {
+  from(pklDistribution025)
+  into(layout.buildDirectory.dir("pklDistributions"))
+}
+
 // this task could be folded into tasks.test by switching to IntelliJ's Gradle test runner
 val prepareTest by tasks.registering {
   // used by EmbeddedExecutorTest
-  dependsOn(pklDistributionCurrent, pklDistribution025)
+  dependsOn(pklDistributionCurrent, copyHistoricalDistribution)
 }
 
 tasks.test {

--- a/pkl-executor/src/test/kotlin/org/pkl/executor/EmbeddedExecutorTest.kt
+++ b/pkl-executor/src/test/kotlin/org/pkl/executor/EmbeddedExecutorTest.kt
@@ -39,7 +39,7 @@ class EmbeddedExecutorTest {
 
         // This context has a pkl-executor version that is lower than the distribution version.
         // It can be enabled once there is a distribution that includes pkl-executor.
-        //ExecutionContext(executor1_2.value, ::convertToOptions1, "Options1, Executor1, Distribution2"),
+        ExecutionContext(executor1_2.value, ::convertToOptions1, "Options1, Executor1, Distribution2"),
 
         ExecutionContext(executor2_1.value, ::convertToOptions1, "Options1, Executor2, Distribution1"),
         ExecutionContext(executor2_1.value, ::convertToOptions2, "Options2, Executor2, Distribution1"),
@@ -70,7 +70,7 @@ class EmbeddedExecutorTest {
     }
 
     // A pkl-executor library that supports ExecutorSpiOptions up to v2
-    // and a Pkl distribution that supports ExecutorSpiOptions up to v.
+    // and a Pkl distribution that supports ExecutorSpiOptions up to v2.
     private val executor2_2: Lazy<Executor> = lazy {
       EmbeddedExecutor(listOf(pklDistribution2), pklExecutorClassLoader2)
     }
@@ -98,18 +98,15 @@ class EmbeddedExecutorTest {
         if (executor.isInitialized()) executor.value.close()
       }
     }
-    
+
     // a Pkl distribution that supports ExecutorSpiOptions up to v1
     private val pklDistribution1: Path by lazy {
-      val path = System.getProperty("pklDistribution025")?.toPath() ?:
-        // can get rid of this path by switching to IntelliJ's Gradle test runner
-        System.getProperty("user.home").toPath()
-          .resolve(".gradle/caches/modules-2/files-2.1/org.pkl-lang/pkl-config-java-all/" +
-            "0.25.0/e9451dda554f1659e49ff5bdd30accd26be7bf0f/pkl-config-java-all-0.25.0.jar")
-      path.apply {
-          if (!exists()) throw AssertionError("Missing test fixture. " +
+      FileTestUtils.rootProjectDir.resolve("pkl-executor/build/pklDistributions/pkl-config-java-all-0.25.0.jar").apply {
+        if (!exists()) {
+          throw AssertionError("Missing test fixture. " +
             "To fix this problem, run `./gradlew :pkl-executor:prepareTest`.")
         }
+      }
     }
 
     // a Pkl distribution that supports ExecutorSpiOptions up to v2
@@ -121,7 +118,7 @@ class EmbeddedExecutorTest {
             "${Release.current().version().withBuild(null).toString().replaceFirst("dev", "SNAPSHOT")}.jar")
       path.apply {
         if (!exists()) throw AssertionError("Missing test fixture. " +
-          "To fix this problem, run `./gradlew :pkl-executor:prepareTest`.")
+          "To fix this problem, run `./gradlew :pkl-config-java:build`.")
       }
     }
 

--- a/pkl-executor/src/test/kotlin/org/pkl/executor/EmbeddedExecutorTest.kt
+++ b/pkl-executor/src/test/kotlin/org/pkl/executor/EmbeddedExecutorTest.kt
@@ -101,7 +101,7 @@ class EmbeddedExecutorTest {
 
     // a Pkl distribution that supports ExecutorSpiOptions up to v1
     private val pklDistribution1: Path by lazy {
-      FileTestUtils.rootProjectDir.resolve("pkl-executor/build/pklDistributions/pkl-config-java-all-0.25.0.jar").apply {
+      FileTestUtils.rootProjectDir.resolve("pkl-executor/build/pklHistoricalDistributions/pkl-config-java-all-0.25.0.jar").apply {
         if (!exists()) {
           throw AssertionError("Missing test fixture. " +
             "To fix this problem, run `./gradlew :pkl-executor:prepareTest`.")
@@ -111,14 +111,11 @@ class EmbeddedExecutorTest {
 
     // a Pkl distribution that supports ExecutorSpiOptions up to v2
     private val pklDistribution2: Path by lazy {
-      val path = System.getProperty("pklDistributionCurrent")?.toPath() ?:
-        // can get rid of this path by switching to IntelliJ's Gradle test runner
-        FileTestUtils.rootProjectDir
-          .resolve("pkl-config-java/build/libs/pkl-config-java-all-" +
-            "${Release.current().version().withBuild(null).toString().replaceFirst("dev", "SNAPSHOT")}.jar")
-      path.apply {
+      FileTestUtils.rootProjectDir
+        .resolve("pkl-config-java/build/libs/pkl-config-java-all-" +
+          "${Release.current().version().withBuild(null).toString().replaceFirst("dev", "SNAPSHOT")}.jar").apply {
         if (!exists()) throw AssertionError("Missing test fixture. " +
-          "To fix this problem, run `./gradlew :pkl-config-java:build`.")
+          "To fix this problem, run `./gradlew :pkl-executor:prepareTest`.")
       }
     }
 


### PR DESCRIPTION
* pkl-excutor tests: copy 0.25.0 distribution into pkl-executable/build
* Use `IoUtils.getPklHomeDir` in HttpClientBuilder
* Simplify Exceptions.java
* Enable testing for older pkl-executor distribution

(CC @translatenix)