### PR TITLE
Avoid resolving paths on fragments

### DIFF
--- a/pkl-doc/src/main/kotlin/org/pkl/doc/DocPackageInfo.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/DocPackageInfo.kt
@@ -161,7 +161,7 @@ data class DocPackageInfo(
       "pkl:/" -> "pkl:${moduleName.substring(4)}".toUri()
       else -> {
         val path = getModulePath(moduleName, moduleNamePrefix).uriEncoded + ".pkl"
-        URI(importUri).resolve(path)
+        URI(importUri + path)
       }
     }
 

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/Bird/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/Bird/index.html
@@ -28,7 +28,7 @@
         <div class="member-signature">open module <span class="name-decl">birds.Bird</span></div>
         <dl class="member-info">
           <dt class="">Module URI:</dt>
-          <dd><span class="import-uri">package://localhost:0/Bird.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
+          <dd><span class="import-uri">package://localhost:0/birds@0.5.0#/Bird.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
           <dd><a href="https://example.com/birds/v0.5.0/blob/Bird.pkl">Bird.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/allFruit/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/allFruit/index.html
@@ -28,7 +28,7 @@
         <div class="member-signature">module <span class="name-decl">birds.allFruit</span></div>
         <dl class="member-info">
           <dt class="">Module URI:</dt>
-          <dd><span class="import-uri">package://localhost:0/allFruit.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
+          <dd><span class="import-uri">package://localhost:0/birds@0.5.0#/allFruit.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
           <dd><a href="https://example.com/birds/v0.5.0/blob/allFruit.pkl">allFruit.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/catalog/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/catalog/index.html
@@ -28,7 +28,7 @@
         <div class="member-signature">module <span class="name-decl">birds.catalog</span></div>
         <dl class="member-info">
           <dt class="">Module URI:</dt>
-          <dd><span class="import-uri">package://localhost:0/catalog.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
+          <dd><span class="import-uri">package://localhost:0/birds@0.5.0#/catalog.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
           <dd><a href="https://example.com/birds/v0.5.0/blob/catalog.pkl">catalog.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/fruit/1.1.0/Fruit/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/fruit/1.1.0/Fruit/index.html
@@ -28,7 +28,7 @@
         <div class="member-signature">module <span class="name-decl">fruit.Fruit</span></div>
         <dl class="member-info">
           <dt class="">Module URI:</dt>
-          <dd><span class="import-uri">package://localhost:0/Fruit.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
+          <dd><span class="import-uri">package://localhost:0/fruit@1.1.0#/Fruit.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>


### PR DESCRIPTION
The more principled solution is to have `importUri` be a `URI` instead of a `String` and to test its scheme.

Generally, the problem is that `URI::resolve` can not assume fragments to be a path (and that it discards fragments altogether).