### PR TITLE
Turn EvalTask into a tracked Gradle task

### DIFF
--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
@@ -19,26 +19,32 @@ import java.io.File;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.UntrackedTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
 import org.pkl.cli.CliEvaluator;
 import org.pkl.cli.CliEvaluatorOptions;
 
-@UntrackedTask(because = "Output file names are known only after execution")
 public abstract class EvalTask extends ModulesTask {
-  @Internal
+  @OutputFile
+  @Optional
   public abstract RegularFileProperty getOutputFile();
 
-  @Internal
+  @Input
+  @Optional
   public abstract Property<String> getOutputFormat();
 
-  @Internal
+  @Input
+  @Optional
   public abstract Property<String> getModuleOutputSeparator();
 
-  @Internal
+  @OutputDirectory
+  @Optional
   public abstract DirectoryProperty getMultipleFileOutputDir();
 
-  @Internal
+  @Input
+  @Optional
   public abstract Property<String> getExpression();
 
   @Override


### PR DESCRIPTION
Rationale: "Output file names are known only after execution" isn't a legitimate reason to make this task untracked because the output directory is known in this case. This is no different from (say) the `JavaCompile` task, where only the class file output directory is known upfront. Forum discussion didn't reveal another reason why this task should be untracked.