### PR TITLE
Fix wrong data type in kotlin example

### DIFF
--- a/docs/modules/kotlin-binding/examples/KotlinConfigExample.kt
+++ b/docs/modules/kotlin-binding/examples/KotlinConfigExample.kt
@@ -12,7 +12,7 @@ class KotlinConfigExample {
     // tag::usage[]
     val evaluator = ConfigEvaluator.preconfigured().forKotlin() // <1>
     val config = evaluator.use { // <2>
-      it.evaluateText("""pigeon { age = 5; diet = "Seeds" }""")
+      it.evaluateText("""pigeon { age = 5; diet = List("Seeds") }""")
     }
     val pigeon = config["pigeon"] // <3>
     val age = pigeon["age"].to<Int>() // <4>


### PR DESCRIPTION
Hey, by trying out the example, provided in the kotlin docs, i figured out, that the data type for seeds is not a viable list and errors are thrown if you're trying to use the example.

So no super large fix, but smth. that will improve the way to get into this