### PR TITLE
JDK version bump cleaups

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -21,17 +21,16 @@ import "jobs/GradleCheckJob.pkl"
 import "jobs/DeployJob.pkl"
 import "jobs/SimpleGradleJob.pkl"
 
-local prbJobs: Listing<String> = gradleCheckJobs.keys.toListing()
-
-local buildAndTestJobs = (prbJobs) {
+local prbJobs: Listing<String> = (gradleCheckJobs.keys.toListing()) {
   "bench"
   "gradle-compatibility"
+}
+
+local buildAndTestJobs = (prbJobs) {
   ...buildNativeJobs.keys.filter((it) -> it.endsWith("snapshot"))
 }
 
 local releaseJobs = (prbJobs) {
-  "bench"
-  "gradle-compatibility"
   ...buildNativeJobs.keys.filter((it) -> it.endsWith("release"))
 }
 

--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -21,16 +21,17 @@ import "jobs/GradleCheckJob.pkl"
 import "jobs/DeployJob.pkl"
 import "jobs/SimpleGradleJob.pkl"
 
-local prbJobs: Listing<String> = (gradleCheckJobs.keys.toListing()) {
-  "bench"
-  "gradle-compatibility"
-}
+local prbJobs: Listing<String> = gradleCheckJobs.keys.toListing()
 
 local buildAndTestJobs = (prbJobs) {
+  "bench"
+  "gradle-compatibility"
   ...buildNativeJobs.keys.filter((it) -> it.endsWith("snapshot"))
 }
 
 local releaseJobs = (prbJobs) {
+  "bench"
+  "gradle-compatibility"
   ...buildNativeJobs.keys.filter((it) -> it.endsWith("release"))
 }
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -753,12 +753,6 @@ workflows:
     - gradle-check-jdk21:
         requires:
         - hold
-    - bench:
-        requires:
-        - hold
-    - gradle-compatibility:
-        requires:
-        - hold
     when:
       matches:
         value: << pipeline.git.branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,7 +628,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
     docker:
-    - image: cimg/openjdk:11.0
+    - image: cimg/openjdk:17.0
   gradle-compatibility:
     steps:
     - checkout
@@ -649,7 +649,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
     docker:
-    - image: cimg/openjdk:11.0
+    - image: cimg/openjdk:17.0
   deploy-snapshot:
     steps:
     - checkout
@@ -751,6 +751,12 @@ workflows:
         requires:
         - hold
     - gradle-check-jdk21:
+        requires:
+        - hold
+    - bench:
+        requires:
+        - hold
+    - gradle-compatibility:
         requires:
         - hold
     when:

--- a/.circleci/jobs/SimpleGradleJob.pkl
+++ b/.circleci/jobs/SimpleGradleJob.pkl
@@ -32,6 +32,6 @@ steps {
 
 job {
   docker {
-    new { image = "cimg/openjdk:11.0" }
+    new { image = "cimg/openjdk:17.0" }
   }
 }

--- a/DEVELOPMENT.adoc
+++ b/DEVELOPMENT.adoc
@@ -2,11 +2,11 @@
 :uri-gng: https://gng.dsun.org
 :uri-jenv: https://www.jenv.be
 :uri-intellij: https://www.jetbrains.com/idea/download/
-:uri-jdk: https://adoptopenjdk.net/releases.html
+:uri-jdk: https://adoptopenjdk.net/releases.html?variant=openjdk17
 
 == Setup
 
-. (mandatory) Install {uri-jdk}[OpenJDK 11 HotSpot] (as long as we support JDK11)
+. (mandatory) Install {uri-jdk}[OpenJDK 17] or higher
 . (recommended) Install {uri-intellij}[IntelliJ IDEA 2023.x] +
 To import the project into IntelliJ, go to File->Open and select the project's root directory.
 If the project is opened but not imported, look for a popup in the lower right corner

--- a/docs/modules/java-binding/pages/codegen.adoc
+++ b/docs/modules/java-binding/pages/codegen.adoc
@@ -24,7 +24,7 @@ See xref:pkl-gradle:index.adoc#installation[Installation] in the Gradle plugin c
 === Java Library
 
 The `pkl-codegen-java` library is available {uri-pkl-codgen-java-maven-module}[from Maven Central].
-It requires Java 11 or higher.
+It requires Java 17 or higher.
 
 ifndef::is-release-version[]
 NOTE: Snapshots are published to repository `{uri-sonatype}`.

--- a/docs/modules/java-binding/pages/pkl-config-java.adoc
+++ b/docs/modules/java-binding/pages/pkl-config-java.adoc
@@ -23,7 +23,7 @@ It offers a higher-level API specifically designed for consuming application run
 == Installation
 
 The _pkl-config-java_ library is available {uri-pkl-config-java-maven-module}[from Maven Central].
-It requires Java 11 or higher.
+It requires Java 17 or higher.
 
 === Gradle
 

--- a/docs/modules/kotlin-binding/pages/codegen.adoc
+++ b/docs/modules/kotlin-binding/pages/codegen.adoc
@@ -19,7 +19,7 @@ See xref:pkl-gradle:index.adoc#installation[Installation] in the Gradle plugin c
 === Java Library
 
 The `pkl-codegen-kotlin` library is available {uri-pkl-codegen-kotlin-maven-module}[from Maven Central].
-It requires Java 11 or higher and Kotlin 1.3 or higher.
+It requires Java 17 or higher and Kotlin 1.3 or higher.
 
 ==== Gradle
 

--- a/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
+++ b/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
@@ -12,7 +12,7 @@ We recommend that Kotlin projects depend on this library instead of _pkl-config-
 == Installation
 
 The _pkl-config-kotlin_ library is available {uri-pkl-config-kotlin-maven-module}[from Maven Central].
-It requires Java 11 or higher and Kotlin 1.5 or higher.
+It requires Java 17 or higher and Kotlin 1.5 or higher.
 
 === Gradle
 

--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -37,7 +37,7 @@ The CLI comes in multiple flavors:
 * Native Linux executable for amd64
 * Native Linux executable for aarch64
 * Native Alpine Linux executable for amd64 (cross-compiled and tested on Oracle Linux 8)
-* Java executable (tested with Java 11/17 on macOS and Oracle Linux, may work on other platforms)
+* Java executable (tested with Java 17/21 on macOS and Oracle Linux, may work on other platforms)
 
 On macOS and Linux, we recommend using the native executables.
 They are self-contained, start up instantly, and run complex Pkl code much faster than the Java executable.
@@ -50,7 +50,7 @@ whereas, the Alpine Linux executable is statically linked against _musl libc_ an
 ====
 
 The Java executable works on multiple platforms and has a smaller binary size than the native executables.
-However, it requires a Java 11 (or higher) runtime on the system path, has a noticeable startup delay,
+However, it requires a Java 17 (or higher) runtime on the system path, has a noticeable startup delay,
 and runs complex Pkl code slower than the native executables.
 
 All flavors are built from the same codebase and undergo the same automated testing.
@@ -190,7 +190,7 @@ This should print something similar to:
 [source,shell]
 [subs="+attributes"]
 ----
-Pkl {pkl-version} (macOS 10.16, Java 11.0.9)
+Pkl {pkl-version} (macOS 14.2, Java 17.0.10)
 ----
 
 === Windows support

--- a/docs/modules/pkl-core/pages/index.adoc
+++ b/docs/modules/pkl-core/pages/index.adoc
@@ -22,7 +22,7 @@ The library can also be used to embed Pkl in Java libraries and applications.
 == Installation
 
 The _pkl-core_ library is available {uri-pkl-core-maven-module}[from Maven Central].
-It requires Java 11 or higher.
+It requires Java 17 or higher.
 
 === Gradle
 

--- a/docs/modules/pkl-doc/pages/index.adoc
+++ b/docs/modules/pkl-doc/pages/index.adoc
@@ -74,7 +74,7 @@ See xref:pkl-gradle:index.adoc#installation[Installation] in the _Gradle Plugin_
 === Java Library
 
 The `pkl-doc` library is available {uri-pkl-doc-maven}[from Maven Central].
-It requires Java 11 or higher.
+It requires Java 17 or higher.
 
 ifndef::is-release-version[]
 NOTE: Snapshots are published to repository `{uri-sonatype}`.

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -21,7 +21,7 @@ That is, plugin version `x.y.z` uses Pkl version `x.y.z`.
 == Installation
 
 The Gradle plugin is available {uri-pkl-gradle-maven-module}[from Maven Central].
-It requires Java 11 or higher and Gradle 6.8 or higher.
+It requires Java 17 or higher and Gradle 8.1 or higher.
 Earlier Gradle versions are not supported.
 
 ifndef::is-release-version[]

--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -321,7 +321,7 @@ publishing {
         description.set("""
           Pkl CLI executable for Java.
           Can be executed directly on *nix (if the `java` command is found on the PATH) and with `java -jar` otherwise.
-          Requires Java 11 or higher.
+          Requires Java 17 or higher.
         """.trimIndent())
       }
     }

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
@@ -1201,6 +1201,7 @@ result = someLib.x
     val err =
       assertThrows<CliException> { evalModuleThatImportsPackage(builtInCerts, packageServer.port) }
     assertThat(err)
+      .hasMessageContaining("Error during SSL handshake with host `localhost`:")
       .hasMessageContaining("unable to find valid certification path to requested target")
       .hasMessageNotContainingAny("java.", "sun.") // class names have been filtered out
   }

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
@@ -1201,8 +1201,6 @@ result = someLib.x
     val err =
       assertThrows<CliException> { evalModuleThatImportsPackage(builtInCerts, packageServer.port) }
     assertThat(err)
