### PR TITLE
Follow HTTP redirects

### DIFF
--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliProjectPackagerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliProjectPackagerTest.kt
@@ -588,7 +588,7 @@ class CliProjectPackagerTest {
               "type": "remote",
               "uri": "projectpackage://localhost:0/birds@0.5.0",
               "checksums": {
-                "sha256": "3f19ab9fcee2f44f93a75a09e531db278c6d2cd25206836c8c2c4071cd7d3118"
+                "sha256": "0a5ad2dc13f06f73f96ba94e8d01d48252bc934e2de71a837620ca0fef8a7453"
               }
             },
             "package://localhost:0/project2@5": {

--- a/pkl-commons-test/src/main/kotlin/org/pkl/commons/test/PackageServer.kt
+++ b/pkl-commons-test/src/main/kotlin/org/pkl/commons/test/PackageServer.kt
@@ -130,11 +130,23 @@ class PackageServer : AutoCloseable {
       return@HttpHandler
     }
     val path = exchange.requestURI.path
+    if (path.startsWith("/HTTP301/")) {
+      exchange.responseHeaders.add("Location", path.removePrefix("/HTTP301"))
+      exchange.sendResponseHeaders(301, -1)
+      exchange.close()
+      return@HttpHandler
+    }
+    if (path.startsWith("/HTTP307/")) {
+      exchange.responseHeaders.add("Location", path.removePrefix("/HTTP307"))
+      exchange.sendResponseHeaders(307, -1)
+      exchange.close()
+      return@HttpHandler
+    }
     val localPath =
       if (path.endsWith(".zip")) packagesDir.resolve(path.drop(1))
       else packagesDir.resolve("${path.drop(1)}${path}.json")
     if (!Files.exists(localPath)) {
-      exchange.sendResponseHeaders(404, 0)
+      exchange.sendResponseHeaders(404, -1)
       exchange.close()
       return@HttpHandler
     }

--- a/pkl-core/src/main/java/org/pkl/core/http/JdkHttpClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/JdkHttpClient.java
@@ -22,6 +22,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.net.ConnectException;
 import java.net.URI;
+import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
@@ -81,6 +82,7 @@ final class JdkHttpClient implements HttpClient {
         java.net.http.HttpClient.newBuilder()
             .sslContext(createSslContext(certificateFiles, certificateUris))
             .connectTimeout(connectTimeout)
+            .followRedirects(Redirect.NORMAL)
             .build();
   }
 

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/packages/packages1.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/packages/packages1.pkl
@@ -16,7 +16,7 @@ examples {
     import("package://localhost:0/birds@0.5.0#/catalog/Ostritch.pkl")
   }
   ["importing while specifying checksum"] {
-    import("package://localhost:0/birds@0.5.0::sha256:3f19ab9fcee2f44f93a75a09e531db278c6d2cd25206836c8c2c4071cd7d3118#/catalog/Swallow.pkl")
+    import("package://localhost:0/birds@0.5.0::sha256:bfaf5281613d170a740505cc87561041f4e0cad1f0e6938bf94f7609f9a4673d#/catalog/Swallow.pkl")
   }
   ["reads"] {
     read("package://localhost:0/birds@0.5.0#/Bird.pkl")

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/packages/packages2.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/packages/packages2.pkl
@@ -20,6 +20,6 @@ examples {
     import("package://localhost:0/birds@0.5.0#/allFruit.pkl").fruitFiles
   }
   ["glob import while specifying checksum"] {
-    import*("package://localhost:0/birds@0.5.0::sha256:3f19ab9fcee2f44f93a75a09e531db278c6d2cd25206836c8c2c4071cd7d3118#/catalog/*.pkl")
+    import*("package://localhost:0/birds@0.5.0::sha256:bfaf5281613d170a740505cc87561041f4e0cad1f0e6938bf94f7609f9a4673d#/catalog/*.pkl")
   }
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/packages/redirects.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/packages/redirects.pkl
@@ -1,0 +1,15 @@
+amends ".../snippetTest.pkl"
+
+examples {
+  ["permanent redirect is followed"] {
+    import("package://localhost:0/HTTP301/birds@0.5.0#/catalog/Swallow.pkl")
+  }
+
+  ["temporary redirect is followed"] {
+    import("package://localhost:0/HTTP307/birds@0.5.0#/catalog/Swallow.pkl")
+  }
+  
+  ["double redirect is followed"] {
+    import("package://localhost:0/HTTP301/HTTP307/birds@0.5.0#/catalog/Swallow.pkl")
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/packages2.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/packages2.pcf
@@ -118,13 +118,13 @@ examples {
   }
   ["glob import while specifying checksum"] {
     new {
-      ["package://localhost:0/birds@0.5.0::sha256:3f19ab9fcee2f44f93a75a09e531db278c6d2cd25206836c8c2c4071cd7d3118#/catalog/Ostritch.pkl"] {
+      ["package://localhost:0/birds@0.5.0::sha256:bfaf5281613d170a740505cc87561041f4e0cad1f0e6938bf94f7609f9a4673d#/catalog/Ostritch.pkl"] {
         name = "Ostritch"
         favoriteFruit {
           name = "Orange"
         }
       }
-      ["package://localhost:0/birds@0.5.0::sha256:3f19ab9fcee2f44f93a75a09e531db278c6d2cd25206836c8c2c4071cd7d3118#/catalog/Swallow.pkl"] {
+      ["package://localhost:0/birds@0.5.0::sha256:bfaf5281613d170a740505cc87561041f4e0cad1f0e6938bf94f7609f9a4673d#/catalog/Swallow.pkl"] {
         name = "Swallow"
         favoriteFruit {
           name = "Apple"

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/redirects.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/redirects.pcf
@@ -1,0 +1,26 @@
+examples {
+  ["permanent redirect is followed"] {
+    new {
+      name = "Swallow"
+      favoriteFruit {
+        name = "Apple"
+      }
+    }
+  }
+  ["temporary redirect is followed"] {
+    new {
+      name = "Swallow"
+      favoriteFruit {
+        name = "Apple"
+      }
+    }
+  }
+  ["double redirect is followed"] {
+    new {
+      name = "Swallow"
+      favoriteFruit {
+        name = "Apple"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Change HttpClient to follow all redirects except HTTPS to HTTP.
- Run language snippet tests with --no-cache and real PackageServer instead of pre-seeded cache. This increases HTTP test coverage and enables testing of package redirects.
- Change PackageServer to return 301 for request paths starting with /HTTP301/ and 307 for request paths starting with /HTTP307/.
- Update some outdated test package checksums that apparently weren't verified.