### PR TITLE
Add workaround for configuration error during maven publish

### DIFF
--- a/buildSrc/src/main/kotlin/pklPublishLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklPublishLibrary.gradle.kts
@@ -103,6 +103,14 @@ tasks.publish {
   dependsOn(validatePom)
 }
 
+// Workaround for maven publish plugin not setting up dependencies correctly.
+// Taken from https://github.com/gradle/gradle/issues/26091#issuecomment-1798137734
+val dependsOnTasks = mutableListOf<String>()
+tasks.withType<AbstractPublishToMaven>().configureEach {
+  dependsOnTasks.add(name.replace("publish", "sign").replaceAfter("Publication", ""))
+  dependsOn(dependsOnTasks)
+}
+
 signing {
   // provided as env vars `ORG_GRADLE_PROJECT_signingKey` and `ORG_GRADLE_PROJECT_signingPassword`
   // in CI.


### PR DESCRIPTION
The maven publish plugin isn't setting up dependencies correctly, and we are getting errors like:

 "Task ':pkl-config-java:publishFatJarPublicationToMavenLocal' uses
  this output of task ':pkl-config-java:signLibraryPublication' without
   declaring an explicit or implicit dependency."

This adds a workaround for this type of error.