### PR TITLE
Fix the sequence length in the YAML parser

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/stdlib/yaml/ParserNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/yaml/ParserNodes.java
@@ -345,14 +345,15 @@ public final class ParserNodes {
       @Override
       public VmListing construct(Node node) {
         var sequenceNode = (SequenceNode) node;
-        var members = EconomicMaps.<Object, ObjectMember>create(sequenceNode.getValue().size());
+        var size = sequenceNode.getValue().size();
+        var members = EconomicMaps.<Object, ObjectMember>create(size);
 
         var result =
             new VmListing(
                 VmUtils.createEmptyMaterializedFrame(),
                 BaseModule.getListingClass().getPrototype(),
                 members,
-                EconomicMaps.size(members));
+                size);
 
         if (!node.isRecursive()) {
           addMembers(sequenceNode, result);
@@ -390,14 +391,15 @@ public final class ParserNodes {
       @Override
       public VmListing construct(Node node) {
         var mappingNode = (MappingNode) node;
-        var members = EconomicMaps.<Object, ObjectMember>create(mappingNode.getValue().size());
+        var size = mappingNode.getValue().size();
+        var members = EconomicMaps.<Object, ObjectMember>create(size);
 
         var result =
             new VmListing(
                 VmUtils.createEmptyMaterializedFrame(),
                 BaseModule.getListingClass().getPrototype(),
                 members,
-                EconomicMaps.size(members));
+                size);
 
         if (!node.isRecursive()) {
           addMembers(mappingNode, result);
@@ -437,7 +439,8 @@ public final class ParserNodes {
       @Override
       public VmObject construct(Node node) {
         var mappingNode = (MappingNode) node;
-        var members = EconomicMaps.<Object, ObjectMember>create(mappingNode.getValue().size());
+        var size = mappingNode.getValue().size();
+        var members = EconomicMaps.<Object, ObjectMember>create(size);
 
         VmObject result;
         if (useMapping) {

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/yamlParser3.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/yamlParser3.pcf
@@ -34,7 +34,13 @@ res1 {
     other = "other"
   }
   productx {
-    "other"
+    new {
+      skux = "BL394Dx"
+      quantityx = 5
+      descriptionx = "Basketballx"
+      pricex = 451.23
+      other = "other"
+    }
     new {
       skux = "BL4438Hx"
       quantityx = 2
@@ -42,6 +48,7 @@ res1 {
       pricex = 2393.23
       other = "other"
     }
+    "other"
   }
   taxx = 252.64999999999998
   totalx = 4444.75
@@ -86,7 +93,13 @@ res2 = List(new {
   other = "other"
 }, new {
   productx {
-    "other"
+    new {
+      skux = "BL394Dx"
+      quantityx = 5
+      descriptionx = "Basketballx"
+      pricex = 451.23
+      other = "other"
+    }
     new {
       skux = "BL4438Hx"
       quantityx = 2
@@ -94,6 +107,7 @@ res2 = List(new {
       pricex = 2393.23
       other = "other"
     }
+    "other"
   }
   other = "other"
 }, new {


### PR DESCRIPTION
The initialSize in EconomicsMaps.create() is not the actual stored size, hence the accurate size is not determined until ObjectMembers are added after addMembers() called.

Since the size set during the creation of VmListing cannot be changed afterwards, the size of node.getValue() is used instead of members' size.