### PR TITLE
Remove obsolete Alpine Linux workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -753,9 +753,6 @@ workflows:
     - gradle-check-jdk21:
         requires:
         - hold
-    - pkl-cli-linux-alpine-amd64-snapshot:
-        requires:
-        - hold
     when:
       matches:
         value: << pipeline.git.branch >>
@@ -764,7 +761,6 @@ workflows:
     jobs:
     - gradle-check-jdk17
     - gradle-check-jdk21
-    - pkl-cli-linux-alpine-amd64-snapshot
     - bench
     - gradle-compatibility
     - pkl-cli-macOS-amd64-snapshot
@@ -776,7 +772,6 @@ workflows:
         requires:
         - gradle-check-jdk17
         - gradle-check-jdk21
-        - pkl-cli-linux-alpine-amd64-snapshot
         - bench
         - gradle-compatibility
         - pkl-cli-macOS-amd64-snapshot
@@ -803,12 +798,6 @@ workflows:
           tags:
             only: /^v?\d+\.\d+\.\d+$/
     - gradle-check-jdk21:
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /^v?\d+\.\d+\.\d+$/
-    - pkl-cli-linux-alpine-amd64-snapshot:
         filters:
           branches:
             ignore: /.*/
@@ -860,7 +849,6 @@ workflows:
         requires:
         - gradle-check-jdk17
         - gradle-check-jdk21
-        - pkl-cli-linux-alpine-amd64-snapshot
         - bench
         - gradle-compatibility
         - pkl-cli-macOS-amd64-release
@@ -903,9 +891,6 @@ workflows:
         requires:
         - hold
     - gradle-check-jdk21:
-        requires:
-        - hold
-    - pkl-cli-linux-alpine-amd64-snapshot:
         requires:
         - hold
     - bench:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -753,6 +753,9 @@ workflows:
     - gradle-check-jdk21:
         requires:
         - hold
+    - pkl-cli-linux-alpine-amd64-snapshot:
+        requires:
+        - hold
     when:
       matches:
         value: << pipeline.git.branch >>
@@ -761,6 +764,7 @@ workflows:
     jobs:
     - gradle-check-jdk17
     - gradle-check-jdk21
+    - pkl-cli-linux-alpine-amd64-snapshot
     - bench
     - gradle-compatibility
     - pkl-cli-macOS-amd64-snapshot
@@ -772,6 +776,7 @@ workflows:
         requires:
         - gradle-check-jdk17
         - gradle-check-jdk21
+        - pkl-cli-linux-alpine-amd64-snapshot
         - bench
         - gradle-compatibility
         - pkl-cli-macOS-amd64-snapshot
@@ -798,6 +803,12 @@ workflows:
           tags:
             only: /^v?\d+\.\d+\.\d+$/
     - gradle-check-jdk21:
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v?\d+\.\d+\.\d+$/
+    - pkl-cli-linux-alpine-amd64-snapshot:
         filters:
           branches:
             ignore: /.*/
@@ -849,6 +860,7 @@ workflows:
         requires:
         - gradle-check-jdk17
         - gradle-check-jdk21
+        - pkl-cli-linux-alpine-amd64-snapshot
         - bench
         - gradle-compatibility
         - pkl-cli-macOS-amd64-release
@@ -891,6 +903,9 @@ workflows:
         requires:
         - hold
     - gradle-check-jdk21:
+        requires:
+        - hold
+    - pkl-cli-linux-alpine-amd64-snapshot:
         requires:
         - hold
     - bench:

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/Main.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/Main.kt
@@ -19,37 +19,23 @@ package org.pkl.cli
 
 import com.github.ajalt.clikt.core.subcommands
 import org.pkl.cli.commands.*
-import org.pkl.commons.cli.CliMain
 import org.pkl.commons.cli.cliMain
 import org.pkl.core.Release
 
 /** Main method of the Pkl CLI (command-line evaluator and REPL). */
 internal fun main(args: Array<String>) {
-  val version = Release.current().versionInfo()
-  val helpLink = "${Release.current().documentation().homepage()}pkl-cli/index.html#usage"
-  val commands =
-    arrayOf(
-      EvalCommand(helpLink),
-      ReplCommand(helpLink),
-      ServerCommand(helpLink),
-      TestCommand(helpLink),
-      ProjectCommand(helpLink),
-      DownloadPackageCommand(helpLink)
-    )
-  val cmd = RootCommand("pkl", version, helpLink).subcommands(*commands)
   cliMain {
-    if (CliMain.compat == "alpine") {
-      // Alpine's main thread has a prohibitively small stack size by default;
-      // https://github.com/oracle/graal/issues/3398
-      var throwable: Throwable? = null
-      Thread(null, { cmd.main(args) }, "alpineMain", 10000000).apply {
-        setUncaughtExceptionHandler { _, t -> throwable = t }
-        start()
-        join()
-      }
-      throwable?.let { throw it }
-    } else {
-      cmd.main(args)
-    }
+    val version = Release.current().versionInfo()
+    val helpLink = "${Release.current().documentation().homepage()}pkl-cli/index.html#usage"
+    RootCommand("pkl", version, helpLink)
+      .subcommands(
+        EvalCommand(helpLink),
+        ReplCommand(helpLink),
+        ServerCommand(helpLink),
+        TestCommand(helpLink),
+        ProjectCommand(helpLink),
+        DownloadPackageCommand(helpLink)
+      )
+      .main(args)
   }
 }


### PR DESCRIPTION
According to https://github.com/oracle/graal/issues/3398, the bug necessitating this workaround was fixed in October 2022.

Note: I can't test this, but hopefully CI can.