### PR TITLE
Introduce specialized ModuleKey(Factory) for `http` uris

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliRepl.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliRepl.kt
@@ -45,6 +45,7 @@ internal class CliRepl(private val options: CliEvaluatorOptions) : CliCommand(op
             ModuleKeyFactories.fromServiceProviders() +
             listOf(
               ModuleKeyFactories.file,
+              ModuleKeyFactories.http,
               ModuleKeyFactories.pkg,
               ModuleKeyFactories.projectpackage,
               ModuleKeyFactories.genericUrl

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -164,6 +164,7 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
       add(ModuleKeyFactories.projectpackage)
       addAll(ModuleKeyFactories.fromServiceProviders())
       add(ModuleKeyFactories.file)
+      add(ModuleKeyFactories.http)
       add(ModuleKeyFactories.genericUrl)
     }
   }

--- a/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
@@ -120,6 +120,7 @@ public final class EvaluatorBuilder {
     builder
         .addModuleKeyFactories(ModuleKeyFactories.fromServiceProviders())
         .addModuleKeyFactory(ModuleKeyFactories.file)
+        .addModuleKeyFactory(ModuleKeyFactories.http)
         .addModuleKeyFactory(ModuleKeyFactories.pkg)
         .addModuleKeyFactory(ModuleKeyFactories.projectpackage)
         .addModuleKeyFactory(ModuleKeyFactories.genericUrl)

--- a/pkl-core/src/main/java/org/pkl/core/module/ModuleKeyFactories.java
+++ b/pkl-core/src/main/java/org/pkl/core/module/ModuleKeyFactories.java
@@ -37,6 +37,9 @@ public final class ModuleKeyFactories {
   /** A factory for file based module keys. */
   public static final ModuleKeyFactory file = new File();
 
+  /** A factory for {@code http:} and {@code https:} module keys. */
+  public static final ModuleKeyFactory http = new Http();
+
   /** A factory for URL based module keys. */
   public static final ModuleKeyFactory genericUrl = new GenericUrl();
 
@@ -147,6 +150,19 @@ public final class ModuleKeyFactories {
       }
 
       return Optional.of(ModuleKeys.file(uri, path));
+    }
+  }
+
+  private static class Http implements ModuleKeyFactory {
+    private Http() {}
+
+    @Override
+    public Optional<ModuleKey> create(URI uri) {
+      var scheme = uri.getScheme();
+      if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
+        return Optional.of(ModuleKeys.http(uri));
+      }
+      return Optional.empty();
     }
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/module/ResolvedModuleKeys.java
+++ b/pkl-core/src/main/java/org/pkl/core/module/ResolvedModuleKeys.java
@@ -18,13 +18,9 @@ package org.pkl.core.module;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.pkl.core.runtime.VmContext;
-import org.pkl.core.util.HttpUtils;
 import org.pkl.core.util.IoUtils;
 
 /** Utilities for obtaining and using resolved module keys. */
@@ -106,14 +102,6 @@ public final class ResolvedModuleKeys {
 
     @Override
     public String loadSource() throws IOException {
-      if (HttpUtils.isHttpUrl(url)) {
-        var httpClient = VmContext.get(null).getHttpClient();
-        var request = HttpRequest.newBuilder(uri).build();
-        var response = httpClient.send(request, BodyHandlers.ofString());
-        HttpUtils.checkHasStatusCode200(response);
-        return response.body();
-      }
-
       return IoUtils.readString(url);
     }
   }

--- a/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
@@ -109,6 +109,7 @@ public final class ExecutorSpiImpl implements ExecutorSpi {
             .addModuleKeyFactory(ModuleKeyFactories.pkg)
             .addModuleKeyFactory(ModuleKeyFactories.projectpackage)
             .addModuleKeyFactory(ModuleKeyFactories.file)
+            .addModuleKeyFactory(ModuleKeyFactories.http)
             .addModuleKeyFactory(ModuleKeyFactories.genericUrl)
             .setEnvironmentVariables(options.getEnvironmentVariables())
             .setExternalProperties(options.getExternalProperties())

--- a/pkl-server/src/main/kotlin/org/pkl/server/Server.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/Server.kt
@@ -223,6 +223,7 @@ class Server(private val transport: MessageTransport, private val httpClient: Ht
     add(ModuleKeyFactories.modulePath(modulePathResolver))
     add(ModuleKeyFactories.pkg)
     add(ModuleKeyFactories.projectpackage)
+    add(ModuleKeyFactories.http)
     add(ModuleKeyFactories.genericUrl)
   }
 }


### PR DESCRIPTION
GenericUrl is a catch-all that uses URL.openConnection(). Since we now have special handling of HTTP urls, it makes more sense to put it in its own module key.

Those that don't use the Http module key specifically but use `GenericUrl` will still be able to fetch `http` urls, but it would use the standard `URL.openConnection` implementation. This works the same as `file:` URIs; if only the `GenericUrl` module key factory is used, Pkl can still load `file:` uris.

(FYI @translatenix)