### PR TITLE
Improve conditional configuration of native build tasks

### DIFF
--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -215,48 +215,36 @@ fun Exec.configureExecutable(
  * Builds the pkl CLI for macOS/amd64.
  */
 val macExecutableAmd64: TaskProvider<Exec> by tasks.registering(Exec::class) {
-  if (buildInfo.os.isMacOsX) {
-    dependsOn(":installGraalVmAmd64")
-    configureExecutable(
-      buildInfo.graalVmAmd64,
-      layout.buildDirectory.file("executable/pkl-macos-amd64")
-    )
-  } else {
-    enabled = false
-  }
+  dependsOn(":installGraalVmAmd64")
+  configureExecutable(
+    buildInfo.graalVmAmd64,
+    layout.buildDirectory.file("executable/pkl-macos-amd64")
+  )
 }
 
 /**
  * Builds the pkl CLI for macOS/aarch64.
  */
 val macExecutableAarch64: TaskProvider<Exec> by tasks.registering(Exec::class) {
-  if (buildInfo.os.isMacOsX) {
-    dependsOn(":installGraalVmAarch64")
-    configureExecutable(
-      buildInfo.graalVmAarch64,
-      layout.buildDirectory.file("executable/pkl-macos-aarch64"),
-      listOf(
-        "-H:+AllowDeprecatedBuilderClassesOnImageClasspath"
-      )
+  dependsOn(":installGraalVmAarch64")
+  configureExecutable(
+    buildInfo.graalVmAarch64,
+    layout.buildDirectory.file("executable/pkl-macos-aarch64"),
+    listOf(
+      "-H:+AllowDeprecatedBuilderClassesOnImageClasspath"
     )
-  } else {
-    enabled = false
-  }
+  )
 }
 
 /**
  * Builds the pkl CLI for linux/amd64.
  */
 val linuxExecutableAmd64: TaskProvider<Exec> by tasks.registering(Exec::class) {
-  if (buildInfo.os.isLinux && buildInfo.arch == "amd64") {
-    dependsOn(":installGraalVmAmd64")
-    configureExecutable(
-      buildInfo.graalVmAmd64,
-      layout.buildDirectory.file("executable/pkl-linux-amd64")
-    )
-  } else {
-    enabled = false
-  }
+  dependsOn(":installGraalVmAmd64")
+  configureExecutable(
+    buildInfo.graalVmAmd64,
+    layout.buildDirectory.file("executable/pkl-linux-amd64")
+  )
 }
 
 /**
@@ -266,15 +254,11 @@ val linuxExecutableAmd64: TaskProvider<Exec> by tasks.registering(Exec::class) {
  * ARM instances.
  */
 val linuxExecutableAarch64: TaskProvider<Exec> by tasks.registering(Exec::class) {
-  if (buildInfo.os.isLinux && buildInfo.arch == "aarch64") {
-    dependsOn(":installGraalVmAarch64")
-    configureExecutable(
-      buildInfo.graalVmAarch64,
-      layout.buildDirectory.file("executable/pkl-linux-aarch64")
-    )
-  } else {
-    enabled = false
-  }
+  dependsOn(":installGraalVmAarch64")
+  configureExecutable(
+    buildInfo.graalVmAarch64,
+    layout.buildDirectory.file("executable/pkl-linux-aarch64")
+  )
 }
 
 /**
@@ -284,20 +268,32 @@ val linuxExecutableAarch64: TaskProvider<Exec> by tasks.registering(Exec::class)
  * Details: https://www.graalvm.org/22.0/reference-manual/native-image/ARM64/
  */
 val alpineExecutableAmd64: TaskProvider<Exec> by tasks.registering(Exec::class) {
-  if (buildInfo.os.isLinux && buildInfo.arch == "amd64" && buildInfo.hasMuslToolchain) {
-    dependsOn(":installGraalVmAmd64")
-    configureExecutable(
-      buildInfo.graalVmAmd64,
-      layout.buildDirectory.file("executable/pkl-alpine-linux-amd64"),
-      listOf("--static", "--libc=musl")
-    )
-  } else {
-    enabled = false
-  }
+  dependsOn(":installGraalVmAmd64")
+  configureExecutable(
+    buildInfo.graalVmAmd64,
+    layout.buildDirectory.file("executable/pkl-alpine-linux-amd64"),
+    listOf("--static", "--libc=musl")
+  )
 }
 
 tasks.assembleNative {
-  dependsOn(macExecutableAmd64, macExecutableAarch64, linuxExecutableAmd64, linuxExecutableAarch64, alpineExecutableAmd64)
+  when {
+    buildInfo.os.isMacOsX -> {
+      dependsOn(macExecutableAmd64)
+      if (buildInfo.arch == "aarch64") {
+        dependsOn(macExecutableAarch64)
+      }
+    }
+    buildInfo.os.isLinux && buildInfo.arch == "aarch64" -> {
+      dependsOn(linuxExecutableAarch64)
+    }
+    buildInfo.os.isLinux && buildInfo.arch == "amd64" -> {
+      dependsOn(linuxExecutableAmd64)
+      if (buildInfo.hasMuslToolchain) {
+        dependsOn(alpineExecutableAmd64)
+      }
+    }
+  }
 }
 
 // make Java executable available to other subprojects

--- a/pkl-core/pkl-core.gradle.kts
+++ b/pkl-core/pkl-core.gradle.kts
@@ -193,7 +193,6 @@ tasks.check {
 }
 
 val testMacExecutableAmd64 by tasks.registering(Test::class) {
-  enabled = buildInfo.os.isMacOsX
   dependsOn(":pkl-cli:macExecutableAmd64")
 
   inputs.dir("src/test/files/LanguageSnippetTests/input").withPropertyName("languageSnippetTestsInput").withPathSensitivity(PathSensitivity.RELATIVE)
@@ -209,7 +208,6 @@ val testMacExecutableAmd64 by tasks.registering(Test::class) {
 }
 
 val testMacExecutableAarch64 by tasks.registering(Test::class) {
-  enabled = buildInfo.os.isMacOsX
   dependsOn(":pkl-cli:macExecutableAarch64")
 
   inputs.dir("src/test/files/LanguageSnippetTests/input")
@@ -225,7 +223,6 @@ val testMacExecutableAarch64 by tasks.registering(Test::class) {
 }
 
 val testLinuxExecutableAmd64 by tasks.registering(Test::class) {
-  enabled = buildInfo.os.isLinux && buildInfo.arch == "amd64"
   dependsOn(":pkl-cli:linuxExecutableAmd64")
 
   inputs.dir("src/test/files/LanguageSnippetTests/input")
@@ -241,7 +238,6 @@ val testLinuxExecutableAmd64 by tasks.registering(Test::class) {
 }
 
 val testLinuxExecutableAarch64 by tasks.registering(Test::class) {
-  enabled = buildInfo.os.isLinux && buildInfo.arch == "aarch64"
   dependsOn(":pkl-cli:linuxExecutableAarch64")
 
   inputs.dir("src/test/files/LanguageSnippetTests/input")
@@ -257,7 +253,6 @@ val testLinuxExecutableAarch64 by tasks.registering(Test::class) {
 }
 
 val testAlpineExecutableAmd64 by tasks.registering(Test::class) {
-  enabled = buildInfo.os.isLinux && buildInfo.arch == "amd64" && buildInfo.hasMuslToolchain
   dependsOn(":pkl-cli:alpineExecutableAmd64")
 
   inputs.dir("src/test/files/LanguageSnippetTests/input")
@@ -273,11 +268,23 @@ val testAlpineExecutableAmd64 by tasks.registering(Test::class) {
 }
 
 tasks.testNative {
-  dependsOn(testLinuxExecutableAmd64)
-  dependsOn(testLinuxExecutableAarch64)
-  dependsOn(testMacExecutableAmd64)
-  dependsOn(testMacExecutableAarch64)
-  dependsOn(testAlpineExecutableAmd64)
+  when {
+    buildInfo.os.isMacOsX -> {
+      dependsOn(testMacExecutableAmd64)
+      if (buildInfo.arch == "aarch64") {
+        dependsOn(testMacExecutableAarch64)
+      }
+    }
+    buildInfo.os.isLinux && buildInfo.arch == "aarch64" -> {
+      dependsOn(testLinuxExecutableAarch64)
+    }
+    buildInfo.os.isLinux && buildInfo.arch == "amd64" -> {
+      dependsOn(testLinuxExecutableAmd64)
+      if (buildInfo.hasMuslToolchain) {
+        dependsOn(testAlpineExecutableAmd64)
+      }
+    }
+  }
 }
 
 tasks.clean {


### PR DESCRIPTION
- Move all conditional configuration to the `assembleNative` and `testNative` "root" tasks
- Also pick default macOS tasks according to CPU architecture (wasn't the case before, but I assume it makes sense)