### PR TITLE
Use Files.newInputStream()/newOutputStream() where appropriate

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/module/ModulePathResolver.java
+++ b/pkl-core/src/main/java/org/pkl/core/module/ModulePathResolver.java
@@ -15,7 +15,6 @@
  */
 package org.pkl.core.module;
 
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -171,7 +170,7 @@ public class ModulePathResolver implements AutoCloseable {
     if (path.endsWith(".jar") || path.endsWith(".zip")) return true;
 
     byte[] buffer;
-    try (var fis = new FileInputStream(path.toFile())) {
+    try (var fis = Files.newInputStream(path)) {
       buffer = fis.readNBytes(39);
     } catch (IOException e) {
       return false;

--- a/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
+++ b/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
@@ -16,7 +16,6 @@
 package org.pkl.core.packages;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -590,7 +589,7 @@ class PackageResolvers {
       var cacheFile = packageDir.resolve(packageDir.getFileName() + ".json");
       if (Files.exists(cacheFile)) {
         return readDependencyMetadataAndComputeChecksum(
-            packageUri, new FileInputStream(cacheFile.toFile()));
+            packageUri, Files.newInputStream(cacheFile));
       }
       return super.getDependencyMetadataAndComputeChecksum(packageUri);
     }

--- a/pkl-core/src/main/java/org/pkl/core/project/ProjectPackager.java
+++ b/pkl-core/src/main/java/org/pkl/core/project/ProjectPackager.java
@@ -16,7 +16,6 @@
 package org.pkl.core.project;
 
 import com.oracle.truffle.api.source.SourceSection;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -198,7 +197,7 @@ public class ProjectPackager {
   private String createDependencyMetadataAndComputeChecksum(
       Project project, Package pkg, Path metadataFile, String zipFileChecksum) throws IOException {
     var dependencyMetadata = createDependencyMetadata(project, pkg, zipFileChecksum);
-    try (var fos = newDigestOutputStream(new FileOutputStream(metadataFile.toFile()))) {
+    try (var fos = newDigestOutputStream(Files.newOutputStream((metadataFile)))) {
       dependencyMetadata.writeTo(fos);
       return ByteArrayUtils.toHex(fos.getMessageDigest().digest());
     }
@@ -287,9 +286,8 @@ public class ProjectPackager {
       Project project, List<Path> files, Path outputZipFile) {
     DigestOutputStream digestOutputStream;
     try {
-      var outputFile = outputZipFile.toFile();
       Files.createDirectories(outputZipFile.getParent());
-      digestOutputStream = newDigestOutputStream(new FileOutputStream(outputFile));
+      digestOutputStream = newDigestOutputStream(Files.newOutputStream(outputZipFile));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
@@ -17,7 +17,6 @@ package org.pkl.core.util;
 
 import com.oracle.truffle.api.TruffleOptions;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -145,7 +144,7 @@ public final class IoUtils {
   }
 
   public static void zipDirectory(Path sourceDir, Path targetFile) throws IOException {
-    try (var zipStream = new ZipOutputStream(new FileOutputStream(targetFile.toFile()))) {
+    try (var zipStream = new ZipOutputStream(Files.newOutputStream(targetFile))) {
       Files.walkFileTree(
           sourceDir,
           new SimpleFileVisitor<>() {


### PR DESCRIPTION
Use `Files.newInputStream(path)` instead of `new FileInputStream(path.toFile())` and `Files.newOutputStream(path)` instead of `new FileOutputStream(path.toFile())`.