### PR TITLE
Make EvalTask track resolved output paths

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliEvaluator.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliEvaluator.kt
@@ -51,9 +51,10 @@ constructor(
   private val consoleWriter: Writer = System.out.writer(),
 ) : CliCommand(options.base) {
   /**
-   * Output files for the modules to be evaluated. Returns `null` if `options.outputPath` is `null`.
-   * Multiple modules may be mapped to the same output file, in which case their outputs are
-   * concatenated with [CliEvaluatorOptions.moduleOutputSeparator].
+   * Output files for the modules to be evaluated. Returns `null` if `options.outputPath` is `null`
+   * or if `options.multipleFileOutputPath` is not `null`. Multiple modules may be mapped to the
+   * same output file, in which case their outputs are concatenated with
+   * [CliEvaluatorOptions.moduleOutputSeparator].
    */
   @Suppress("MemberVisibilityCanBePrivate")
   val outputFiles: Set<File>? by lazy {

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
@@ -28,15 +28,18 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
@@ -142,6 +145,7 @@ public abstract class BasePklTask extends DefaultTask {
 
   @LateInit protected CliBaseOptions cachedOptions;
 
+  // Must be called during task execution time only.
   @Internal
   protected CliBaseOptions getCliBaseOptions() {
     if (cachedOptions == null) {
@@ -175,6 +179,12 @@ public abstract class BasePklTask extends DefaultTask {
   protected List<URI> getSourceModulesAsUris() {
     return Collections.emptyList();
   }
+
+  @Inject
+  protected abstract ObjectFactory getObjects();
+
+  @Inject
+  protected abstract ProviderFactory getProviders();
 
   protected List<Path> parseModulePath() {
     return getModulePath().getFiles().stream().map(File::toPath).collect(Collectors.toList());

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
@@ -69,8 +69,8 @@ public abstract class EvalTask extends ModulesTask {
   @OutputFiles
   @Optional
   public SetProperty<File> getOutputPaths() {
-    var ret = getObjectFactory().setProperty(File.class).value(getCliEvaluator().getOutputFiles());
-    ret.disallowChanges();
+    var ret = getObjectFactory().setProperty(File.class);
+    ret.value(getCliEvaluator().getOutputFiles()).disallowChanges();
     return ret;
   }
 

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
@@ -33,7 +33,8 @@ public abstract class EvalTask extends ModulesTask {
   @Internal
   public abstract RegularFileProperty getOutputFile();
 
-  @Internal
+  @Input
+  @Optional
   public abstract Property<String> getOutputFormat();
 
   @Input

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
@@ -16,17 +16,19 @@
 package org.pkl.gradle.task;
 
 import java.io.File;
+import java.util.Set;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.UntrackedTask;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectories;
+import org.gradle.api.tasks.OutputFiles;
 import org.pkl.cli.CliEvaluator;
 import org.pkl.cli.CliEvaluatorOptions;
 
-@UntrackedTask(
-    because =
-        "Output file names accept placeholder values, and actual file names and directories can't be known ahead of time")
 public abstract class EvalTask extends ModulesTask {
   @Internal
   public abstract RegularFileProperty getOutputFile();
@@ -34,28 +36,49 @@ public abstract class EvalTask extends ModulesTask {
   @Internal
   public abstract Property<String> getOutputFormat();
 
-  @Internal
+  @Input
+  @Optional
   public abstract Property<String> getModuleOutputSeparator();
 
   @Internal
   public abstract DirectoryProperty getMultipleFileOutputDir();
 
-  @Internal
+  @Input
+  @Optional
   public abstract Property<String> getExpression();
+
+  @Internal
+  public Provider<CliEvaluator> getCliEvaluator() {
+    return getProject()
+        .provider(
+            () ->
+                new CliEvaluator(
+                    new CliEvaluatorOptions(
+                        getCliBaseOptions(),
+                        getOutputFile().get().getAsFile().getAbsolutePath(),
+                        getOutputFormat().get(),
+                        getModuleOutputSeparator().get(),
+                        mapAndGetOrNull(
+                            getMultipleFileOutputDir(), (it) -> it.getAsFile().getAbsolutePath()),
+                        getExpression().get())));
+  }
+
+  @OutputFiles
+  @Optional
+  public Provider<Set<File>> getOutputPaths() {
+    return getCliEvaluator().map(CliEvaluator::getOutputFiles);
+  }
+
+  @OutputDirectories
+  @Optional
+  public Provider<Set<File>> getMultipleFileOutputPaths() {
+    return getCliEvaluator().map(CliEvaluator::getOutputDirectories);
+  }
 
   @Override
   protected void doRunTask() {
     //noinspection ResultOfMethodCallIgnored
     getOutputs().getPreviousOutputFiles().forEach(File::delete);
-
-    new CliEvaluator(
-            new CliEvaluatorOptions(
-                getCliBaseOptions(),
-                getOutputFile().get().getAsFile().getAbsolutePath(),
-                getOutputFormat().get(),
-                getModuleOutputSeparator().get(),
-                mapAndGetOrNull(getMultipleFileOutputDir(), it -> it.getAsFile().getAbsolutePath()),
-                getExpression().get()))
-        .run();
+    getCliEvaluator().get().run();
   }
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
@@ -19,32 +19,26 @@ import java.io.File;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.UntrackedTask;
 import org.pkl.cli.CliEvaluator;
 import org.pkl.cli.CliEvaluatorOptions;
 
+@UntrackedTask(because = "Output file names are known only after execution")
 public abstract class EvalTask extends ModulesTask {
-  @OutputFile
-  @Optional
+  @Internal
   public abstract RegularFileProperty getOutputFile();
 
-  @Input
-  @Optional
+  @Internal
   public abstract Property<String> getOutputFormat();
 
-  @Input
-  @Optional
+  @Internal
   public abstract Property<String> getModuleOutputSeparator();
 
-  @OutputDirectory
-  @Optional
+  @Internal
   public abstract DirectoryProperty getMultipleFileOutputDir();
 
-  @Input
-  @Optional
+  @Internal
   public abstract Property<String> getExpression();
 
   @Override

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
@@ -24,7 +24,9 @@ import org.gradle.api.tasks.UntrackedTask;
 import org.pkl.cli.CliEvaluator;
 import org.pkl.cli.CliEvaluatorOptions;
 
-@UntrackedTask(because = "Output file names are known only after execution")
+@UntrackedTask(
+    because =
+        "Output file names accept placeholder values, and actual file names and directories can't be known ahead of time")
 public abstract class EvalTask extends ModulesTask {
   @Internal
   public abstract RegularFileProperty getOutputFile();

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
@@ -17,10 +17,12 @@ package org.pkl.gradle.task;
 
 import java.io.File;
 import java.util.Set;
+import javax.inject.Inject;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -30,8 +32,14 @@ import org.pkl.cli.CliEvaluator;
 import org.pkl.cli.CliEvaluatorOptions;
 
 public abstract class EvalTask extends ModulesTask {
+
+  // not tracked because it might contain placeholders
   @Internal
   public abstract RegularFileProperty getOutputFile();
+
+  // not tracked because it might contain placeholders
+  @Internal
+  public abstract DirectoryProperty getMultipleFileOutputDir();
 
   @Input
   @Optional
@@ -41,16 +49,16 @@ public abstract class EvalTask extends ModulesTask {
   @Optional
   public abstract Property<String> getModuleOutputSeparator();
 
-  @Internal
-  public abstract DirectoryProperty getMultipleFileOutputDir();
-
   @Input
   @Optional
   public abstract Property<String> getExpression();
 
+  @Inject
+  public abstract ProviderFactory getProviderFactory();
+
   @Internal
   public Provider<CliEvaluator> getCliEvaluator() {
-    return getProject()
+    return getProviderFactory()
         .provider(
             () ->
                 new CliEvaluator(

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
@@ -78,7 +78,7 @@ public abstract class EvalTask extends ModulesTask {
 
   @OutputDirectories
   @Optional
-  public FileCollection getEffectiveOutputDirectories() {
+  public FileCollection getEffectiveOutputDirs() {
     return getObjects()
         .fileCollection()
         .from(cliEvaluator.map(e -> nullToEmpty(e.getOutputDirectories())));

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/EvalTask.java
@@ -67,9 +67,10 @@ public abstract class EvalTask extends ModulesTask {
                               getMultipleFileOutputDir(), it -> it.getAsFile().getAbsolutePath()),
                           getExpression().get())));
 
+  @SuppressWarnings("unused")
   @OutputFiles
   @Optional
-  public FileCollection getEffectiveOutputFilePaths() {
+  public FileCollection getEffectiveOutputFiles() {
     return getObjects()
         .fileCollection()
         .from(cliEvaluator.map(e -> nullToEmpty(e.getOutputFiles())));
@@ -77,7 +78,7 @@ public abstract class EvalTask extends ModulesTask {
 
   @OutputDirectories
   @Optional
-  public FileCollection getOutputDirectories() {
+  public FileCollection getEffectiveOutputDirectories() {
     return getObjects()
         .fileCollection()
         .from(cliEvaluator.map(e -> nullToEmpty(e.getOutputDirectories())));

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
@@ -128,12 +128,15 @@ public abstract class ModulesTask extends BasePklTask {
   }
 
   /**
-   * Converts either a file or a URI to a URI. We convert a file to a URI via the {@link
+   * Converts either a file or a URI to a URI. We convert a relative file to a URI via the {@link
    * IoUtils#createUri(String)} because other ways of conversion can make relative paths into
    * absolute URIs, which may break module loading.
    */
   private URI parsedModuleNotationToUri(Object notation) {
     if (notation instanceof File file) {
+      if (file.isAbsolute()) {
+        return file.toPath().toUri();
+      }
       return IoUtils.createUri(IoUtils.toNormalizedPathString(file.toPath()));
     } else if (notation instanceof URI uri) {
       return uri;

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/EvaluatorsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/EvaluatorsTest.kt
@@ -553,7 +553,7 @@ class EvaluatorsTest : AbstractTest() {
   }
 
   @Test
-  fun `implicit dependency tracking for output file`() {
+  fun `implicit dependency tracking for effective output files`() {
     writeFile("file1.pkl", "foo = 1")
     
     writeFile("file2.pkl", "bar = 1")
@@ -582,7 +582,7 @@ class EvaluatorsTest : AbstractTest() {
       }
 
       val printEvalFiles by tasks.registering {
-        inputs.files(doEval)
+        inputs.files(doEval.map { it.effectiveOutputFiles })
         doLast {
           println("evalCounter.txt")
           println(file("evalCounter.txt").readText())
@@ -594,12 +594,12 @@ class EvaluatorsTest : AbstractTest() {
         }
       }
     """.trimIndent())
-    
+
     val result1 = runTask("printEvalFiles")
-    
+
     // `doEval` task is invoked transitively.
     assertThat(result1.task(":doEval")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-    
+
     assertThat(result1.output).contains("""
       evalCounter.txt
       doEval executed
@@ -697,7 +697,7 @@ class EvaluatorsTest : AbstractTest() {
         }
         
         tasks.register('printEvalDirs', PrintTask) {
-          inputDirs.from(tasks.named('evalTest'))
+          inputDirs.from(tasks.named('evalTest').map { it.effectiveOutputDirectories })
           
           doLast {
             println "evalCounter.txt"

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/EvaluatorsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/EvaluatorsTest.kt
@@ -16,11 +16,13 @@
 package org.pkl.gradle
 
 import java.nio.file.Path
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.pkl.commons.readString
+import org.pkl.commons.toNormalizedPathString
 import org.pkl.commons.test.PackageServer
 import java.nio.file.Path
 import kotlin.io.path.readText


### PR DESCRIPTION
This makes Gradle track `getOutputPaths()` and `getMultipleFileOutputPaths`. These represent the actual outputs of the EvalTask.