### PR TITLE
Enable caching of native image building and test tasks

### DIFF
--- a/docs/docs.gradle.kts
+++ b/docs/docs.gradle.kts
@@ -32,5 +32,5 @@ dependencies {
 tasks.test {
   inputs.files(fileTree("modules").matching {
     include("**/pages/*.adoc")
-  })
+  }).withPropertyName("asciiDocFiles").withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -138,9 +138,10 @@ fun Exec.configureExecutable(isEnabled: Boolean, outputFile: Provider<RegularFil
   enabled = isEnabled
   dependsOn(":installGraalVm")
 
-  inputs.files(sourceSets.main.map { it.output })
-  inputs.files(configurations.runtimeClasspath)
+  inputs.files(sourceSets.main.map { it.output }).withPropertyName("mainSourceSets").withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.files(configurations.runtimeClasspath).withPropertyName("runtimeClasspath").withNormalizer(ClasspathNormalizer::class)
   outputs.file(outputFile)
+  outputs.cacheIf { true }
 
   workingDir(outputFile.map { it.asFile.parentFile })
   executable = "${buildInfo.graalVm.baseDir}/bin/native-image"

--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -140,6 +140,7 @@ fun Exec.configureExecutable(isEnabled: Boolean, outputFile: Provider<RegularFil
 
   inputs.files(sourceSets.main.map { it.output }).withPropertyName("mainSourceSets").withPathSensitivity(PathSensitivity.RELATIVE)
   inputs.files(configurations.runtimeClasspath).withPropertyName("runtimeClasspath").withNormalizer(ClasspathNormalizer::class)
+inputs.files(file(buildInfo.graalVm.baseDir).resolve("bin/native-image")).withPropertyName("graalVmNativeImage").withPathSensitivity(PathSensitivity.ABSOLUTE)
   outputs.file(outputFile)
   outputs.cacheIf { true }
 

--- a/pkl-core/pkl-core.gradle.kts
+++ b/pkl-core/pkl-core.gradle.kts
@@ -154,9 +154,9 @@ tasks.compileKotlin {
 }
 
 tasks.test {
-  inputs.dir("src/test/files/LanguageSnippetTests/input")
-  inputs.dir("src/test/files/LanguageSnippetTests/input-helper")
-  inputs.dir("src/test/files/LanguageSnippetTests/output")
+  inputs.dir("src/test/files/LanguageSnippetTests/input").withPropertyName("languageSnippetTestsInput").withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.dir("src/test/files/LanguageSnippetTests/input-helper").withPropertyName("languageSnippetTestsInputHelper").withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.dir("src/test/files/LanguageSnippetTests/output").withPropertyName("languageSnippetTestsOutput").withPathSensitivity(PathSensitivity.RELATIVE)
 
   useJUnitPlatform {
     excludeEngines("MacAmd64LanguageSnippetTestsEngine")
@@ -168,9 +168,9 @@ tasks.test {
 }
 
 val testJavaExecutable by tasks.registering(Test::class) {
-  inputs.dir("src/test/files/LanguageSnippetTests/input")
-  inputs.dir("src/test/files/LanguageSnippetTests/input-helper")
-  inputs.dir("src/test/files/LanguageSnippetTests/output")
+  inputs.dir("src/test/files/LanguageSnippetTests/input").withPropertyName("languageSnippetTestsInput").withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.dir("src/test/files/LanguageSnippetTests/input-helper").withPropertyName("languageSnippetTestsInputHelper").withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.dir("src/test/files/LanguageSnippetTests/output").withPropertyName("languageSnippetTestsOutput").withPathSensitivity(PathSensitivity.RELATIVE)
 
   testClassesDirs = files(tasks.test.get().testClassesDirs)
   classpath =
@@ -196,9 +196,9 @@ val testMacExecutableAmd64 by tasks.registering(Test::class) {
   enabled = buildInfo.os.isMacOsX && buildInfo.graalVm.isGraal22
   dependsOn(":pkl-cli:macExecutableAmd64")
 
-  inputs.dir("src/test/files/LanguageSnippetTests/input")
-  inputs.dir("src/test/files/LanguageSnippetTests/input-helper")
-  inputs.dir("src/test/files/LanguageSnippetTests/output")
+  inputs.dir("src/test/files/LanguageSnippetTests/input").withPropertyName("languageSnippetTestsInput").withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.dir("src/test/files/LanguageSnippetTests/input-helper").withPropertyName("languageSnippetTestsInputHelper").withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.dir("src/test/files/LanguageSnippetTests/output").withPropertyName("languageSnippetTestsOutput").withPathSensitivity(PathSensitivity.RELATIVE)
 
   testClassesDirs = files(tasks.test.get().testClassesDirs)
   classpath = tasks.test.get().classpath

--- a/pkl-server/pkl-server.gradle.kts
+++ b/pkl-server/pkl-server.gradle.kts
@@ -14,6 +14,6 @@ dependencies {
 }
 
 tasks.test {
-  inputs.dir("src/test/files/SnippetTests/input")
-  inputs.dir("src/test/files/SnippetTests/output")
+  inputs.dir("src/test/files/SnippetTests/input").withPropertyName("snippetTestsInput").withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.dir("src/test/files/SnippetTests/output").withPropertyName("snippetTestsOutput").withPathSensitivity(PathSensitivity.RELATIVE)
 }


### PR DESCRIPTION
This pull requests enables caching for the native image building task and improves the caching effectiveness of some of the test tasks in the project.
1. the native image building is a generic `Exec` tasks for which caching needs to be enabled explicitly (see [docs](https://docs.gradle.org/current/userguide/build_cache.html#using_the_runtime_api)) as the build tool doesn't have natively have enough information to cache it effectively -- furthermore some steps need to be taken to normalize the classpath (JARs come with an embedded timestamp in their manifest and this needs to be ignored), as well as not rely on absolute paths
2. while tests are usually cacheable, path relativity needs to be added as a property to ensure the results can be retrieved from a cache without relying on the environment of the machine running the task

All touched properties got a name to make sure it was easy to find them with [Build Scan®](https://scans.gradle.com/).

These issues have been diagnosed using [the build validation scripts by Gradle](https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/bf70ec7e5e57ab0996d68a970745512b79462134/Gradle.md).