### PR TITLE
Fix amending module with abstract class

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/VmModifier.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/VmModifier.java
@@ -72,6 +72,14 @@ public final class VmModifier {
 
   public static final int VALID_OBJECT_MEMBER_MODIFIERS = LOCAL;
 
+  public static final int TYPEALIAS_OBJECT_MEMBER = TYPE_ALIAS | CONST;
+
+  public static final int LOCAL_TYPEALIAS_OBJECT_MEMBER = LOCAL | TYPEALIAS_OBJECT_MEMBER;
+
+  public static final int CLASS_OBJECT_MEMBER = CLASS | CONST;
+
+  public static final int LOCAL_CLASS_OBJECT_MEMBER = LOCAL | CLASS_OBJECT_MEMBER;
+
   public static boolean isLocal(int modifiers) {
     return (modifiers & LOCAL) != 0;
   }

--- a/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
@@ -305,11 +305,13 @@ public final class AstBuilder extends AbstractAstBuilder<Object> {
                   doVisitClassProperties(propertyCtxs, propertyNames),
                   doVisitMethodDefs(methodCtxs));
 
+          var isLocal = VmModifier.isLocal(modifiers);
+
           var result =
               new ObjectMember(
                   sourceSection,
                   headerSection,
-                  modifiers | VmModifier.CONST,
+                  isLocal ? VmModifier.LOCAL_CLASS_OBJECT_MEMBER : VmModifier.CLASS_OBJECT_MEMBER,
                   scope.getName(),
                   scope.getQualifiedName());
 
@@ -360,7 +362,9 @@ public final class AstBuilder extends AbstractAstBuilder<Object> {
               new ObjectMember(
                   sourceSection,
                   headerSection,
-                  modifiers | VmModifier.CONST,
+                  isLocal
+                      ? VmModifier.LOCAL_TYPEALIAS_OBJECT_MEMBER
+                      : VmModifier.TYPEALIAS_OBJECT_MEMBER,
                   scopeName,
                   scope.getQualifiedName());
 

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/modules/Birds.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/modules/Birds.pkl
@@ -1,0 +1,12 @@
+module Birds
+
+abstract class Bird {
+  name: String
+}
+
+class Pigeon extends Bird {
+  name = "Pigeon"
+  passenger: Boolean
+}
+
+pidgy: Pigeon?

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/modules/amendModule6.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/modules/amendModule6.pkl
@@ -1,0 +1,1 @@
+amends ".../input-helper/modules/Birds.pkl"

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/modules/amendModule6.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/modules/amendModule6.pcf
@@ -1,0 +1,1 @@
+pidgy = null


### PR DESCRIPTION
This fixes an assertion error that gets thrown if:
1. A module declares a class as abstract
2. An amending module does not instantiate a value that is an instance of that class
3. Java assertions are turned on

Underneath the hood, the modifiers of the class/typelias object member is considered different from the modifiers on the VmClass/VmTypeAlias values.

The object model skips forcing any explicitly members that are explicitly declared hidden, abstract, or local.
However, it _should_ evaluate any abstract classes found in a module. So, it's incorrect to apply the same modifiers on the class to the object member.