### PR TITLE
Fix source links in pkldoc

### DIFF
--- a/pkl-doc/src/main/kotlin/org/pkl/doc/DocGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/DocGenerator.kt
@@ -179,7 +179,7 @@ internal class DocPackage(val docPackageInfo: DocPackageInfo, val modules: List<
         mod,
         docPackageInfo.version,
         docPackageInfo.getModuleImportUri(mod.moduleName),
-        docPackageInfo.getModuleSourceCode(mod.moduleName)?.toEncodedUri(),
+        docPackageInfo.getModuleSourceCode(mod.moduleName),
         exampleModulesBySubject[mod.moduleName] ?: listOf()
       )
     }

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/DocPackageInfo.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/DocPackageInfo.kt
@@ -165,10 +165,10 @@ data class DocPackageInfo(
       }
     }
 
-  internal fun getModuleSourceCode(moduleName: String): String? {
+  internal fun getModuleSourceCode(moduleName: String): URI? {
     val path = "/" + getModulePath(moduleName, moduleNamePrefix).uriEncoded + ".pkl"
     // assumption: the fragment is only used for line numbers
-    return sourceCodeUrlScheme?.replace("%{path}", path)?.substringBefore('#')
+    return sourceCodeUrlScheme?.replace("%{path}", path)?.substringBefore('#')?.let(URI::create)
   }
 
   /** Information about a depended-on package. */

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/DocPackageInfo.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/DocPackageInfo.kt
@@ -160,17 +160,13 @@ data class DocPackageInfo(
     when (importUri) {
       "pkl:/" -> "pkl:${moduleName.substring(4)}".toUri()
       else -> {
-        val path =
-          getModulePath(moduleName, moduleNamePrefix)
-            .split("/")
-            .map { it.uriEncoded }
-            .joinToString("/") { it } + ".pkl"
+        val path = getModulePath(moduleName, moduleNamePrefix).uriEncoded + ".pkl"
         URI(importUri).resolve(path)
       }
     }
 
   internal fun getModuleSourceCode(moduleName: String): String? {
-    val path = "/" + getModulePath(moduleName, moduleNamePrefix) + ".pkl"
+    val path = "/" + getModulePath(moduleName, moduleNamePrefix).uriEncoded + ".pkl"
     // assumption: the fragment is only used for line numbers
     return sourceCodeUrlScheme?.replace("%{path}", path)?.substringBefore('#')
   }

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/DocScope.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/DocScope.kt
@@ -253,7 +253,7 @@ internal class PackageScope(
   private val moduleScopes: Map<String, ModuleScope> by lazy {
     modules.associate { module ->
       val docUrl =
-        url.resolve(getModulePath(module.moduleName, modulePrefix).uriEncodedPath + "/index.html")
+        url.resolve(getModulePath(module.moduleName, modulePrefix).uriEncoded + "/index.html")
       module.moduleName to ModuleScope(module, docUrl, this)
     }
   }
@@ -326,7 +326,7 @@ internal class ModuleScope(
     get() = module.moduleName
 
   val path: String by lazy {
-    getModulePath(module.moduleName, parent!!.docPackageInfo.moduleNamePrefix).uriEncodedPath
+    getModulePath(module.moduleName, parent!!.docPackageInfo.moduleNamePrefix).uriEncoded
   }
 
   override val dataUrl: URI by lazy { parent!!.dataUrl.resolve("./$path/index.js") }
@@ -386,11 +386,12 @@ internal class ClassScope(
 ) : PageScope() {
   override val url: URI by lazy {
     // `isModuleClass` distinction is relevant when this scope is a link target
-    if (clazz.isModuleClass) parentUrl else parentUrl.resolve("${clazz.simpleName.uriEncoded}.html")
+    if (clazz.isModuleClass) parentUrl
+    else parentUrl.resolve("${clazz.simpleName.uriEncodedComponent}.html")
   }
 
   override val dataUrl: URI by lazy {
-    parent!!.dataUrl.resolve("${clazz.simpleName.uriEncoded}.js")
+    parent!!.dataUrl.resolve("${clazz.simpleName.uriEncodedComponent}.js")
   }
 
   override fun getMethod(name: String): MethodScope? =

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
@@ -600,7 +600,8 @@ internal abstract class PageGenerator<out S>(
         for (example in examples) {
           if (first) first = false else +", "
           a {
-            href = docModule.parent.docPackageInfo.getModuleSourceCode(example.moduleName)!!
+            href =
+              docModule.parent.docPackageInfo.getModuleSourceCode(example.moduleName)!!.toString()
             +example.shortModuleName
           }
         }

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
@@ -426,7 +426,7 @@ internal abstract class PageGenerator<out S>(
   // anchors, and requires no JS
   protected fun HtmlBlockTag.renderAnchor(anchorId: String, cssClass: String = "anchor") {
     div {
-      id = anchorId.uriEncoded
+      id = anchorId.uriEncodedComponent
       classes = setOf(cssClass)
       +" " // needs some content to be considered a valid anchor by browsers
     }
@@ -457,7 +457,7 @@ internal abstract class PageGenerator<out S>(
   protected fun HtmlBlockTag.renderSelfLink(memberName: String) {
     a {
       classes = setOf("member-selflink", "material-icons")
-      href = "#${memberName.uriEncoded}"
+      href = "#${memberName.uriEncodedComponent}"
       +"link"
     }
   }

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/Util.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/Util.kt
@@ -119,7 +119,12 @@ internal fun String.replaceSourceCodePlaceholders(
     .replace("%{endLine}", sourceLocation.endLine.toString())
 }
 
-internal val String.uriEncoded
+/**
+ * Encodes a URI string, encoding characters that are part of URI syntax.
+ *
+ * Follows `encodeURIComponent` from ECMAScript.
+ */
+internal val String.uriEncodedComponent
   get(): String {
     val ret = URLEncoder.encode(this, StandardCharsets.UTF_8)
     // Replace `+` with `%20` to be safe
@@ -128,13 +133,18 @@ internal val String.uriEncoded
     return ret.replace("+", "%20")
   }
 
-internal val String.uriEncodedPath
-  get(): String = split("/").map { it.uriEncoded }.joinToString("/") { it }
+/**
+ * Encodes a URI string, preserving characters that are part of URI syntax.
+ *
+ * Follows `encodeURI` from ECMAScript.
+ */
+internal val String.uriEncoded
+  get(): String = replace(Regex("([^;/?:@&=+\$,#]+)")) { it.value.uriEncodedComponent }
 
 fun getModulePath(moduleName: String, packagePrefix: String): String =
   moduleName.substring(packagePrefix.length).replace('.', '/')
 
-internal fun String.toEncodedUri(): URI = URI(uriEncodedPath)
+internal fun String.toEncodedUri(): URI = URI(uriEncoded)
 
 /**
  * Turns `"foo.bar.baz-biz"` into ``"foo.bar.`baz-biz`"``.

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/Module Containing Spaces/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/Module Containing Spaces/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/Module%20Containing%20Spaces.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/Module%20Containing%20Spaces.pkl">Module Containing Spaces.pkl</a></dd>
+          <dd><a href="https://example.com/package1/Module%20Containing%20Spaces.pkl">Module Containing Spaces.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/baseModule/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/baseModule/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/baseModule.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/baseModule.pkl">baseModule.pkl</a></dd>
+          <dd><a href="https://example.com/package1/baseModule.pkl">baseModule.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classAnnotations/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classAnnotations/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classAnnotations.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classAnnotations.pkl">classAnnotations.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classAnnotations.pkl">classAnnotations.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classComments/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classComments/index.html
@@ -33,7 +33,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classComments.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classComments.pkl">classComments.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classComments.pkl">classComments.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classInheritance/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classInheritance/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classInheritance.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classInheritance.pkl">classInheritance.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classInheritance.pkl">classInheritance.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classMethodComments/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classMethodComments/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classMethodComments.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classMethodComments.pkl">classMethodComments.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classMethodComments.pkl">classMethodComments.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classMethodModifiers/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classMethodModifiers/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classMethodModifiers.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classMethodModifiers.pkl">classMethodModifiers.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classMethodModifiers.pkl">classMethodModifiers.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classMethodTypeAnnotations/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classMethodTypeAnnotations/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classMethodTypeAnnotations.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classMethodTypeAnnotations.pkl">classMethodTypeAnnotations.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classMethodTypeAnnotations.pkl">classMethodTypeAnnotations.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classMethodTypeReferences/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classMethodTypeReferences/index.html
@@ -33,7 +33,7 @@ the same module, a different module, and external modules.</p></div>
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classMethodTypeReferences.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classMethodTypeReferences.pkl">classMethodTypeReferences.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classMethodTypeReferences.pkl">classMethodTypeReferences.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyAnnotations/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyAnnotations/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classPropertyAnnotations.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classPropertyAnnotations.pkl">classPropertyAnnotations.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classPropertyAnnotations.pkl">classPropertyAnnotations.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyComments/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyComments/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classPropertyComments.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classPropertyComments.pkl">classPropertyComments.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classPropertyComments.pkl">classPropertyComments.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyModifiers/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyModifiers/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classPropertyModifiers.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classPropertyModifiers.pkl">classPropertyModifiers.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classPropertyModifiers.pkl">classPropertyModifiers.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyTypeAnnotations/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyTypeAnnotations/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classPropertyTypeAnnotations.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classPropertyTypeAnnotations.pkl">classPropertyTypeAnnotations.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classPropertyTypeAnnotations.pkl">classPropertyTypeAnnotations.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyTypeReferences/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classPropertyTypeReferences/index.html
@@ -33,7 +33,7 @@ the same module, a different module, and external modules.</p></div>
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classPropertyTypeReferences.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classPropertyTypeReferences.pkl">classPropertyTypeReferences.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classPropertyTypeReferences.pkl">classPropertyTypeReferences.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classTypeConstraints/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/classTypeConstraints/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/classTypeConstraints.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/classTypeConstraints.pkl">classTypeConstraints.pkl</a></dd>
+          <dd><a href="https://example.com/package1/classTypeConstraints.pkl">classTypeConstraints.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/docExampleSubject1/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/docExampleSubject1/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/docExampleSubject1.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/docExampleSubject1.pkl">docExampleSubject1.pkl</a></dd>
+          <dd><a href="https://example.com/package1/docExampleSubject1.pkl">docExampleSubject1.pkl</a></dd>
           <dt class="">Examples:</dt>
           <dd><a href="https://example.com/package1/docExample.pkl">docExample</a>, <a href="https://example.com/package1/docExample2.pkl">docExample2</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/docExampleSubject2/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/docExampleSubject2/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/docExampleSubject2.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/docExampleSubject2.pkl">docExampleSubject2.pkl</a></dd>
+          <dd><a href="https://example.com/package1/docExampleSubject2.pkl">docExampleSubject2.pkl</a></dd>
           <dt class="">Examples:</dt>
           <dd><a href="https://example.com/package1/docExample.pkl">docExample</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/docLinks/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/docLinks/index.html
@@ -41,7 +41,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/docLinks.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/docLinks.pkl">docLinks.pkl</a></dd>
+          <dd><a href="https://example.com/package1/docLinks.pkl">docLinks.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/methodAnnotations/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/methodAnnotations/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/methodAnnotations.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/methodAnnotations.pkl">methodAnnotations.pkl</a></dd>
+          <dd><a href="https://example.com/package1/methodAnnotations.pkl">methodAnnotations.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleComments/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleComments/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/moduleComments.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleComments.pkl">moduleComments.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleComments.pkl">moduleComments.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleExtend/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleExtend/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/moduleExtend.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleExtend.pkl">moduleExtend.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleExtend.pkl">moduleExtend.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleInfoAnnotation/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleInfoAnnotation/index.html
@@ -32,7 +32,7 @@
           <dt class="">Pkl version:</dt>
           <dd>0.10.0 or higher</dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleInfoAnnotation.pkl">moduleInfoAnnotation.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleInfoAnnotation.pkl">moduleInfoAnnotation.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodCommentInheritance/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodCommentInheritance/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/moduleMethodCommentInheritance.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleMethodCommentInheritance.pkl">moduleMethodCommentInheritance.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleMethodCommentInheritance.pkl">moduleMethodCommentInheritance.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodComments/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodComments/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/moduleMethodComments.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleMethodComments.pkl">moduleMethodComments.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleMethodComments.pkl">moduleMethodComments.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodModifiers/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodModifiers/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/moduleMethodModifiers.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleMethodModifiers.pkl">moduleMethodModifiers.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleMethodModifiers.pkl">moduleMethodModifiers.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodTypeAnnotations/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodTypeAnnotations/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/moduleMethodTypeAnnotations.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleMethodTypeAnnotations.pkl">moduleMethodTypeAnnotations.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleMethodTypeAnnotations.pkl">moduleMethodTypeAnnotations.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodTypeReferences/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleMethodTypeReferences/index.html
@@ -33,7 +33,7 @@ the same module, a different module, and external modules.</p></div>
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/moduleMethodTypeReferences.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleMethodTypeReferences.pkl">moduleMethodTypeReferences.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleMethodTypeReferences.pkl">moduleMethodTypeReferences.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyAnnotations/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyAnnotations/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/modulePropertyAnnotations.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/modulePropertyAnnotations.pkl">modulePropertyAnnotations.pkl</a></dd>
+          <dd><a href="https://example.com/package1/modulePropertyAnnotations.pkl">modulePropertyAnnotations.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyCommentInheritance/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyCommentInheritance/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/modulePropertyCommentInheritance.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/modulePropertyCommentInheritance.pkl">modulePropertyCommentInheritance.pkl</a></dd>
+          <dd><a href="https://example.com/package1/modulePropertyCommentInheritance.pkl">modulePropertyCommentInheritance.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyComments/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyComments/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/modulePropertyComments.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/modulePropertyComments.pkl">modulePropertyComments.pkl</a></dd>
+          <dd><a href="https://example.com/package1/modulePropertyComments.pkl">modulePropertyComments.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyModifiers/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyModifiers/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/modulePropertyModifiers.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/modulePropertyModifiers.pkl">modulePropertyModifiers.pkl</a></dd>
+          <dd><a href="https://example.com/package1/modulePropertyModifiers.pkl">modulePropertyModifiers.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyTypeAnnotations/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyTypeAnnotations/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/modulePropertyTypeAnnotations.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/modulePropertyTypeAnnotations.pkl">modulePropertyTypeAnnotations.pkl</a></dd>
+          <dd><a href="https://example.com/package1/modulePropertyTypeAnnotations.pkl">modulePropertyTypeAnnotations.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyTypeReferences/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/modulePropertyTypeReferences/index.html
@@ -33,7 +33,7 @@ the same module, a different module, and external modules.</p></div>
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/modulePropertyTypeReferences.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/modulePropertyTypeReferences.pkl">modulePropertyTypeReferences.pkl</a></dd>
+          <dd><a href="https://example.com/package1/modulePropertyTypeReferences.pkl">modulePropertyTypeReferences.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleTypes1/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleTypes1/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/moduleTypes1.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleTypes1.pkl">moduleTypes1.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleTypes1.pkl">moduleTypes1.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleTypes2/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/moduleTypes2/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/moduleTypes2.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/moduleTypes2.pkl">moduleTypes2.pkl</a></dd>
+          <dd><a href="https://example.com/package1/moduleTypes2.pkl">moduleTypes2.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/nested/nested2/nestedModule/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/nested/nested2/nestedModule/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/nested/nested2/nestedModule.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/nested/nested2/nestedModule.pkl">nestedModule.pkl</a></dd>
+          <dd><a href="https://example.com/package1/nested/nested2/nestedModule.pkl">nestedModule.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/shared/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/shared/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/shared.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/shared.pkl">shared.pkl</a></dd>
+          <dd><a href="https://example.com/package1/shared.pkl">shared.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/ternalPackage/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/ternalPackage/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/ternalPackage.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/ternalPackage.pkl">ternalPackage.pkl</a></dd>
+          <dd><a href="https://example.com/package1/ternalPackage.pkl">ternalPackage.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/typeAliasInheritance/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/typeAliasInheritance/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/typeAliasInheritance.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/typeAliasInheritance.pkl">typeAliasInheritance.pkl</a></dd>
+          <dd><a href="https://example.com/package1/typeAliasInheritance.pkl">typeAliasInheritance.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/typealiases/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/typealiases/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/typealiases.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/typealiases.pkl">typealiases.pkl</a></dd>
+          <dd><a href="https://example.com/package1/typealiases.pkl">typealiases.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/typealiases2/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/typealiases2/index.html
@@ -32,7 +32,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/typealiases2.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/typealiases2.pkl">typealiases2.pkl</a></dd>
+          <dd><a href="https://example.com/package1/typealiases2.pkl">typealiases2.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/unionTypes/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/unionTypes/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/unionTypes.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/unionTypes.pkl">unionTypes.pkl</a></dd>
+          <dd><a href="https://example.com/package1/unionTypes.pkl">unionTypes.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/unlistedClass/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/unlistedClass/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/unlistedClass.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/unlistedClass.pkl">unlistedClass.pkl</a></dd>
+          <dd><a href="https://example.com/package1/unlistedClass.pkl">unlistedClass.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/unlistedMethod/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/unlistedMethod/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/unlistedMethod.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/unlistedMethod.pkl">unlistedMethod.pkl</a></dd>
+          <dd><a href="https://example.com/package1/unlistedMethod.pkl">unlistedMethod.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/unlistedProperty/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/unlistedProperty/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">https://example.com/unlistedProperty.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/package1/unlistedProperty.pkl">unlistedProperty.pkl</a></dd>
+          <dd><a href="https://example.com/package1/unlistedProperty.pkl">unlistedProperty.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package2/4.5.6/Module3/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package2/4.5.6/Module3/index.html
@@ -31,7 +31,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">modulepath:/com/package2/Module3.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/blob/4.5.6/Module3.pkl">Module3.pkl</a></dd>
+          <dd><a href="https://example.com/blob/4.5.6/Module3.pkl">Module3.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/Bird/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/Bird/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">package://localhost:0/Bird.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/birds/v0.5.0/blob/Bird.pkl">Bird.pkl</a></dd>
+          <dd><a href="https://example.com/birds/v0.5.0/blob/Bird.pkl">Bird.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/allFruit/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/allFruit/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">package://localhost:0/allFruit.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/birds/v0.5.0/blob/allFruit.pkl">allFruit.pkl</a></dd>
+          <dd><a href="https://example.com/birds/v0.5.0/blob/allFruit.pkl">allFruit.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/catalog/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/localhost:0/birds/0.5.0/catalog/index.html
@@ -30,7 +30,7 @@
           <dt class="">Module URI:</dt>
           <dd><span class="import-uri">package://localhost:0/catalog.pkl</span><i class="copy-uri-button material-icons">content_copy</i></dd>
           <dt class="">Source code:</dt>
-          <dd><a href="https%3A//example.com/birds/v0.5.0/blob/catalog.pkl">catalog.pkl</a></dd>
+          <dd><a href="https://example.com/birds/v0.5.0/blob/catalog.pkl">catalog.pkl</a></dd>
           <dt class="runtime-data hidden">Known subtypes:</dt>
           <dd id="known-subtypes" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">Known usages:</dt>


### PR DESCRIPTION
Fixes an issue where source links are incorrectly URI encoded; i.e. `https%3A//github.com` instead of `https://github.com`.

This was causing the browser to resolve these as relative to the enclosing page.