### PR TITLE
Fix buildSrc Kotlin/Java compat

### DIFF
--- a/patches/graalVm23.patch
+++ b/patches/graalVm23.patch
@@ -1,5 +1,5 @@
 diff --git a/bench/gradle.lockfile b/bench/gradle.lockfile
-index 0673df5..3a9d913 100644
+index 148e27635..3a9d913e1 100644
 --- a/bench/gradle.lockfile
 +++ b/bench/gradle.lockfile
 @@ -8,9 +8,9 @@ net.sf.jopt-simple:jopt-simple:5.0.4=jmh,jmhCompileClasspath,jmhImplementationDe
@@ -16,10 +16,10 @@ index 0673df5..3a9d913 100644
  org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
  org.jetbrains.kotlin:kotlin-daemon-embeddable:1.7.10=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
 diff --git a/buildSrc/build.gradle.kts b/buildSrc/build.gradle.kts
-index 73eb367..6e526b6 100644
+index e8bf11759..770845b74 100644
 --- a/buildSrc/build.gradle.kts
 +++ b/buildSrc/build.gradle.kts
-@@ -12,6 +12,6 @@ dependencies {
+@@ -18,15 +18,15 @@ dependencies {
  }
  
  java {
@@ -28,8 +28,18 @@ index 73eb367..6e526b6 100644
 +  sourceCompatibility = JavaVersion.VERSION_17
 +  targetCompatibility = JavaVersion.VERSION_17
  }
+ 
+ kotlin {
+   target {
+     compilations.configureEach {
+       kotlinOptions {
+-        jvmTarget = "11"
++        jvmTarget = "17"
+       }
+     }
+   }
 diff --git a/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts b/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts
-index 4daf287..6ef0256 100644
+index 4daf287a7..6ef0256e6 100644
 --- a/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts
 +++ b/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts
 @@ -24,13 +24,13 @@ configurations {
@@ -50,7 +60,7 @@ index 4daf287..6ef0256 100644
    }
  }
 diff --git a/docs/gradle.lockfile b/docs/gradle.lockfile
-index 196e592..e33eb75 100644
+index 6c81fe86a..e33eb75cc 100644
 --- a/docs/gradle.lockfile
 +++ b/docs/gradle.lockfile
 @@ -7,8 +7,8 @@ net.bytebuddy:byte-buddy:1.12.21=testCompileClasspath,testImplementationDependen
@@ -65,11 +75,10 @@ index 196e592..e33eb75 100644
  org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
  org.jetbrains.kotlin:kotlin-daemon-embeddable:1.7.10=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
 diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
-index 5171a9a..6761c58 100644
+index c83f86681..42d94eb11 100644
 --- a/gradle/libs.versions.toml
 +++ b/gradle/libs.versions.toml
-@@ -8,11 +8,11 @@ commonMark = "0.+"
- downloadTaskPlugin = "4.1.2"
+@@ -8,11 +8,11 @@ downloadTaskPlugin = "4.1.2"
  geantyref = "1.+"
  googleJavaFormat = "1.15.0"
  # must not use `+` because used in download URL
@@ -85,7 +94,7 @@ index 5171a9a..6761c58 100644
  graalVmSha256-linux-aarch64 = "177d682f3455d00fa2491246e809d9c9b743187a82115ad3f578998b4935d5a1"
  ideaExtPlugin = "1.1"
 diff --git a/pkl-cli/gradle.lockfile b/pkl-cli/gradle.lockfile
-index 1360caa..0892665 100644
+index 937699a07..089266510 100644
 --- a/pkl-cli/gradle.lockfile
 +++ b/pkl-cli/gradle.lockfile
 @@ -9,13 +9,13 @@ net.java.dev.jna:jna:5.6.0=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
@@ -135,7 +144,7 @@ index 1360caa..0892665 100644
 -empty=annotationProcessor,archives,compile,intransitiveDependenciesMetadata,javaExecutable,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,shadow,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 +empty=annotationProcessor,archives,compile,intransitiveDependenciesMetadata,javaExecutable,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,shadow,signatures,sourcesJar,stagedAlpineLinuxAmd64Executable,stagedLinuxAarch64Executable,stagedLinuxAmd64Executable,stagedMacAarch64Executable,stagedMacAmd64Executable,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 diff --git a/pkl-codegen-java/gradle.lockfile b/pkl-codegen-java/gradle.lockfile
-index 9bf6cba..901c8d8 100644
+index c8387af6d..901c8d824 100644
 --- a/pkl-codegen-java/gradle.lockfile
 +++ b/pkl-codegen-java/gradle.lockfile
 @@ -10,8 +10,8 @@ net.bytebuddy:byte-buddy:1.12.21=testCompileClasspath,testImplementationDependen
@@ -175,7 +184,7 @@ index 9bf6cba..901c8d8 100644
 -empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 +empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,signatures,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 diff --git a/pkl-codegen-kotlin/gradle.lockfile b/pkl-codegen-kotlin/gradle.lockfile
-index 42331c2..7974715 100644
+index 64ac99e02..79747158b 100644
 --- a/pkl-codegen-kotlin/gradle.lockfile
 +++ b/pkl-codegen-kotlin/gradle.lockfile
 @@ -10,8 +10,8 @@ net.bytebuddy:byte-buddy:1.12.21=testCompileClasspath,testImplementationDependen
@@ -215,7 +224,7 @@ index 42331c2..7974715 100644
 -empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 +empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,signatures,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 diff --git a/pkl-commons-cli/gradle.lockfile b/pkl-commons-cli/gradle.lockfile
-index 6cac9f4..f603276 100644
+index 1e587bbb1..f6032762c 100644
 --- a/pkl-commons-cli/gradle.lockfile
 +++ b/pkl-commons-cli/gradle.lockfile
 @@ -8,8 +8,8 @@ net.bytebuddy:byte-buddy:1.12.21=testCompileClasspath,testImplementationDependen
@@ -255,7 +264,7 @@ index 6cac9f4..f603276 100644
 -empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 +empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,signatures,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 diff --git a/pkl-commons/gradle.lockfile b/pkl-commons/gradle.lockfile
-index 4170e1a..0a23c04 100644
+index 4170e1a96..0a23c0402 100644
 --- a/pkl-commons/gradle.lockfile
 +++ b/pkl-commons/gradle.lockfile
 @@ -27,4 +27,4 @@ org.junit.platform:junit-platform-commons:1.9.3=testCompileClasspath,testImpleme
@@ -265,7 +274,7 @@ index 4170e1a..0a23c04 100644
 -empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 +empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,signatures,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 diff --git a/pkl-config-java/gradle.lockfile b/pkl-config-java/gradle.lockfile
-index 271ca49..3648401 100644
+index 9de444020..36484015d 100644
 --- a/pkl-config-java/gradle.lockfile
 +++ b/pkl-config-java/gradle.lockfile
 @@ -11,8 +11,8 @@ net.bytebuddy:byte-buddy:1.12.21=testCompileClasspath,testImplementationDependen
@@ -305,7 +314,7 @@ index 271ca49..3648401 100644
 -empty=annotationProcessor,apiDependenciesMetadata,archives,compile,compileOnly,compileOnlyDependenciesMetadata,fatJar,firstPartySourcesJars,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,pklCoreSourcesJar,runtime,runtimeOnlyDependenciesMetadata,shadow,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 +empty=annotationProcessor,apiDependenciesMetadata,archives,compile,compileOnly,compileOnlyDependenciesMetadata,fatJar,firstPartySourcesJars,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,pklCoreSourcesJar,runtime,runtimeOnlyDependenciesMetadata,shadow,signatures,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 diff --git a/pkl-config-kotlin/gradle.lockfile b/pkl-config-kotlin/gradle.lockfile
-index 681ecdb..5c8f48b 100644
+index ee3c3149d..5c8f48b04 100644
 --- a/pkl-config-kotlin/gradle.lockfile
 +++ b/pkl-config-kotlin/gradle.lockfile
 @@ -10,8 +10,8 @@ net.bytebuddy:byte-buddy:1.12.21=testCompileClasspath,testImplementationDependen
@@ -345,7 +354,7 @@ index 681ecdb..5c8f48b 100644
 -empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,pklConfigJavaAll,runtime,runtimeOnlyDependenciesMetadata,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 +empty=annotationProcessor,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,pklConfigJavaAll,runtime,runtimeOnlyDependenciesMetadata,signatures,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 diff --git a/pkl-core/gradle.lockfile b/pkl-core/gradle.lockfile
-index a4ad3ca..cf5be68 100644
+index b7bb8012f..cf5be682d 100644
 --- a/pkl-core/gradle.lockfile
 +++ b/pkl-core/gradle.lockfile
 @@ -13,9 +13,9 @@ org.antlr:ST4:4.3=antlr
@@ -368,7 +377,7 @@ index a4ad3ca..cf5be68 100644
 -empty=apiDependenciesMetadata,archives,compile,generatorAnnotationProcessor,generatorApiDependenciesMetadata,generatorCompileOnly,generatorCompileOnlyDependenciesMetadata,generatorIntransitiveDependenciesMetadata,generatorKotlinScriptDef,generatorKotlinScriptDefExtensions,generatorRuntimeOnlyDependenciesMetadata,intransitiveDependenciesMetadata,javaExecutable,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 +empty=apiDependenciesMetadata,archives,compile,generatorAnnotationProcessor,generatorApiDependenciesMetadata,generatorCompileOnly,generatorCompileOnlyDependenciesMetadata,generatorIntransitiveDependenciesMetadata,generatorKotlinScriptDef,generatorKotlinScriptDefExtensions,generatorRuntimeOnlyDependenciesMetadata,intransitiveDependenciesMetadata,javaExecutable,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtime,runtimeOnlyDependenciesMetadata,signatures,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 diff --git a/pkl-doc/gradle.lockfile b/pkl-doc/gradle.lockfile
-index 9a78e5a..629fd77 100644
+index 7fb966ded..629fd7748 100644
 --- a/pkl-doc/gradle.lockfile
 +++ b/pkl-doc/gradle.lockfile
 @@ -11,7 +11,7 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava=test
@@ -421,7 +430,7 @@ index 9a78e5a..629fd77 100644
 -empty=annotationProcessor,archives,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtimeOnlyDependenciesMetadata,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions
 +empty=annotationProcessor,archives,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,runtimeOnlyDependenciesMetadata,signatures,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions
 diff --git a/pkl-executor/gradle.lockfile b/pkl-executor/gradle.lockfile
-index c5fa512..0d31a41 100644
+index cff368c31..0d31a41e7 100644
 --- a/pkl-executor/gradle.lockfile
 +++ b/pkl-executor/gradle.lockfile
 @@ -6,8 +6,8 @@ net.bytebuddy:byte-buddy:1.12.21=testCompileClasspath,testImplementationDependen
@@ -442,7 +451,7 @@ index c5fa512..0d31a41 100644
 -empty=annotationProcessor,apiDependenciesMetadata,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,pklDistribution,runtime,runtimeOnlyDependenciesMetadata,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 +empty=annotationProcessor,apiDependenciesMetadata,archives,compile,compileOnly,compileOnlyDependenciesMetadata,intransitiveDependenciesMetadata,kotlinCompilerPluginClasspath,kotlinNativeCompilerPluginClasspath,kotlinScriptDef,kotlinScriptDefExtensions,pklDistribution,runtime,runtimeOnlyDependenciesMetadata,signatures,sourcesJar,testAnnotationProcessor,testApiDependenciesMetadata,testCompile,testCompileOnly,testCompileOnlyDependenciesMetadata,testIntransitiveDependenciesMetadata,testKotlinScriptDef,testKotlinScriptDefExtensions,testRuntime
 diff --git a/pkl-gradle/gradle.lockfile b/pkl-gradle/gradle.lockfile
-index 4db8f8d..d8eaca1 100644
+index 4db8f8d46..d8eaca1a4 100644
 --- a/pkl-gradle/gradle.lockfile
 +++ b/pkl-gradle/gradle.lockfile
 @@ -17,10 +17,14 @@ org.jetbrains.kotlin:kotlin-scripting-common:1.7.10=kotlinCompilerPluginClasspat
@@ -465,7 +474,7 @@ index 4db8f8d..d8eaca1 100644
  org.junit.jupiter:junit-jupiter-api:5.9.3=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath,testRuntimeOnlyDependenciesMetadata
  org.junit.jupiter:junit-jupiter-engine:5.9.3=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath,testRuntimeOnlyDependenciesMetadata
 diff --git a/pkl-server/gradle.lockfile b/pkl-server/gradle.lockfile
-index 22b6965..813fd46 100644
+index 426d96268..813fd4643 100644
 --- a/pkl-server/gradle.lockfile
 +++ b/pkl-server/gradle.lockfile
 @@ -6,8 +6,8 @@ net.bytebuddy:byte-buddy:1.12.21=testCompileClasspath,testImplementationDependen
@@ -480,7 +489,7 @@ index 22b6965..813fd46 100644
  org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
  org.jetbrains.kotlin:kotlin-daemon-embeddable:1.7.10=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
 diff --git a/pkl-tools/gradle.lockfile b/pkl-tools/gradle.lockfile
-index a04dc3b..c1a960c 100644
+index 9f47df5b4..c1a960c74 100644
 --- a/pkl-tools/gradle.lockfile
 +++ b/pkl-tools/gradle.lockfile
 @@ -10,13 +10,15 @@ io.leangen.geantyref:geantyref:1.3.14=default,runtimeClasspath,testRuntimeClassp
@@ -506,7 +515,7 @@ index a04dc3b..c1a960c 100644
  org.jetbrains.kotlinx:kotlinx-serialization-bom:1.5.1=default,runtimeClasspath,testRuntimeClasspath
  org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.5.1=default,runtimeClasspath,testRuntimeClasspath
 diff --git a/stdlib/gradle.lockfile b/stdlib/gradle.lockfile
-index 00a8691..7e06c36 100644
+index c24011720..7e06c366c 100644
 --- a/stdlib/gradle.lockfile
 +++ b/stdlib/gradle.lockfile
 @@ -6,12 +6,12 @@ com.github.ajalt.clikt:clikt:3.5.1=pkldoc


### PR DESCRIPTION
This fixes an issue where Gradle fails to build because of Java/Kotlin getting mismatching versions when targeting macOS/aarch64.