### PR TITLE
[Fix][CI] Use JDK 17 image for deploy-snapshot job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,7 +672,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
     docker:
-    - image: cimg/openjdk:17.0
+    - image: cimg/openjdk:11.0
   deploy-release:
     steps:
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,7 +672,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
     docker:
-    - image: cimg/openjdk:11.0
+    - image: cimg/openjdk:17.0
   deploy-release:
     steps:
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,7 +672,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
     docker:
-    - image: cimg/openjdk:11.0
+    - image: cimg/openjdk:17.0
   deploy-release:
     steps:
     - checkout
@@ -695,7 +695,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
     docker:
-    - image: cimg/openjdk:11.0
+    - image: cimg/openjdk:17.0
   github-release:
     steps:
     - attach_workspace:

--- a/.circleci/jobs/DeployJob.pkl
+++ b/.circleci/jobs/DeployJob.pkl
@@ -23,7 +23,7 @@ command: String
 
 job {
   docker {
-    new { image = "cimg/openjdk:11.0" }
+    new { image = "cimg/openjdk:17.0" }
   }
 }
 


### PR DESCRIPTION
# Cause

The CI is failing for deploy-snapshot job.
Ref: https://app.circleci.com/pipelines/github/apple/pkl/760/workflows/b39c0772-56db-4ba3-a5bc-edef38e25bc2/jobs/4203

The reason is that using image is JDK11.0, but we specify the 17.0