### PR TITLE
Suppress warnings for `System.getProperty("line.separator")`

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
@@ -175,6 +175,7 @@ public final class IoUtils {
   }
 
   // not stored to avoid build-time initialization by native-image
+  @SuppressWarnings("SystemGetProperty")
   public static String getLineSeparator() {
     return System.getProperty("line.separator");
   }


### PR DESCRIPTION
`class System` gets initialized at build time through `native-image` and added to the heap. We initialize everything at build time via the `--initialize-at-build-time=` flag.