### PR TITLE
Ensure owner and receiver are reset after executing alias

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
@@ -1627,9 +1627,12 @@ public abstract class TypeNode extends PklNode {
       VmUtils.setOwner(frame, VmUtils.getOwner(typeAlias.getEnclosingFrame()));
       VmUtils.setReceiver(frame, VmUtils.getReceiver(typeAlias.getEnclosingFrame()));
 
-      aliasedTypeNode.execute(frame, value);
-      VmUtils.setOwner(frame, prevOwner);
-      VmUtils.setReceiver(frame, prevReceiver);
+      try {
+        aliasedTypeNode.execute(frame, value);
+      } finally {
+        VmUtils.setOwner(frame, prevOwner);
+        VmUtils.setReceiver(frame, prevReceiver);
+      }
     }
 
     /** See docstring on {@link TypeAliasTypeNode#execute}. */
@@ -1640,10 +1643,12 @@ public abstract class TypeNode extends PklNode {
       VmUtils.setOwner(frame, VmUtils.getOwner(typeAlias.getEnclosingFrame()));
       VmUtils.setReceiver(frame, VmUtils.getReceiver(typeAlias.getEnclosingFrame()));
 
-      aliasedTypeNode.executeAndSet(frame, value);
-
-      VmUtils.setOwner(frame, prevOwner);
-      VmUtils.setReceiver(frame, prevReceiver);
+      try {
+        aliasedTypeNode.executeAndSet(frame, value);
+      } finally {
+        VmUtils.setOwner(frame, prevOwner);
+        VmUtils.setReceiver(frame, prevReceiver);
+      }
     }
 
     @Override

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAlias2.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAlias2.pkl
@@ -35,3 +35,10 @@ typealias Bar = Foo
 class Baz extends Bar {}
 
 res7 = (new Baz {}).value
+
+typealias MappingOrListing = Mapping|Listing
+
+res8 = new {
+  foo = 5
+  bar = if (foo is MappingOrListing) "bar" else foo
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAlias2.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAlias2.pcf
@@ -11,3 +11,7 @@ res6 {
   name = "Other"
 }
 res7 = 42
+res8 {
+  foo = 5
+  bar = 5
+}


### PR DESCRIPTION
This fixes an issue where the frame's owner/receiver are not reset if a type test on a typealias fails.