### PR TITLE
Fix gradle dependency declare issue & order

### DIFF
--- a/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
+++ b/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
@@ -46,7 +46,7 @@ Groovy::
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
-  compile "org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}"
+  implementation "org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}"
 }
 
 repositories {

--- a/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
+++ b/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
@@ -20,6 +20,26 @@ To use the library in a Gradle project, declare the following dependency:
 
 [tabs]
 ====
+Kotlin::
++
+.build.gradle.kts
+[source,kotlin,subs="+attributes"]
+----
+dependencies {
+  implementation("org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}")
+}
+
+repositories {
+ifdef::is-release-version[]
+  mavenCentral()
+endif::[]
+ifndef::is-release-version[]
+  maven { url = uri("{uri-sonatype}") }
+endif::[]
+}
+----
+
+
 Groovy::
 +
 .build.gradle
@@ -35,25 +55,6 @@ ifdef::is-release-version[]
 endif::[]
 ifndef::is-release-version[]
   maven { url "{uri-sonatype}" }
-endif::[]
-}
-----
-
-Kotlin::
-+
-.build.gradle.kts
-[source,kotlin,subs="+attributes"]
-----
-dependencies {
-  compile("org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}")
-}
-
-repositories {
-ifdef::is-release-version[]
-  mavenCentral()
-endif::[]
-ifndef::is-release-version[]
-  maven { url = uri("{uri-sonatype}") }
 endif::[]
 }
 ----

--- a/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
+++ b/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
@@ -34,7 +34,7 @@ ifdef::is-release-version[]
   mavenCentral()
 endif::[]
 ifndef::is-release-version[]
-  maven { url = uri("{uri-sonatype}") }
+  maven(url = "{uri-sonatype}")
 endif::[]
 }
 ----


### PR DESCRIPTION
compile(...) is not supported in Gradle Kotlin DSL by default. Changed it to implementation(...). Also moved Kotlin to the first tab in Gradle, because it is now the default Gradle Language