### PR TITLE
fix typos

### DIFF
--- a/pkl-doc/src/main/kotlin/org/pkl/doc/DocPackageInfo.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/DocPackageInfo.kt
@@ -67,7 +67,7 @@ data class DocPackageInfo(
   /**
    * The overview documentation for this package.
    *
-   * Supports the same Morkdown syntax as Pkldoc comments. By default, only the first paragraph is
+   * Supports the same Markdown syntax as Pkldoc comments. By default, only the first paragraph is
    * displayed.
    */
   val overview: String?,
@@ -176,7 +176,7 @@ data class DocPackageInfo(
     /** The name of the depended-on package. */
     val name: String,
 
-    /** The URI of the dependend-upon package, if any. */
+    /** The URI of the depended-upon package, if any. */
     val uri: @Contextual URI?,
 
     /** The version of the depended-on package. */

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/DocsiteInfo.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/DocsiteInfo.kt
@@ -27,7 +27,7 @@ data class DocsiteInfo(
   /**
    * The overview documentation on the main page of this website.
    *
-   * Uses the same Morkdown format as Pkldoc comments. Unless expanded, only the first paragraph is
+   * Uses the same Markdown format as Pkldoc comments. Unless expanded, only the first paragraph is
    * shown.
    */
   val overview: String?,


### PR DESCRIPTION
1. M `o` rkdown -> Markdown
2. depende `n` d -> depended