### PR TITLE
Change HttpClientInitException to extend RuntimeException

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClientInitException.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClientInitException.java
@@ -15,13 +15,11 @@
  */
 package org.pkl.core.http;
 
-import org.pkl.core.PklException;
-
 /**
  * Indicates that an error occurred while initializing an HTTP client. A common example is an error
  * reading or parsing a certificate.
  */
-public class HttpClientInitException extends PklException {
+public class HttpClientInitException extends RuntimeException {
   public HttpClientInitException(String message) {
     super(message);
   }


### PR DESCRIPTION
PklException is mainly used to indicate errors during evaluation of Pkl code. It isn't a suitable superclass for HttpClientInitException.