### PR TITLE
Fix build issue where test fixtures weren't generated

### DIFF
--- a/pkl-commons-test/pkl-commons-test.gradle.kts
+++ b/pkl-commons-test/pkl-commons-test.gradle.kts
@@ -24,7 +24,8 @@ dependencies {
  */
 val createTestPackages by tasks.registering
 
-tasks.test {
+// make sure that declaring a dependency on this project suffices to have test fixtures generated
+tasks.processResources {
   dependsOn(createTestPackages)
   dependsOn(exportCerts)
 }


### PR DESCRIPTION
Make sure that declaring a dependency on project `pkl-commons-test` suffices to have its test fixtures generated.

This fix should work reliably.
However, there may be a more idiomatic way to achieve the same result.