### PR TITLE
Split out base settings in stdlib for reuse

### DIFF
--- a/pkl-core/src/test/files/LanguageSnippetTests/input/stdlib/settings.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/stdlib/settings.pkl
@@ -1,0 +1,25 @@
+amends ".../snippetTest.pkl"
+
+import "pkl:AbstractSettings"
+import "pkl:Project"
+import "pkl:settings"
+import "pkl:reflect"
+
+local evaluatorSettingsClass = reflect.Class(AbstractSettings.Evaluator)
+
+local function allProperties(clazz: reflect.Class?): Map<String,reflect.Property> =
+  if (clazz == null) Map() else
+    allProperties(clazz.superclass) + clazz.properties
+
+facts {
+  ["`evaluatorSettings` in children of `pkl:AbstractSettings` have subtypes of `AbstractSettings.Evaluator`"] {
+    for (cls in List(settings.getClass(), Project.getClass())) {
+      ...new Listing {
+        local properties = allProperties(reflect.Class(cls))
+        local evaluatorSettingsType = properties["evaluatorSettings"].type as reflect.DeclaredType
+        local clazz = evaluatorSettingsType.referent as reflect.Class
+        clazz == evaluatorSettingsClass || clazz.isSubclassOf(evaluatorSettingsClass)
+      }
+    }
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotFindStdLibModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotFindStdLibModule.err
@@ -6,6 +6,7 @@ x | import "pkl:nonExisting"
 at cannotFindStdLibModule#nonExisting (file:///$snippetsDir/input/errors/cannotFindStdLibModule.pkl)
 
 Available standard library modules:
+pkl:AbstractSettings
 pkl:base
 pkl:Benchmark
 pkl:DocPackageInfo

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/projects/badProjectDeps4/bug.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/projects/badProjectDeps4/bug.err
@@ -1,6 +1,6 @@
 –– Pkl Error ––
 Expected value of type `*RemoteDependency|LocalDependency`, but got a different `pkl.Project`.
-Value: new ModuleClass { package = null; tests {}; dependencies {}; evaluatorSetting...
+Value: new ModuleClass { evaluatorSettings { proxy = null; externalProperties = null...
 
 xxx | dependencies: Mapping<String(!contains("/")), *RemoteDependency|LocalDependency>
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ at pkl.Project#dependencies (pkl:Project)
 
 * Value is not of type `LocalDependency` because:
   Type constraint `this.package != null` violated.
-  Value: new ModuleClass { package = null; tests {}; dependencies {}; evaluatorSetti...
+  Value: new ModuleClass { evaluatorSettings { proxy = null; externalProperties = nu...
 
 x | dependencies {
     ^^^^^^^^^^^^^^

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/stdlib/settings.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/stdlib/settings.pcf
@@ -1,0 +1,6 @@
+facts {
+  ["`evaluatorSettings` in children of `pkl:AbstractSettings` have subtypes of `AbstractSettings.Evaluator`"] {
+    true
+    true
+  }
+}

--- a/stdlib/AbstractSettings.pkl
+++ b/stdlib/AbstractSettings.pkl
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Definitions for configuration of Pkl itself.
+/// 
+/// This module is intended to be extended by different types/scopes of settings modules (machine,
+/// user, project, etc).
+@ModuleInfo { minPklVersion = "0.26.0" }
+abstract module pkl.AbstractSettings
+
+/// Settings that control how Pkl talks to HTTP proxies.
+class Proxy {
+  /// The proxy to use for HTTP(S) connections.
+  ///
+  /// At the moment, only HTTP proxies are supported.
+  ///
+  /// Example:
+  /// ```
+  /// local proxyPassword = read("my-proxy-password.txt").text
+  /// address = "http://myuser@\(proxyPassword):my.proxy.example.com:5080"
+  /// ```
+  address: Uri(startsWith("http://"))
+
+  /// Hosts to which all connections should bypass a proxy.
+  ///
+  /// Values can be either hostnames, or CIDR blocks.
+  ///
+  /// Follows the same rules as cURL's [--noproxy](https://curl.se/docs/manpage.html#--noproxy)
+  /// flag.
+  noProxy: Listing<String>(isDistinct)
+}
+
+/// Common settings for Pkl's own evaluator.
+/// 
+/// This limited class is `open` to allow different extensions 
+open class Evaluator {
+  /// Configuration of the HTTP proxy to use, `null` for none.
+  proxy: Proxy?
+}
+
+/// Configuration of Pkl's own evaluator.
+///
+/// These settings influence the behavior of the evaluator when running the `pkl eval`, `pkl test`,
+/// and `pkl repl` CLI commands.
+evaluatorSettings: Evaluator

--- a/stdlib/Project.pkl
+++ b/stdlib/Project.pkl
@@ -67,6 +67,8 @@
 @ModuleInfo { minPklVersion = "0.26.0" }
 module pkl.Project
 
+extends "pkl:AbstractSettings"
+
 import "pkl:Project"
 import "pkl:reflect"
 import "pkl:semver"
@@ -392,7 +394,7 @@ class Package {
   fixed uri: PackageUri = "\(baseUri)@\(version)"
 }
 
-class EvaluatorSettings {
+class EvaluatorSettings extends Evaluator {
   /// The external properties available to Pkl, read using the `prop:` scheme.
   externalProperties: Mapping<String, String>?
 

--- a/stdlib/settings.pkl
+++ b/stdlib/settings.pkl
@@ -22,41 +22,43 @@
 @ModuleInfo { minPklVersion = "0.26.0" }
 module pkl.settings
 
+extends "pkl:AbstractSettings"
+
 /// The editor for viewing and editing Pkl files.
 editor: Editor = System
 
 /// The editor associated with `file:` URLs ending in `.pkl`.
-hidden System: Editor = new {
+hidden const System: Editor = new {
   urlScheme = "%{url}, line %{line}"
 }
 
 /// The [IntelliJ IDEA](https://www.jetbrains.com/idea) editor.
-hidden Idea: Editor = new {
+hidden const Idea: Editor = new {
   urlScheme = "idea://open?file=%{path}&line=%{line}"
 }
 
 /// The [GoLand](https://www.jetbrains.com/go/) editor.
-hidden GoLand: Editor = new {
+hidden const GoLand: Editor = new {
   urlScheme = "goland://open?file=%{path}&line=%{line}"
 }
 
 /// The [TextMate](https://macromates.com) editor.
-hidden TextMate: Editor = new {
+hidden const TextMate: Editor = new {
   urlScheme = "txmt://open?url=%{url}&line=%{line}&column=%{column}"
 }
 
 /// The [Sublime Text](https://www.sublimetext.com) editor.
-hidden Sublime: Editor = new {
+hidden const Sublime: Editor = new {
   urlScheme = "subl://open?url=%{url}&line=%{line}&column=%{column}"
 }
 
 /// The [Atom](https://atom.io) editor.
-hidden Atom: Editor = new {
+hidden const Atom: Editor = new {
   urlScheme = "atom://open?url=%{url}&line=%{line}&column=%{column}"
 }
 
 /// The [Visual Studio Code](https://code.visualstudio.com) editor.
-hidden VsCode: Editor = new {
+hidden const VsCode: Editor = new {
   urlScheme = "vscode://file/%{path}:%{line}:%{column}"
 }
 


### PR DESCRIPTION
This PR defines `pkl:AbstractSettings` as a common parent module for `pkl:settings` and `pkl:Project`.

Since user-level evaluator settings should be limited to user/machine specific ones (to avoid unnecessary "works on my machine"), whereas `PklProject`s might want to set more detailed settings.

There isn't an overwhelming win from making `pkl:AbstractSettings` a super-module, other than `evaluatorSettings` (and possibly other properties in the future) being defined in all children by default. Alternatively, `pkl:AbstractSettings` could define all `class`es that might be used somewhere, and it just being `import`ed, i.e.

`settings.pkl`:
```
module pkl.settings

import "pkl:AbstractSettings"

proxy: AbstractSettings.Proxy

//...
```

`Project.pkl`:
```
module pkl.Project

import "pkl:AbstractSettings"

evaluatorSettings: AbstractSettings.Evaluator

//...
```
