### PR TITLE
Enable Gradle build caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,6 @@ org.gradle.jvmargs= \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 org.gradle.parallel=true
+org.gradle.caching=true
 kotlin.stdlib.default.dependency=false
 #org.gradle.workers.max=1


### PR DESCRIPTION
Speed ups developing process *a bit* 🙃 
See also https://docs.gradle.org/current/userguide/build_cache.html

Some statistics:
> Running `./gradlew clean build console=plain`

**Cache disabled**
clean build 1m 2s
clean build 53s
clean build 51s
*260 actionable tasks: 248 executed, 12 up-to-date*

**Cache enabled**
clean build 48s
clean build 37s
clean build 37s
*260 actionable tasks: 153 executed, 69 from cache, 38 up-to-date*