### PR TITLE
Swap Kotlin/Groovy tab order in documentation

### DIFF
--- a/docs/modules/java-binding/pages/codegen.adoc
+++ b/docs/modules/java-binding/pages/codegen.adoc
@@ -50,7 +50,7 @@ ifdef::is-release-version[]
   mavenCentral()
 endif::[]
 ifndef::is-release-version[]
-  maven { url = uri("{uri-sonatype}") }
+  maven(url = "{uri-sonatype}")
 endif::[]
 }
 ----

--- a/docs/modules/java-binding/pages/codegen.adoc
+++ b/docs/modules/java-binding/pages/codegen.adoc
@@ -36,25 +36,6 @@ To use the library in a Gradle project, declare the following dependency:
 
 [tabs]
 ====
-Groovy::
-+
-.build.gradle
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  implementation "org.pkl-lang:pkl-codegen-java:{pkl-artifact-version}"
-}
-
-repositories {
-ifdef::is-release-version[]
-  mavenCentral()
-endif::[]
-ifndef::is-release-version[]
-  maven { url "{uri-sonatype}" }
-endif::[]
-}
-----
-
 Kotlin::
 +
 .build.gradle.kts
@@ -70,6 +51,25 @@ ifdef::is-release-version[]
 endif::[]
 ifndef::is-release-version[]
   maven { url = uri("{uri-sonatype}") }
+endif::[]
+}
+----
+
+Groovy::
++
+.build.gradle
+[source,groovy,subs="+attributes"]
+----
+dependencies {
+  implementation "org.pkl-lang:pkl-codegen-java:{pkl-artifact-version}"
+}
+
+repositories {
+ifdef::is-release-version[]
+  mavenCentral()
+endif::[]
+ifndef::is-release-version[]
+  maven { url "{uri-sonatype}" }
 endif::[]
 }
 ----

--- a/docs/modules/java-binding/pages/pkl-config-java.adoc
+++ b/docs/modules/java-binding/pages/pkl-config-java.adoc
@@ -31,6 +31,25 @@ To use the library in a Gradle project, declare the following dependency:
 
 [tabs]
 ====
+Kotlin::
++
+.build.gradle.kts
+[source,kotlin,subs="+attributes"]
+----
+dependencies {
+  implementation("org.pkl-lang:pkl-config-java:{pkl-artifact-version}")
+}
+
+repositories {
+ifdef::is-release-version[]
+  mavenCentral()
+endif::[]
+ifndef::is-release-version[]
+  maven { url = uri("{uri-sonatype}") }
+endif::[]
+}
+----
+
 Groovy::
 +
 .build.gradle
@@ -50,25 +69,6 @@ repositories {
   maven { url "{uri-sonatype}" }
 }
 endif::[]
-----
-
-Kotlin::
-+
-.build.gradle.kts
-[source,kotlin,subs="+attributes"]
-----
-dependencies {
-  implementation("org.pkl-lang:pkl-config-java:{pkl-artifact-version}")
-}
-
-repositories {
-ifdef::is-release-version[]
-  mavenCentral()
-endif::[]
-ifndef::is-release-version[]
-  maven { url = uri("{uri-sonatype}") }
-endif::[]
-}
 ----
 ====
 

--- a/docs/modules/java-binding/pages/pkl-config-java.adoc
+++ b/docs/modules/java-binding/pages/pkl-config-java.adoc
@@ -45,7 +45,7 @@ ifdef::is-release-version[]
   mavenCentral()
 endif::[]
 ifndef::is-release-version[]
-  maven { url = uri("{uri-sonatype}") }
+  maven(url = "{uri-sonatype}")
 endif::[]
 }
 ----

--- a/docs/modules/kotlin-binding/pages/codegen.adoc
+++ b/docs/modules/kotlin-binding/pages/codegen.adoc
@@ -41,7 +41,7 @@ ifdef::is-release-version[]
   mavenCentral()
 endif::[]
 ifndef::is-release-version[]
-  maven { url = uri("{uri-sonatype}") }
+  maven(url = "{uri-sonatype}")
 endif::[]
 }
 ----

