### PR TITLE
Add CI to release/x.x branch

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===// 
 // File gets rendered to .circleci/config.yml via git hook.
-amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.0.2#/PklCI.pkl"
+amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.1.0#/PklCI.pkl"
 
 import "jobs/BuildNativeJob.pkl"
 import "jobs/GradleCheckJob.pkl"
@@ -71,6 +71,10 @@ release {
       }
     }
   }
+}
+
+releaseBranch {
+  jobs = releaseJobs
 }
 
 triggerDocsBuild = "both"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -896,3 +896,18 @@ workflows:
             ignore: /.*/
           tags:
             only: /^v?\d+\.\d+\.\d+$/
+  release-branch:
+    jobs:
+    - gradle-check-jdk11
+    - gradle-check-jdk17
+    - check-patch-file
+    - bench
+    - pkl-cli-macOS-amd64-release
+    - pkl-cli-linux-amd64-release
+    - pkl-cli-macOS-aarch64-release
+    - pkl-cli-linux-aarch64-release
+    - pkl-cli-linux-alpine-amd64-release
+    when:
+      matches:
+        value: << pipeline.git.branch >>
+        pattern: ^release/\d+\.\d+$

--- a/.circleci/jobs/BuildNativeJob.pkl
+++ b/.circleci/jobs/BuildNativeJob.pkl
@@ -16,7 +16,7 @@
 /// Builds the native `pkl` CLI
 extends "GradleJob.pkl"
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.0.0#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.0#/Config.pkl"
 import "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.0#/URI.pkl"
 
 /// The OS to run on

--- a/.circleci/jobs/DeployJob.pkl
+++ b/.circleci/jobs/DeployJob.pkl
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 extends "GradleJob.pkl"
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.0.0#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.0#/Config.pkl"
 
 local self = this
 

--- a/.circleci/jobs/GradleCheckJob.pkl
+++ b/.circleci/jobs/GradleCheckJob.pkl
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 extends "GradleJob.pkl"
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.0.0#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.0#/Config.pkl"
 
 javaVersion: "11.0"|"17.0"
 

--- a/.circleci/jobs/GradleJob.pkl
+++ b/.circleci/jobs/GradleJob.pkl
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 abstract module GradleJob
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.0.0#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.0#/Config.pkl"
 
 /// Whether this is a release build or not.
 isRelease: Boolean = false

--- a/.circleci/jobs/SimpleGradleJob.pkl
+++ b/.circleci/jobs/SimpleGradleJob.pkl
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 extends "GradleJob.pkl"
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.0.0#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.0#/Config.pkl"
 
 name: String = command
 


### PR DESCRIPTION
Adds logic to build (but not deploy) commits on the release branch.

This is so we have CI coverage for new patch releases of older versions.