### PR TITLE
Polish HttpClient API

### DIFF
--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
@@ -185,7 +185,7 @@ data class CliBaseOptions(
    */
   val httpClient: HttpClient by lazy {
     with(HttpClient.builder()) {
-      setTestPort(testPort)
+      testPort(testPort)
       if (normalizedCaCertificates.isEmpty()) {
         addDefaultCliCertificates()
       } else {

--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClient.java
@@ -42,14 +42,14 @@ public interface HttpClient extends AutoCloseable {
      *
      * <p>Defaults to {@code "Pkl/$version ($os; $flavor)"}.
      */
-    Builder setUserAgent(String userAgent);
+    Builder userAgent(String userAgent);
 
     /**
      * Sets the timeout for connecting to a server.
      *
      * <p>Defaults to 60 seconds.
      */
-    Builder setConnectTimeout(java.time.Duration timeout);
+    Builder connectTimeout(java.time.Duration timeout);
 
     /**
      * Sets the timeout for the interval between sending a request and receiving response headers.
@@ -57,7 +57,7 @@ public interface HttpClient extends AutoCloseable {
      * <p>Defaults to 60 seconds. To set a timeout for a specific request, use {@link
      * HttpRequest.Builder#timeout}.
      */
-    Builder setRequestTimeout(java.time.Duration timeout);
+    Builder requestTimeout(java.time.Duration timeout);
 
     /**
      * Adds a CA certificate file to the client's trust store.
@@ -114,7 +114,7 @@ public interface HttpClient extends AutoCloseable {
      * <p>If set, requests that specify port 12110 will be modified to use the given port. This is
      * an internal test option.
      */
-    Builder setTestPort(int port);
+    Builder testPort(int port);
 
     /**
      * Creates a new {@code HttpClient} from the current state of this builder.
@@ -158,10 +158,9 @@ public interface HttpClient extends AutoCloseable {
    * Sends an HTTP request. The response body is processed by the given body handler.
    *
    * <p>If the request does not specify a {@linkplain HttpRequest#timeout timeout}, the client's
-   * {@linkplain Builder#setRequestTimeout request timeout} is used. If the request does not specify
-   * a preferred {@linkplain HttpRequest#version() HTTP version}, HTTP/2 is used. The request's
-   * {@code User-Agent} header is set to the client's {@link Builder#setUserAgent User-Agent}
-   * header.
+   * {@linkplain Builder#requestTimeout request timeout} is used. If the request does not specify a
+   * preferred {@linkplain HttpRequest#version() HTTP version}, HTTP/2 is used. The request's {@code
+   * User-Agent} header is set to the client's {@link Builder#userAgent User-Agent} header.
    *
    * <p>Depending on the given body handler, this method blocks until response headers or the entire
    * response body has been received. If response headers are not received within the request

--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClientBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClientBuilder.java
@@ -49,19 +49,19 @@ final class HttpClientBuilder implements HttpClient.Builder {
         "Pkl/" + release.version() + " (" + release.os() + "; " + release.flavor() + ")";
   }
 
-  public HttpClient.Builder setUserAgent(String userAgent) {
+  public HttpClient.Builder userAgent(String userAgent) {
     this.userAgent = userAgent;
     return this;
   }
 
   @Override
-  public HttpClient.Builder setConnectTimeout(Duration timeout) {
+  public HttpClient.Builder connectTimeout(Duration timeout) {
     this.connectTimeout = timeout;
     return this;
   }
 
   @Override
-  public HttpClient.Builder setRequestTimeout(Duration timeout) {
+  public HttpClient.Builder requestTimeout(Duration timeout) {
     this.requestTimeout = timeout;
     return this;
   }
@@ -104,7 +104,7 @@ final class HttpClientBuilder implements HttpClient.Builder {
   }
 
   @Override
-  public HttpClient.Builder setTestPort(int port) {
+  public HttpClient.Builder testPort(int port) {
     testPort = port;
     return this;
   }

--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClientInitException.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClientInitException.java
@@ -15,13 +15,11 @@
  */
 package org.pkl.core.http;
 
-import org.pkl.core.PklException;
-
 /**
  * Indicates that an error occurred while initializing an HTTP client. A common example is an error
  * reading or parsing a certificate.
  */
-public class HttpClientInitException extends PklException {
+public class HttpClientInitException extends RuntimeException {
   public HttpClientInitException(String message) {
     super(message);
   }

--- a/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
@@ -162,7 +162,7 @@ public class ExecutorSpiImpl implements ExecutorSpi {
           for (var uri : key.certificateUris) {
             builder.addCertificates(uri);
           }
-          builder.setTestPort(key.testPort);
+          builder.testPort(key.testPort);
           // If the above didn't add any certificates,
           // builder will use the JVM's default SSL context.
           return builder.buildLazily();

--- a/pkl-core/src/test/kotlin/org/pkl/core/StackFrameTransformersTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/StackFrameTransformersTest.kt
@@ -12,7 +12,7 @@ class StackFrameTransformersTest {
   @Disabled
   fun replacePackageUriWithSourceCodeUrl() {
     PackageServer().use { server ->
-      val httpClient = HttpClient.builder().setTestPort(server.port).build()
+      val httpClient = HttpClient.builder().testPort(server.port).build()
       EvaluatorBuilder.preconfigured()
         .setHttpClient(httpClient)
         .build().use {

--- a/pkl-core/src/test/kotlin/org/pkl/core/http/HttpClientTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/http/HttpClientTest.kt
@@ -39,9 +39,9 @@ class HttpClientTest {
   @Test
   fun `can build custom client`() {
     val client = HttpClient.builder()
-      .setUserAgent("Agent 1")
-      .setRequestTimeout(Duration.ofHours(86))
-      .setConnectTimeout(Duration.ofMinutes(42))
+      .userAgent("Agent 1")
+      .requestTimeout(Duration.ofHours(86))
+      .connectTimeout(Duration.ofMinutes(42))
       .build() as RequestRewritingClient
 
     assertThat(client.userAgent).isEqualTo("Agent 1")

--- a/pkl-core/src/test/kotlin/org/pkl/core/packages/PackageResolversTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/packages/PackageResolversTest.kt
@@ -39,7 +39,7 @@ class PackageResolversTest {
       val httpClient: HttpClient by lazy {
         HttpClient.builder()
           .addCertificates(FileTestUtils.selfSignedCertificate)
-          .setTestPort(packageServer.port)
+          .testPort(packageServer.port)
           .build()
       }
     }

--- a/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectDependenciesResolverTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectDependenciesResolverTest.kt
@@ -27,7 +27,7 @@ class ProjectDependenciesResolverTest {
     val httpClient: HttpClient by lazy {
       HttpClient.builder()
         .addCertificates(FileTestUtils.selfSignedCertificate)
-        .setTestPort(packageServer.port)
+        .testPort(packageServer.port)
         .build()
     }
   }

--- a/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectTest.kt
@@ -141,7 +141,7 @@ class ProjectTest {
       val project = Project.loadFromPath(projectDir.resolve("PklProject"))
       val httpClient = HttpClient.builder()
         .addCertificates(FileTestUtils.selfSignedCertificate)
-        .setTestPort(server.port)
+        .testPort(server.port)
         .build()
       val evaluator = EvaluatorBuilder.preconfigured()
         .applyFromProject(project)


### PR DESCRIPTION
- Rename builder methods from setFoo() to foo(). As of Java 17, the getFoo()/setFoo(value) naming convention has been effectively replaced with foo()/foo(value). Especially for a pre-1.0 project, it makes sense to align with this development.
- Do not rename addFoo() builder methods to distinguish them from setters.
- Change HttpClientInitException to extend RuntimeException instead of PklException. Except for PklBugException, no other exception class extends PklException.