--- a/docs/modules/kotlin-binding/pages/codegen.adoc
+++ b/docs/modules/kotlin-binding/pages/codegen.adoc
@@ -27,25 +27,6 @@ To use the library in a Gradle project, declare the following dependency:
 
 [tabs]
 ====
-Groovy::
-+
-.build.gradle
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  implementation "org.pkl-lang:pkl-codegen-kotlin:{pkl-artifact-version}"
-}
-
-repositories {
-ifdef::is-release-version[]
-  mavenCentral()
-endif::[]
-ifndef::is-release-version[]
-  maven { url "{uri-sonatype}" }
-endif::[]
-}
-----
-
 Kotlin::
 +
 .build.gradle.kts
@@ -61,6 +42,25 @@ ifdef::is-release-version[]
 endif::[]
 ifndef::is-release-version[]
   maven { url = uri("{uri-sonatype}") }
+endif::[]
+}
+----
+
+Groovy::
++
+.build.gradle
+[source,groovy,subs="+attributes"]
+----
+dependencies {
+  implementation "org.pkl-lang:pkl-codegen-kotlin:{pkl-artifact-version}"
+}
+
+repositories {
+ifdef::is-release-version[]
+  mavenCentral()
+endif::[]
+ifndef::is-release-version[]
+  maven { url "{uri-sonatype}" }
 endif::[]
 }
 ----

--- a/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
+++ b/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
@@ -20,25 +20,6 @@ To use the library in a Gradle project, declare the following dependency:
 
 [tabs]
 ====
-Groovy::
-+
-.build.gradle
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  implementation "org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}"
-}
-
-repositories {
-ifdef::is-release-version[]
-  mavenCentral()
-endif::[]
-ifndef::is-release-version[]
-  maven { url "{uri-sonatype}" }
-endif::[]
-}
-----
-
 Kotlin::
 +
 .build.gradle.kts
@@ -54,6 +35,25 @@ ifdef::is-release-version[]
 endif::[]
 ifndef::is-release-version[]
   maven { url = uri("{uri-sonatype}") }
+endif::[]
+}
+----
+
+Groovy::
++
+.build.gradle
+[source,groovy,subs="+attributes"]
+----
+dependencies {
+  implementation "org.pkl-lang:pkl-config-kotlin:{pkl-artifact-version}"
+}
+
+repositories {
+ifdef::is-release-version[]
+  mavenCentral()
+endif::[]
+ifndef::is-release-version[]
+  maven { url "{uri-sonatype}" }
 endif::[]
 }
 ----

--- a/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
+++ b/docs/modules/kotlin-binding/pages/pkl-config-kotlin.adoc
@@ -34,7 +34,7 @@ ifdef::is-release-version[]
   mavenCentral()
 endif::[]
 ifndef::is-release-version[]
-  maven { url = uri("{uri-sonatype}") }
+  maven(url = "{uri-sonatype}")
 endif::[]
 }
 ----

--- a/docs/modules/pkl-core/pages/index.adoc
+++ b/docs/modules/pkl-core/pages/index.adoc
@@ -44,7 +44,7 @@ ifdef::is-release-version[]
   mavenCentral()
 endif::[]
 ifndef::is-release-version[]
-  maven { url = uri("{uri-sonatype}") }
+  maven(url = "{uri-sonatype}")
 endif::[]
 }
 ----

--- a/docs/modules/pkl-core/pages/index.adoc
+++ b/docs/modules/pkl-core/pages/index.adoc
@@ -30,25 +30,6 @@ To use the library in a Gradle project, declare the following dependency:
 
 [tabs]
 ====
-Groovy::
-+
-.build.gradle
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  implementation "org.pkl-lang:pkl-core:{pkl-artifact-version}"
-}
-
-repositories {
-ifdef::is-release-version[]
-  mavenCentral()
-endif::[]
-ifndef::is-release-version[]
-  maven { url "{uri-sonatype}" }
-endif::[]
-}
-----
-
 Kotlin::
 +
 .build.gradle.kts
@@ -64,6 +45,25 @@ ifdef::is-release-version[]
 endif::[]
 ifndef::is-release-version[]
   maven { url = uri("{uri-sonatype}") }
