### PR TITLE
Handle `null` pathElements gracefully in message passing API

### DIFF
--- a/docs/modules/bindings-specification/pages/message-passing-api.adoc
+++ b/docs/modules/bindings-specification/pages/message-passing-api.adoc
@@ -451,6 +451,8 @@ The response to <<list-resources-request>>.
 If successful, `pathElements` is set.
 Otherwise, `error` is set.
 
+If neither are set, `pathElements` default to an empty list.
+
 [source,pkl]
 ----
 /// A number identifying this request.
@@ -506,6 +508,8 @@ Type: <<client-message,Client>> <<response-message,Response>>
 The response to <<list-modules-request>>.
 If successful, `pathElements` is set.
 Otherwise, `error` is set.
+
+If neither are set, `pathElements` default to an empty list.
 
 [source,pkl]
 ----

--- a/pkl-server/src/main/kotlin/org/pkl/server/ClientModuleKeyFactory.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ClientModuleKeyFactory.kt
@@ -97,7 +97,7 @@ internal class ClientModuleKeyFactory(
                     if (response.error != null) {
                       completeExceptionally(IOException(response.error))
                     } else {
-                      complete(response.pathElements!!)
+                      complete(response.pathElements ?: emptyList())
                     }
                   }
                   else -> completeExceptionally(ProtocolException("unexpected response"))

--- a/pkl-server/src/main/kotlin/org/pkl/server/ClientResourceReader.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ClientResourceReader.kt
@@ -68,10 +68,10 @@ internal class ClientResourceReader(
           transport.send(request) { response ->
             when (response) {
               is ListResourcesResponse ->
-                if (response.pathElements != null) {
-                  complete(response.pathElements)
-                } else {
+                if (response.error != null) {
                   completeExceptionally(IOException(response.error))
+                } else {
+                  complete(response.pathElements ?: emptyList())
                 }
               else -> completeExceptionally(ProtocolException("Unexpected response"))
             }

--- a/pkl-server/src/test/kotlin/org/pkl/server/ServerTest.kt
+++ b/pkl-server/src/test/kotlin/org/pkl/server/ServerTest.kt
@@ -295,6 +295,43 @@ class ServerTest {
   }
 
   @Test
+  fun `glob resources -- null pathElements and null error`() {
+    val reader = ResourceReaderSpec(scheme = "bird", hasHierarchicalUris = true, isGlobbable = true)
+    val evaluatorId = client.sendCreateEvaluatorRequest(resourceReaders = listOf(reader))
+    client.send(
+      EvaluateRequest(
+        requestId = 1,
+        evaluatorId = evaluatorId,
+        moduleUri = URI("repl:text"),
+        moduleText =
+          """
+        res = read*("bird:/**.txt").keys
+      """
+            .trimIndent(),
+        expr = "res"
+      )
+    )
+    val listResourcesRequest = client.receive<ListResourcesRequest>()
+    client.send(
+      ListResourcesResponse(
+        requestId = listResourcesRequest.requestId,
+        evaluatorId = listResourcesRequest.evaluatorId,
+        pathElements = null,
+        error = null
+      )
+    )
+    val evaluateResponse = client.receive<EvaluateResponse>()
+    assertThat(evaluateResponse.result!!.debugYaml)
+      .isEqualTo(
+        """
+        - 6
+        - []
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `glob resource error`() {
     val reader = ResourceReaderSpec(scheme = "bird", hasHierarchicalUris = true, isGlobbable = true)
     val evaluatorId = client.sendCreateEvaluatorRequest(resourceReaders = listOf(reader))
@@ -500,6 +537,47 @@ class ServerTest {
         - bird:/birds/pigeon.pkl
         - bird:/majesticBirds/barnOwl.pkl
         - bird:/majesticBirds/elfOwl.pkl
+    """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `glob module -- null pathElements and null error`() {
+    val reader =
+      ModuleReaderSpec(
+        scheme = "bird",
+        hasHierarchicalUris = true,
+        isLocal = true,
+        isGlobbable = true
+      )
+    val evaluatorId = client.sendCreateEvaluatorRequest(moduleReaders = listOf(reader))
+
+    client.send(
+      EvaluateRequest(
+        requestId = 1,
+        evaluatorId = evaluatorId,
+        moduleUri = URI("repl:text"),
+        moduleText = """res = import*("bird:/**.pkl").keys""",
+        expr = "res"
+      )
+    )
+    val listModulesMsg = client.receive<ListModulesRequest>()
+    client.send(
+      ListModulesResponse(
+        requestId = listModulesMsg.requestId,
+        evaluatorId = evaluatorId,
+        pathElements = null,
+        error = null
+      )
+    )
+
+    val evaluateResponse = client.receive<EvaluateResponse>()
+    assertThat(evaluateResponse.result!!.debugRendering)
+      .isEqualTo(
+        """
+      - 6
+      - []
     """
           .trimIndent()
       )


### PR DESCRIPTION
In messages "List Resources Response" and "List Modules Response", if `pathElements` and `error` are both null, default to an empty list.