### PR TITLE
Update pkl-config-java.adoc

### DIFF
--- a/docs/modules/java-binding/pages/pkl-config-java.adoc
+++ b/docs/modules/java-binding/pages/pkl-config-java.adoc
@@ -50,7 +50,6 @@ repositories {
   maven { url "{uri-sonatype}" }
 }
 endif::[]
-}
 ----
 
 Kotlin::


### PR DESCRIPTION
There was an unpaired useless end bracket at _Installation_ > _Gradle_ > Codes in _Groovy_ which is removed in this PR.
<img width="859" alt="Screenshot 2024-03-19 at 15 53 39" src="https://github.com/apple/pkl/assets/47817169/3832d9e1-5203-49bf-b1c4-5f468b5648c9">
