### PR TITLE
Enable useCustomStringDelimiters for pkl test example output

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/TestRunner.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/TestRunner.java
@@ -263,7 +263,7 @@ public class TestRunner {
                 VmUtils.createSyntheticObjectProperty(Identifier.EXAMPLES, "examples", examples)),
             0);
     var builder = new StringBuilder();
-    new PcfRenderer(builder, "  ", converter, false, false).renderDocument(outputFileContent);
+    new PcfRenderer(builder, "  ", converter, false, true).renderDocument(outputFileContent);
     try {
       Files.writeString(outputFile, builder);
     } catch (IOException e) {


### PR DESCRIPTION
This should make the `<file>-expected.pcf` file a bit easier to read when examples contain quotes or backslashes.