-      // on some JDK11's this doesn't cause SSLHandshakeException but some other SSLException
-      // .hasMessageContaining("Error during SSL handshake with host `localhost`:")
       .hasMessageContaining("unable to find valid certification path to requested target")
       .hasMessageNotContainingAny("java.", "sun.") // class names have been filtered out
   }

--- a/pkl-core/src/main/java/org/pkl/core/http/JdkHttpClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/JdkHttpClient.java
@@ -101,9 +101,6 @@ final class JdkHttpClient implements HttpClient {
               "errorSslHandshake", request.uri().getHost(), Exceptions.getRootReason(e)));
     } catch (SSLException e) {
       throw new SSLException(Exceptions.getRootReason(e));
-    } catch (IOException e) {
-      // JDK 11 throws IOException instead of SSLHandshakeException
-      throw new IOException(Exceptions.getRootReason(e));
     } catch (InterruptedException e) {
       // next best thing after letting (checked) InterruptedException bubble up
       Thread.currentThread().interrupt();

--- a/pkl-gradle/pkl-gradle.gradle.kts
+++ b/pkl-gradle/pkl-gradle.gradle.kts
@@ -65,7 +65,7 @@ gradlePlugin {
 
 gradlePluginTests {
   // keep in sync with `PklPlugin.MIN_GRADLE_VERSION`
-  minGradleVersion = GradleVersion.version("7.2")
+  minGradleVersion = GradleVersion.version("8.1")
   maxGradleVersion = GradleVersion.version("8.99")
   skippedGradleVersions = listOf()
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -62,7 +62,7 @@ import org.pkl.gradle.task.TestTask;
 @SuppressWarnings("unused")
 public class PklPlugin implements Plugin<Project> {
 
-  private static final String MIN_GRADLE_VERSION = "7.2";
+  private static final String MIN_GRADLE_VERSION = "8.1";
 
   @LateInit private Project project;
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,8 +35,8 @@ dependencyResolutionManagement {
 }
 
 val javaVersion = JavaVersion.current()
-require(javaVersion.isJava11Compatible) {
-  "Project requires Java 11 or higher, but found ${javaVersion.majorVersion}."
+require(javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
+  "Project requires Java 17 or higher, but found ${javaVersion.majorVersion}."
 }
 
 if (gradle.startParameter.taskNames.contains("updateDependencyLocks") ||


### PR DESCRIPTION
* Fix CI job for bench and gradle-compatibility
* Fix documentation issues around Java compatibility (Java 11 -> Java 17)
* Bump minimum Gradle version to 8.1