### PR TITLE
Update amending example

### DIFF
--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -86,7 +86,7 @@ stockPigeon {
   }
 }
 
-woodPigeon {
+woodPigeon = (stockPigeon) {
   name = "Common wood pigeon"
   taxonomy { // <1>
     species = "Columba palumbus"

--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -75,22 +75,25 @@ Consider the following example.
 [source,{pkl}]
 .nestedAmends.pkl
 ----
-woodPigeon {
-  name = "Common wood pigeon"
+stockPigeon {
+  name = "Stock pigeon"
   diet = "Seeds"
   taxonomy {
-    species = "Columba palumbus"
-  }
-}
-
-stockPigeon = (woodPigeon) {
-  name = "Stock pigeon"
-  taxonomy { // <1>
+    kingdom = "Animalia"
+    clade = "Columbimorphae"
+    order = "Columbiformes"
     species = "Columba oenas"
   }
 }
 
-dodo = (stockPigeon) { // <2>
+woodPigeon {
+  name = "Common wood pigeon"
+  taxonomy { // <1>
+    species = "Columba palumbus"
+  }
+}
+
+dodo = (woodPigeon) { // <2>
   name = "Dodo"
   extinct = true // <3>
   taxonomy {
@@ -103,7 +106,7 @@ dodo = (stockPigeon) { // <2>
 <3> New fields can be added to objects when amending.
 
 Notice how you only have to change `taxonomy.species`.
-In this example, `bird.taxonomy` has `kingdom`, `clade`, `order` and `species`.
+In this example, `stockPigeon.taxonomy` has `kingdom`, `clade`, `order` and `species`.
 You are amending `stockPigeon`, to define `woodPigeon`.
 They have the same `taxonomy`, except for `species`.
 This notation says that everything in `taxonomy` should be what it is in the object you are amending (`stockPigeon`), except for `species`, which should be `"Columba palumbus"` .
@@ -111,27 +114,36 @@ This notation says that everything in `taxonomy` should be what it is in the obj
 For the input above, Pkl produces the following output.
 [source,{pkl}]
 ----
-woodPigeon {
-  name = "Common wood pigeon"
-  diet = "Seeds"
-  taxonomy {
-    species = "Columba palumbus"
-  }
-}
 stockPigeon {
   name = "Stock pigeon"
   diet = "Seeds"
   taxonomy {
+    kingdom = "Animalia"
+    clade = "Columbimorphae"
+    order = "Columbiformes"
     species = "Columba oenas"
+  }
+}
+woodPigeon {
+  name = "Common wood pigeon"
+  diet = "Seeds"
+  taxonomy {
+    kingdom = "Animalia"
+    clade = "Columbimorphae"
+    order = "Columbiformes"
+    species = "Columba palumbus"
   }
 }
 dodo {
   name = "Dodo"
   diet = "Seeds"
-  extinct = true
   taxonomy {
+    kingdom = "Animalia"
+    clade = "Columbimorphae"
+    order = "Columbiformes"
     species = "Raphus cucullatus"
   }
+  extinct = true
 }
 ----
 


### PR DESCRIPTION
Looking through the [Ammending](https://pkl-lang.org/main/current/language-tutorial/02_filling_out_a_template.html#amending) section of the "Filling out a template" tutorial, it seemed like the code snippets and the textual explanation didn't align nicely. I've updated the code snippets to match the text surrounding them as it seemed like the text was the correct one. Here's a summary of changes:

1. Swapped out the relationship between stock and wood pigeon - it appeared like wood pigeon should be amending stock pigeon rather than the other way around.
2. Added `kingdom`, `clade`, and `order` to `stockPigeon.taxonomy` as the text was referencing those fields, but those were missing from the code snippet.
3. Updated the output snippet to reflect the code reorganization.
