### PR TITLE
Cannot assign property with fixed/const in spread

### DIFF
--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/cannotAssignFixedProperty3.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/cannotAssignFixedProperty3.pkl
@@ -1,0 +1,5 @@
+amends "../basic/fixedProperty2.pkl"
+
+p = new {
+  ...new Dynamic { name = "Osprey" }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAssignFixedProperty3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAssignFixedProperty3.err
@@ -1,0 +1,14 @@
+–– Pkl Error ––
+Cannot assign to fixed property `name`.
+
+x | ...new Dynamic { name = "Osprey" }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at cannotAssignFixedProperty3#p (file:///$snippetsDir/input/errors/cannotAssignFixedProperty3.pkl)
+
+x | ...new Dynamic { name = "Osprey" }
+                     ^^^^
+at cannotAssignFixedProperty3#p.name (file:///$snippetsDir/input/errors/cannotAssignFixedProperty3.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)


### PR DESCRIPTION
When using spread syntax with typed object, properties that are fixed or const cannot be assigned or amended.
This should be checked in the checkTypedProperty() function.