+endif::[]
+}
+----
+
+Groovy::
++
+.build.gradle
+[source,groovy,subs="+attributes"]
+----
+dependencies {
+  implementation "org.pkl-lang:pkl-core:{pkl-artifact-version}"
+}
+
+repositories {
+ifdef::is-release-version[]
+  mavenCentral()
+endif::[]
+ifndef::is-release-version[]
+  maven { url "{uri-sonatype}" }
 endif::[]
 }
 ----

--- a/docs/modules/pkl-doc/pages/index.adoc
+++ b/docs/modules/pkl-doc/pages/index.adoc
@@ -100,7 +100,7 @@ ifdef::is-release-version[]
   mavenCentral()
 endif::[]
 ifndef::is-release-version[]
-  maven { url = uri("{uri-sonatype}") }
+  maven(url = "{uri-sonatype}")
 endif::[]
 }
 ----

--- a/docs/modules/pkl-doc/pages/index.adoc
+++ b/docs/modules/pkl-doc/pages/index.adoc
@@ -86,25 +86,6 @@ To use the library in a Gradle project, declare the following dependency:
 
 [tabs]
 ====
-Groovy::
-+
-.build.gradle
-[source,groovy,subs="+attributes"]
-----
-dependencies {
-  implementation "org.pkl-lang:pkl-doc:{pkl-artifact-version}"
-}
-
-repositories {
-ifdef::is-release-version[]
-  mavenCentral()
-endif::[]
-ifndef::is-release-version[]
-  maven { url "{uri-sonatype}" }
-endif::[]
-}
-----
-
 Kotlin::
 +
 .build.gradle.kts
@@ -120,6 +101,25 @@ ifdef::is-release-version[]
 endif::[]
 ifndef::is-release-version[]
   maven { url = uri("{uri-sonatype}") }
+endif::[]
+}
+----
+
+Groovy::
++
+.build.gradle
+[source,groovy,subs="+attributes"]
+----
+dependencies {
+  implementation "org.pkl-lang:pkl-doc:{pkl-artifact-version}"
+}
+
+repositories {
+ifdef::is-release-version[]
+  mavenCentral()
+endif::[]
+ifndef::is-release-version[]
+  maven { url "{uri-sonatype}" }
 endif::[]
 }
 ----

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -51,7 +51,7 @@ ifdef::is-release-version[]
         mavenCentral()
 endif::[]
 ifndef::is-release-version[]
-        maven { url = uri("{uri-sonatype}") }
+        maven(url = "{uri-sonatype}")
 endif::[]
     }
 }

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -32,31 +32,6 @@ The plugin is applied as follows:
 
 [tabs]
 ====
-Groovy::
-+
-.build.gradle
-[source,groovy,subs="+attributes"]
-----
-plugins {
-  id "org.pkl-lang" version "{pkl-artifact-version}"
-}
-----
-+
-.settings.gradle
-[source,groovy,subs="+attributes"]
-----
-pluginManagement {
-    repositories {
-ifdef::is-release-version[]
-        mavenCentral()
-endif::[]
-ifndef::is-release-version[]
-        maven { url "{uri-sonatype}" }
-endif::[]
-    }
-}
-----
-
 Kotlin::
 +
 .build.gradle.kts
@@ -77,6 +52,31 @@ ifdef::is-release-version[]
 endif::[]
 ifndef::is-release-version[]
         maven { url = uri("{uri-sonatype}") }
+endif::[]
+    }
+}
+----
+
+Groovy::
++
+.build.gradle
+[source,groovy,subs="+attributes"]
+----
+plugins {
+  id "org.pkl-lang" version "{pkl-artifact-version}"
+}
+----
++
+.settings.gradle
+[source,groovy,subs="+attributes"]
+----
+pluginManagement {
+    repositories {
+ifdef::is-release-version[]
+        mavenCentral()
+endif::[]
+ifndef::is-release-version[]
+        maven { url "{uri-sonatype}" }
 endif::[]
     }
 }


### PR DESCRIPTION
Following up on https://github.com/apple/pkl/pull/411; this PR changes the order of the Groovy and Kotlin tabs in the documentation, making Kotlin the new default.