### PR TITLE
Implemented package mapping for Java/Kotlin code generation

### DIFF
--- a/docs/modules/java-binding/pages/codegen.adoc
+++ b/docs/modules/java-binding/pages/codegen.adoc
@@ -164,13 +164,6 @@ This annotation is required to have `java.lang.annotation.ElementType.TYPE_USE` 
 or it may generate code that does not compile.
 ====
 
-.--implement-serializable
-[%collapsible]
-====
-Default: (flag not set) +
-Whether to make generated classes implement `java.io.Serializable`.
-====
-
 Common code generator options:
 
 include::{partialsdir}/cli-codegen-options.adoc[]

--- a/docs/modules/java-binding/partials/cli-codegen-options.adoc
+++ b/docs/modules/java-binding/partials/cli-codegen-options.adoc
@@ -29,14 +29,46 @@ Default: (not set) +
 Whether to make generated classes implement `java.io.Serializable`.
 ====
 
-.-m, --package-mapping
+.--package-mapping
 [%collapsible]
 ====
 Default: (none) +
-Example: `foo=com.org.foo` +
+Example: `foo.=com.example.foo.` +
 Allows to change default package names (derived from Pkl module name prefixes) in the generated code.
 
-When you need the generated package names to be different from the default package names derived from Pkl module name prefixes, you can define a package mapping, where the key is the original Pkl module name prefix, and the value is its replacement. When you do, the generated code `package` declarations, as well as file locations, will be modified according to the mapping.
+When you need the generated package names to be different from the default package names derived from Pkl module name prefixes, you can define a package mapping, where the key is the original Pkl module name prefix, and the value is its replacement.
+When you do, the generated code's `package` declarations, as well as file locations, will be modified according to the mapping.
 
-Repeat this option to define multiple mappings. Keys must be valid Pkl module name prefixes. Values must be valid dot-separated package names.
+The prefixes are replaced literally, which means that dots at the end are important: in most cases, you must ensure that you have an ending dot on both sides of a mapping (except for an empty mapping, if you use it), otherwise you may get unexpected results:
+
+....
+// Assuming the following arguments:
+--package-mapping com.foo.=x  // Dot on the left only
+--package-mapping org.bar=y.  // Dot on the right only
+--package-mapping net.baz=z   // No dots
+
+// The following renames will be made:
+"com.foo.bar" -> "xbar"       // Target prefix merged into the suffix
+"org.bar.baz" -> "y..baz"     // Double dot, invalid package name
+"net.baz.qux" -> "z.qux"      // Looks okay, but...
+"net.bazqux"  -> "zqux"       // ...may cut the package name in the middle.
+....
+
+When computing the appropriate target package name, the longest matching prefix is used:
+
+....
+// Assuming the following arguments:
+--package-mapping com.foo.=x.
+--package-mapping com.=y.
+--package-mapping =z.
+
+// The following renames will be made:
+com.foo.bar -> "x.bar"
+com.baz.qux -> "y.baz.qux"
+org.foo.bar -> "z.org.foo.bar"
+....
+
+Repeat this option to define multiple mappings.
+Keys can be arbitrary strings, including an empty string.
+Values must be valid dot-separated package names, also possibly terminated by a dot.
 ====

--- a/docs/modules/java-binding/partials/cli-codegen-options.adoc
+++ b/docs/modules/java-binding/partials/cli-codegen-options.adoc
@@ -21,3 +21,22 @@ Relative paths are resolved against the working directory.
 Default: (not set) +
 Flag that indicates to generate config classes for use with Spring Boot.
 ====
+
+.--implement-serializable
+[%collapsible]
+====
+Default: (not set) +
+Whether to make generated classes implement `java.io.Serializable`.
+====
+
+.-m, --package-mapping
+[%collapsible]
+====
+Default: (none) +
+Example: `foo=com.org.foo` +
+Allows to change default package names (derived from Pkl module name prefixes) in the generated code.
+
+When you need the generated package names to be different from the default package names derived from Pkl module name prefixes, you can define a package mapping, where the key is the original Pkl module name prefix, and the value is its replacement. When you do, the generated code `package` declarations, as well as file locations, will be modified according to the mapping.
+
+Repeat this option to define multiple mappings. Keys must be valid Pkl module name prefixes. Values must be valid dot-separated package names.
+====

--- a/docs/modules/java-binding/partials/cli-codegen-options.adoc
+++ b/docs/modules/java-binding/partials/cli-codegen-options.adoc
@@ -42,7 +42,7 @@ When you do, the generated code's `package` declarations, class names, as well a
 The prefixes are replaced literally, which means that dots at the end are important.
 If you want to rename packages only, in most cases, you must ensure that you have an ending dot on both sides of a mapping (except for an empty mapping, if you use it), otherwise you may get unexpected results:
 
-....
+----
 // Assuming the following arguments:
 --rename com.foo.=x  // Dot on the left only
 --rename org.bar=y.  // Dot on the right only
@@ -53,11 +53,11 @@ If you want to rename packages only, in most cases, you must ensure that you hav
 "org.bar.baz" -> "y..baz"     // Double dot, invalid name
 "net.baz.qux" -> "z.qux"      // Looks okay, but...
 "net.bazqux"  -> "zqux"       // ...may cut the name in the middle.
-....
+----
 
 When computing the appropriate target name, the longest matching prefix is used:
 
-....
+----
 // Assuming the following arguments:
 --rename com.foo.Main=w.Main
 --rename com.foo.=x.
@@ -69,7 +69,7 @@ com.foo.Main -> w.Main
 com.foo.bar  -> x.bar
 com.baz.qux  -> y.baz.qux
 org.foo.bar  -> z.org.foo.bar
-....
+----
 
 Repeat this option to define multiple mappings.
 Keys can be arbitrary strings, including an empty string.

--- a/docs/modules/java-binding/partials/cli-codegen-options.adoc
+++ b/docs/modules/java-binding/partials/cli-codegen-options.adoc
@@ -29,46 +29,49 @@ Default: (not set) +
 Whether to make generated classes implement `java.io.Serializable`.
 ====
 
-.--package-mapping
+.--rename
 [%collapsible]
 ====
 Default: (none) +
 Example: `foo.=com.example.foo.` +
-Allows to change default package names (derived from Pkl module name prefixes) in the generated code.
+Allows to change default class and package names (derived from Pkl module names) in the generated code.
 
-When you need the generated package names to be different from the default package names derived from Pkl module name prefixes, you can define a package mapping, where the key is the original Pkl module name prefix, and the value is its replacement.
-When you do, the generated code's `package` declarations, as well as file locations, will be modified according to the mapping.
+When you need the generated class or package names to be different from the default names derived from the Pkl module names, you can define a rename mapping, where the key is the original Pkl module name prefix, and the value is its replacement.
+When you do, the generated code's `package` declarations, class names, as well as file locations, will be modified according to this mapping.
 
-The prefixes are replaced literally, which means that dots at the end are important: in most cases, you must ensure that you have an ending dot on both sides of a mapping (except for an empty mapping, if you use it), otherwise you may get unexpected results:
+The prefixes are replaced literally, which means that dots at the end are important.
+If you want to rename packages only, in most cases, you must ensure that you have an ending dot on both sides of a mapping (except for an empty mapping, if you use it), otherwise you may get unexpected results:
 
 ....
 // Assuming the following arguments:
---package-mapping com.foo.=x  // Dot on the left only
---package-mapping org.bar=y.  // Dot on the right only
---package-mapping net.baz=z   // No dots
+--rename com.foo.=x  // Dot on the left only
+--rename org.bar=y.  // Dot on the right only
+--rename net.baz=z   // No dots
 
 // The following renames will be made:
 "com.foo.bar" -> "xbar"       // Target prefix merged into the suffix
-"org.bar.baz" -> "y..baz"     // Double dot, invalid package name
+"org.bar.baz" -> "y..baz"     // Double dot, invalid name
 "net.baz.qux" -> "z.qux"      // Looks okay, but...
-"net.bazqux"  -> "zqux"       // ...may cut the package name in the middle.
+"net.bazqux"  -> "zqux"       // ...may cut the name in the middle.
 ....
 
-When computing the appropriate target package name, the longest matching prefix is used:
+When computing the appropriate target name, the longest matching prefix is used:
 
 ....
 // Assuming the following arguments:
---package-mapping com.foo.=x.
---package-mapping com.=y.
---package-mapping =z.
+--rename com.foo.Main=w.Main
+--rename com.foo.=x.
+--rename com.=y.
+--rename =z.
 
 // The following renames will be made:
-com.foo.bar -> "x.bar"
-com.baz.qux -> "y.baz.qux"
-org.foo.bar -> "z.org.foo.bar"
+com.foo.Main -> w.Main
+com.foo.bar  -> x.bar
+com.baz.qux  -> y.baz.qux
+org.foo.bar  -> z.org.foo.bar
 ....
 
 Repeat this option to define multiple mappings.
 Keys can be arbitrary strings, including an empty string.
-Values must be valid dot-separated package names, also possibly terminated by a dot.
+Values must be valid dot-separated fully qualified class name prefixes, possibly terminated by a dot.
 ====

--- a/docs/modules/pkl-gradle/partials/gradle-codegen-properties.adoc
+++ b/docs/modules/pkl-gradle/partials/gradle-codegen-properties.adoc
@@ -36,4 +36,16 @@ Example: `generateSpringBootConfig = true` +
 Whether to generate config classes for use with Spring Boot.
 ====
 
+.packageMapping: MapProperty<String, String>
+[%collapsible]
+====
+Default: `[:]` +
+Example: `packageMapping = ["foo": "com.org.foo", "bar": "com.org.bar"]` +
+Allows to change default package names (derived from Pkl module name prefixes) in the generated code.
+
+When you need the generated package names to be different from the default package names derived from Pkl module name prefixes, you can define a package mapping, where the key is the original Pkl module name prefix, and the value is its replacement. When you do, the generated code `package` declarations, as well as file locations, will be modified according to the mapping.
+
+Keys in this mapping must be valid Pkl module name prefixes. Values must be valid dot-separated package names.
+====
+
 // TODO: fixme (implementSerializable)

--- a/docs/modules/pkl-gradle/partials/gradle-codegen-properties.adoc
+++ b/docs/modules/pkl-gradle/partials/gradle-codegen-properties.adoc
@@ -40,12 +40,47 @@ Whether to generate config classes for use with Spring Boot.
 [%collapsible]
 ====
 Default: `[:]` +
-Example: `packageMapping = ["foo": "com.org.foo", "bar": "com.org.bar"]` +
+Example: `packageMapping = ["foo.": "com.example.foo.", "bar.": "com.example.bar."]` +
 Allows to change default package names (derived from Pkl module name prefixes) in the generated code.
 
-When you need the generated package names to be different from the default package names derived from Pkl module name prefixes, you can define a package mapping, where the key is the original Pkl module name prefix, and the value is its replacement. When you do, the generated code `package` declarations, as well as file locations, will be modified according to the mapping.
+When you need the generated package names to be different from the default package names derived from Pkl module name prefixes, you can define a package mapping, where the key is the original Pkl module name prefix, and the value is its replacement.
+When you do, the generated code's `package` declarations, as well as file locations, will be modified according to the mapping.
 
-Keys in this mapping must be valid Pkl module name prefixes. Values must be valid dot-separated package names.
+The prefixes are replaced literally, which means that dots at the end are important: in most cases, you must ensure that you have an ending dot on both sides of a mapping (except for an empty mapping, if you use it), otherwise you may get unexpected results:
+
+....
+// Assuming the following mapping configuration:
+packageMapping = [
+  "com.foo.": "x",  // Dot on the left only
+  "org.bar": "y.",  // Dot on the right only
+  "net.baz": "z"    // No dots
+]
+
+// The following renames will be made:
+"com.foo.bar" -> "xbar"       // Target prefix merged into the suffix
+"org.bar.baz" -> "y..baz"     // Double dot, invalid package name
+"net.baz.qux" -> "z.qux"      // Looks okay, but...
+"net.bazqux"  -> "zqux"       // ...may cut the package name in the middle.
+....
+
+When computing the appropriate target package name, the longest matching prefix is used:
+
+....
+// Assuming the following mapping configuration:
+packageMapping = [
+  "com.foo.": "x.",
+  "com.": "y.",
+  "": "z."
+]
+
+// The following renames will be made:
+com.foo.bar -> "x.bar"
+com.baz.qux -> "y.baz.qux"
+org.foo.bar -> "z.org.foo.bar"
+....
+
+Keys in this mapping can be arbitrary strings, including an empty string.
+Values must be valid dot-separated package names, also possibly terminated by a dot.
 ====
 
 // TODO: fixme (implementSerializable)

--- a/docs/modules/pkl-gradle/partials/gradle-codegen-properties.adoc
+++ b/docs/modules/pkl-gradle/partials/gradle-codegen-properties.adoc
@@ -40,13 +40,14 @@ Whether to generate config classes for use with Spring Boot.
 [%collapsible]
 ====
 Default: `[:]` +
-Example: `packageMapping = ["foo.": "com.example.foo.", "bar.": "com.example.bar."]` +
-Allows to change default package names (derived from Pkl module name prefixes) in the generated code.
+Example: `packageMapping = ["foo.": "com.example.foo.", "bar.Config": "com.example.bar.Config"]` +
+Allows to change default class and package names (derived from Pkl module names) in the generated code.
 
-When you need the generated package names to be different from the default package names derived from Pkl module name prefixes, you can define a package mapping, where the key is the original Pkl module name prefix, and the value is its replacement.
-When you do, the generated code's `package` declarations, as well as file locations, will be modified according to the mapping.
+When you need the generated class or package names to be different from the default names derived from the Pkl module names, you can define a rename mapping, where the key is the original Pkl module name prefix, and the value is its replacement.
+When you do, the generated code's `package` declarations, class names, as well as file locations, will be modified according to this mapping.
 
-The prefixes are replaced literally, which means that dots at the end are important: in most cases, you must ensure that you have an ending dot on both sides of a mapping (except for an empty mapping, if you use it), otherwise you may get unexpected results:
+The prefixes are replaced literally, which means that dots at the end are important.
+If you want to rename packages only, in most cases, you must ensure that you have an ending dot on both sides of a mapping (except for an empty mapping, if you use it), otherwise you may get unexpected results:
 
 ....
 // Assuming the following mapping configuration:
@@ -58,29 +59,31 @@ packageMapping = [
 
 // The following renames will be made:
 "com.foo.bar" -> "xbar"       // Target prefix merged into the suffix
-"org.bar.baz" -> "y..baz"     // Double dot, invalid package name
+"org.bar.baz" -> "y..baz"     // Double dot, invalid name
 "net.baz.qux" -> "z.qux"      // Looks okay, but...
-"net.bazqux"  -> "zqux"       // ...may cut the package name in the middle.
+"net.bazqux"  -> "zqux"       // ...may cut the name in the middle.
 ....
 
-When computing the appropriate target package name, the longest matching prefix is used:
+When computing the appropriate target name, the longest matching prefix is used:
 
 ....
 // Assuming the following mapping configuration:
 packageMapping = [
+  "com.foo.Main": "w.Main",
   "com.foo.": "x.",
   "com.": "y.",
   "": "z."
 ]
 
 // The following renames will be made:
-com.foo.bar -> "x.bar"
-com.baz.qux -> "y.baz.qux"
-org.foo.bar -> "z.org.foo.bar"
+com.foo.Main -> w.Main
+com.foo.bar  -> x.bar
+com.baz.qux  -> y.baz.qux
+org.foo.bar  -> z.org.foo.bar
 ....
 
 Keys in this mapping can be arbitrary strings, including an empty string.
-Values must be valid dot-separated package names, also possibly terminated by a dot.
+Values must be valid dot-separated fully qualifed class name prefixes, possibly terminated by a dot.
 ====
 
 // TODO: fixme (implementSerializable)

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
@@ -54,8 +54,37 @@ data class CliJavaCodeGeneratorOptions(
   val nonNullAnnotation: String? = null,
 
   /** Whether to make generated classes implement [java.io.Serializable] */
-  val implementSerializable: Boolean = false
+  val implementSerializable: Boolean = false,
+  
+  /**
+   * A string defining a mapping of packages.
+   * 
+   * When the user wants to have different Java package names, compared to default package names
+   * derived from Pkl module names, a package mapping can be defined. This is expected to be
+   * a string in the following format:
+   * ```none
+   * pkl.package.name1:java.package.name1; pkl.package.name2:java.package.name2; ...
+   * ```
+   * Whitespace around `:` and `;` characters is optional.
+   * 
+   * When this option is set, the mapping will be used to translate package names derived from
+   * module names to the specified package names.
+   */
+  val packageMapping: String? = null
 ) {
+  private val parsedPackageMapping: Map<String, String> by lazy {
+    packageMapping?.let { m ->
+      val entries = m.split(";")
+      entries.associate { entry ->
+        val parts = entry.trim().split(":", limit = 2)
+        require(parts.size == 2) {
+          "Invalid package mapping: $packageMapping"
+        }
+        parts.first().trim() to parts.last().trim()
+      }
+    } ?: emptyMap()
+  }
+  
   fun toJavaCodegenOptions() =
     JavaCodegenOptions(
       indent,
@@ -64,6 +93,7 @@ data class CliJavaCodeGeneratorOptions(
       generateSpringBootConfig,
       paramsAnnotation,
       nonNullAnnotation,
-      implementSerializable
+      implementSerializable,
+      parsedPackageMapping
     )
 }

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
@@ -57,13 +57,13 @@ data class CliJavaCodeGeneratorOptions(
   val implementSerializable: Boolean = false,
 
   /**
-   * A mapping of packages.
+   * A rename mapping for class names.
    *
-   * When you need to have Java package names different from the default package names derived from
-   * Pkl module names, you can define a package mapping, where the key is the original Pkl module
-   * name, and the value is its replacement.
+   * When you need to have Java class or package names different from the default names derived from
+   * Pkl module names, you can define a rename mapping, where the key is a prefix of the original
+   * Pkl module name, and the value is the desired replacement.
    */
-  val packageMapping: Map<String, String> = emptyMap()
+  val renames: Map<String, String> = emptyMap()
 ) {
   fun toJavaCodegenOptions() =
     JavaCodegenOptions(
@@ -74,6 +74,6 @@ data class CliJavaCodeGeneratorOptions(
       paramsAnnotation,
       nonNullAnnotation,
       implementSerializable,
-      packageMapping
+      renames
     )
 }

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
@@ -55,13 +55,13 @@ data class CliJavaCodeGeneratorOptions(
 
   /** Whether to make generated classes implement [java.io.Serializable] */
   val implementSerializable: Boolean = false,
-  
+
   /**
    * A mapping of packages.
-   * 
-   * When you need to have Java package names different from the default package
-   * names derived from Pkl module names, you can define a package mapping, where the key
-   * is the original Pkl module name, and the value is its replacement.
+   *
+   * When you need to have Java package names different from the default package names derived from
+   * Pkl module names, you can define a package mapping, where the key is the original Pkl module
+   * name, and the value is its replacement.
    */
   val packageMapping: Map<String, String> = emptyMap()
 ) {

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
@@ -57,34 +57,14 @@ data class CliJavaCodeGeneratorOptions(
   val implementSerializable: Boolean = false,
   
   /**
-   * A string defining a mapping of packages.
+   * A mapping of packages.
    * 
-   * When the user wants to have different Java package names, compared to default package names
-   * derived from Pkl module names, a package mapping can be defined. This is expected to be
-   * a string in the following format:
-   * ```none
-   * pkl.package.name1:java.package.name1; pkl.package.name2:java.package.name2; ...
-   * ```
-   * Whitespace around `:` and `;` characters is optional.
-   * 
-   * When this option is set, the mapping will be used to translate package names derived from
-   * module names to the specified package names.
+   * When you need to have Java package names different from the default package
+   * names derived from Pkl module names, you can define a package mapping, where the key
+   * is the original Pkl module name, and the value is its replacement.
    */
-  val packageMapping: String? = null
+  val packageMapping: Map<String, String> = emptyMap()
 ) {
-  private val parsedPackageMapping: Map<String, String> by lazy {
-    packageMapping?.let { m ->
-      val entries = m.split(";")
-      entries.associate { entry ->
-        val parts = entry.trim().split(":", limit = 2)
-        require(parts.size == 2) {
-          "Invalid package mapping: $packageMapping"
-        }
-        parts.first().trim() to parts.last().trim()
-      }
-    } ?: emptyMap()
-  }
-  
   fun toJavaCodegenOptions() =
     JavaCodegenOptions(
       indent,
@@ -94,6 +74,6 @@ data class CliJavaCodeGeneratorOptions(
       paramsAnnotation,
       nonNullAnnotation,
       implementSerializable,
-      parsedPackageMapping
+      packageMapping
     )
 }

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -36,6 +36,7 @@ import kotlin.takeIf
 import kotlin.to
 import org.pkl.core.*
 import org.pkl.core.util.CodeGeneratorUtils
+import org.pkl.core.util.IoUtils
 
 class JavaCodeGeneratorException(message: String) : RuntimeException(message)
 
@@ -75,7 +76,7 @@ data class JavaCodegenOptions(
    * 
    * Can be used when the package name in the generated source code should be different from the
    * package name derived from the Pkl module declaration .
-   * */
+   */
   val packageMapping: Map<String, String> = emptyMap()
 )
 
@@ -131,7 +132,7 @@ class JavaCodeGenerator(
     }
 
   private val propertyFileName: String
-    get() = "resources/META-INF/org/pkl/config/java/mapper/classes/${schema.moduleName}.properties"
+    get() = "resources/META-INF/org/pkl/config/java/mapper/classes/${IoUtils.encodePath(schema.moduleName)}.properties"
 
   private val propertiesFile: String
     get() {

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -161,9 +161,9 @@ class JavaCodeGenerator(
       return AnnotationSpec.builder(className).build()
     }
 
-  val javaFileName: String
+  private val javaFileName: String
     get() {
-      val (packageName, className) = mapModuleName(schema.moduleName)
+      val (packageName, className) = nameMapper.map(schema.moduleName)
       val dirPath = packageName.replace('.', '/')
       return if (dirPath.isEmpty()) {
         "java/$className.java"
@@ -202,7 +202,7 @@ class JavaCodeGenerator(
         moduleClass.addMethod(appendPropertyMethod().addModifiers(modifier).build())
       }
 
-      val (packageName, _) = mapModuleName(schema.moduleName)
+      val (packageName, _) = nameMapper.map(schema.moduleName)
 
       return JavaFile.builder(packageName, moduleClass.build())
         .indent(codegenOptions.indent)
@@ -691,7 +691,7 @@ class JavaCodeGenerator(
       .endControlFlow()
 
   private fun PClass.toJavaPoetName(): ClassName {
-    val (packageName, moduleClassName) = mapModuleName(moduleName)
+    val (packageName, moduleClassName) = nameMapper.map(moduleName)
     return if (isModuleClass) {
       ClassName.get(packageName, moduleClassName)
     } else {
@@ -701,7 +701,7 @@ class JavaCodeGenerator(
 
   // generated type is a nested enum class
   private fun TypeAlias.toJavaPoetName(): ClassName {
-    val (packageName, moduleClassName) = mapModuleName(moduleName)
+    val (packageName, moduleClassName) = nameMapper.map(moduleName)
     return ClassName.get(packageName, moduleClassName, simpleName)
   }
 
@@ -874,18 +874,6 @@ class JavaCodeGenerator(
   }
 
   private val nameMapper = NameMapper(codegenOptions.renames)
-
-  private fun mapModuleName(name: String): kotlin.Pair<String, String> {
-    val mappedName = nameMapper.mapToClassName(name)
-    val packageName = mappedName.packageName
-    val className =
-      if (mappedName.classNameWasChanged(name)) {
-        mappedName.className
-      } else {
-        mappedName.className.replaceFirstChar { it.titlecaseChar() }
-      }
-    return packageName to className
-  }
 }
 
 internal val javaReservedWords =

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -34,6 +34,7 @@ import kotlin.apply
 import kotlin.let
 import kotlin.takeIf
 import kotlin.to
+import org.pkl.commons.PackageMapper
 import org.pkl.core.*
 import org.pkl.core.util.CodeGeneratorUtils
 import org.pkl.core.util.IoUtils
@@ -70,10 +71,10 @@ data class JavaCodegenOptions(
 
   /** Whether to make generated classes implement [java.io.Serializable] */
   val implementSerializable: Boolean = false,
-  
+
   /**
    * A mapping from Pkl module-derived package names and custom package names.
-   * 
+   *
    * Can be used when the package name in the generated source code should be different from the
    * package name derived from the Pkl module declaration .
    */
@@ -132,7 +133,8 @@ class JavaCodeGenerator(
     }
 
   private val propertyFileName: String
-    get() = "resources/META-INF/org/pkl/config/java/mapper/classes/${IoUtils.encodePath(schema.moduleName)}.properties"
+    get() =
+      "resources/META-INF/org/pkl/config/java/mapper/classes/${IoUtils.encodePath(schema.moduleName)}.properties"
 
   private val propertiesFile: String
     get() {
@@ -871,9 +873,10 @@ class JavaCodeGenerator(
     }
   }
 
-  private fun mapPackageName(name: String): String =
-    codegenOptions.packageMapping[name] ?: name
-  
+  private val packageMapper = PackageMapper(codegenOptions.packageMapping)
+
+  private fun mapPackageName(name: String): String = packageMapper.map("$name.").removeSuffix(".")
+
   private fun mapModuleName(name: String): kotlin.Pair<String, String> {
     val packageName = mapPackageName(name.substringBeforeLast('.', ""))
     val className = name.substringAfterLast('.').replaceFirstChar { it.titlecaseChar() }

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -876,9 +876,14 @@ class JavaCodeGenerator(
   private val nameMapper = NameMapper(codegenOptions.renames)
 
   private fun mapModuleName(name: String): kotlin.Pair<String, String> {
-    val mappedName = nameMapper.map(name)
-    val packageName = mappedName.substringBeforeLast('.', "")
-    val className = mappedName.substringAfterLast('.').replaceFirstChar { it.titlecaseChar() }
+    val mappedName = nameMapper.mapToClassName(name)
+    val packageName = mappedName.packageName
+    val className =
+      if (mappedName.classNameWasChanged(name)) {
+        mappedName.className
+      } else {
+        mappedName.className.replaceFirstChar { it.titlecaseChar() }
+      }
     return packageName to className
   }
 }

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -34,7 +34,7 @@ import kotlin.apply
 import kotlin.let
 import kotlin.takeIf
 import kotlin.to
-import org.pkl.commons.PackageMapper
+import org.pkl.commons.NameMapper
 import org.pkl.core.*
 import org.pkl.core.util.CodeGeneratorUtils
 import org.pkl.core.util.IoUtils
@@ -73,12 +73,12 @@ data class JavaCodegenOptions(
   val implementSerializable: Boolean = false,
 
   /**
-   * A mapping from Pkl module-derived package names and custom package names.
+   * A mapping from Pkl module name prefixes to their replacements.
    *
-   * Can be used when the package name in the generated source code should be different from the
-   * package name derived from the Pkl module declaration .
+   * Can be used when the class or package name in the generated source code should be different
+   * from the corresponding name derived from the Pkl module declaration .
    */
-  val packageMapping: Map<String, String> = emptyMap()
+  val renames: Map<String, String> = emptyMap()
 )
 
 /** Entrypoint for the Java code generator API. */
@@ -873,13 +873,12 @@ class JavaCodeGenerator(
     }
   }
 
-  private val packageMapper = PackageMapper(codegenOptions.packageMapping)
-
-  private fun mapPackageName(name: String): String = packageMapper.map("$name.").removeSuffix(".")
+  private val nameMapper = NameMapper(codegenOptions.renames)
 
   private fun mapModuleName(name: String): kotlin.Pair<String, String> {
-    val packageName = mapPackageName(name.substringBeforeLast('.', ""))
-    val className = name.substringAfterLast('.').replaceFirstChar { it.titlecaseChar() }
+    val mappedName = nameMapper.map(name)
+    val packageName = mappedName.substringBeforeLast('.', "")
+    val className = mappedName.substringAfterLast('.').replaceFirstChar { it.titlecaseChar() }
     return packageName to className
   }
 }

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
@@ -111,15 +111,17 @@ class PklJavaCodegenCommand :
 
   private val packageMapping: Map<String, String> by
     option(
-      names = arrayOf("-m", "--package-mapping"),
-      metavar = "<module_name=package_name>",
-      help = """
-        Replace the default package name of the generated Java classes (repeatable).
-        By default, the package name of generated classes is derived from the Pkl module name.
-        With this option, you can override the name for the given modules with custom names.
-      """.trimIndent()
-    )
-    .associate()
+        names = arrayOf("--package-mapping"),
+        metavar = "<module_prefix=package_prefix>",
+        help =
+          """
+            Replace the default package name of the generated Java classes (repeatable).
+            By default, the package name of generated classes is derived from the Pkl module name.
+            With this option, you can override the name for the given modules with custom names.
+          """
+            .trimIndent()
+      )
+      .associate()
 
   override fun run() {
     val options =

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
@@ -112,7 +112,7 @@ class PklJavaCodegenCommand :
   private val renames: Map<String, String> by
     option(
         names = arrayOf("--rename"),
-        metavar = "<module_prefix=class_prefix>",
+        metavar = "<old_name=new_name>",
         help =
           """
             Replace a prefix in the names of the generated Java classes (repeatable).

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
@@ -17,6 +17,7 @@
 
 package org.pkl.codegen.java
 
+import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -108,6 +109,18 @@ class PklJavaCodegenCommand :
       )
       .flag()
 
+  private val packageMapping: Map<String, String> by
+    option(
+      names = arrayOf("-m", "--package-mapping"),
+      metavar = "<module_name=package_name>",
+      help = """
+        Replace the default package name of the generated Java classes (repeatable).
+        By default, the package name of generated classes is derived from the Pkl module name.
+        With this option, you can override the name for the given modules with custom names.
+      """.trimIndent()
+    )
+    .associate()
+
   override fun run() {
     val options =
       CliJavaCodeGeneratorOptions(
@@ -119,7 +132,8 @@ class PklJavaCodegenCommand :
         generateSpringBootConfig = generateSpringboot,
         paramsAnnotation = paramsAnnotation,
         nonNullAnnotation = nonNullAnnotation,
-        implementSerializable = implementSerializable
+        implementSerializable = implementSerializable,
+        packageMapping = packageMapping
       )
     CliJavaCodeGenerator(options).run()
   }

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
@@ -109,15 +109,16 @@ class PklJavaCodegenCommand :
       )
       .flag()
 
-  private val packageMapping: Map<String, String> by
+  private val renames: Map<String, String> by
     option(
-        names = arrayOf("--package-mapping"),
-        metavar = "<module_prefix=package_prefix>",
+        names = arrayOf("--rename"),
+        metavar = "<module_prefix=class_prefix>",
         help =
           """
-            Replace the default package name of the generated Java classes (repeatable).
-            By default, the package name of generated classes is derived from the Pkl module name.
-            With this option, you can override the name for the given modules with custom names.
+            Replace a prefix in the names of the generated Java classes (repeatable).
+            By default, the names of generated classes are derived from the Pkl module names.
+            With this option, you can override the modify the default names, renaming entire
+            classes or just their packages.
           """
             .trimIndent()
       )
@@ -135,7 +136,7 @@ class PklJavaCodegenCommand :
         paramsAnnotation = paramsAnnotation,
         nonNullAnnotation = nonNullAnnotation,
         implementSerializable = implementSerializable,
-        packageMapping = packageMapping
+        renames = renames
       )
     CliJavaCodeGenerator(options).run()
   }

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
@@ -226,7 +226,7 @@ class CliJavaCodeGeneratorTest {
         CliJavaCodeGeneratorOptions(
           CliBaseOptions(listOf(module1PklFile, module2PklFile, module3PklFile).map { it.toUri() }),
           outputDir,
-          packageMapping = mapOf("org.foo" to "com.foo.x", "org.baz" to "com.baz.a.b")
+          renames = mapOf("org.foo" to "com.foo.x", "org.baz" to "com.baz.a.b")
         )
       )
 

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
@@ -173,6 +173,115 @@ class CliJavaCodeGeneratorTest {
     )
   }
 
+  @Test
+  fun `custom package names`(@TempDir tempDir: Path) {
+    val module1 =
+      PklModule(
+        "org.foo.Module1",
+        """
+          module org.foo.Module1
+
+          class Person {
+            name: String
+          }
+        """
+      )
+
+    val module2 =
+      PklModule(
+        "org.bar.Module2",
+        """
+          module org.bar.Module2
+          
+          import "../../org/foo/Module1.pkl"
+
+          class Group {
+            owner: Module1.Person
+            name: String
+          }
+        """
+      )
+
+    val module3 =
+      PklModule(
+        "org.baz.Module3",
+        """
+          module org.baz.Module3
+          
+          import "../../org/bar/Module2.pkl"
+
+          class Supergroup {
+            owner: Module2.Group
+          }
+        """
+      )
+    
+    val module1PklFile = module1.writeToDisk(tempDir.resolve("org/foo/Module1.pkl"))
+    val module2PklFile = module2.writeToDisk(tempDir.resolve("org/bar/Module2.pkl"))
+    val module3PklFile = module3.writeToDisk(tempDir.resolve("org/baz/Module3.pkl"))
+    val outputDir = tempDir.resolve("output")
+
+    val generator =
+      CliJavaCodeGenerator(
+        CliJavaCodeGeneratorOptions(
+          CliBaseOptions(listOf(module1PklFile, module2PklFile, module3PklFile).map { it.toUri() }),
+          outputDir,
+          packageMapping = "org.foo:com.foo.x ; org.baz : com.baz.a.b"
+        )
+      )
+
+    generator.run()
+    
+    val module1JavaFile = outputDir.resolve("java/com/foo/x/Module1.java")
+    module1JavaFile.readString().let {
+      assertContains("package com.foo.x;", it)
+      
+      assertContains("public final class Module1 {", it)
+
+      assertContains(
+        """
+        |  public static final class Person {
+        |    public final @NonNull String name;
+        """,
+        it
+      )
+    }
+    
+    val module2JavaFile = outputDir.resolve("java/org/bar/Module2.java")
+    module2JavaFile.readString().let {
+      assertContains("package org.bar;", it)
+      
+      assertContains("import com.foo.x.Module1;", it)
+      
+      assertContains("public final class Module2 {", it)
+      
+      assertContains(
+        """
+        |  public static final class Group {
+        |    public final Module1. @NonNull Person owner;
+        """,
+        it
+      )
+    }
+    
+    val module3JavaFile = outputDir.resolve("java/com/baz/a/b/Module3.java")
+    module3JavaFile.readString().let {
+      assertContains("package com.baz.a.b;", it)
+
+      assertContains("import org.bar.Module2;", it)
+
+      assertContains("public final class Module3 {", it)
+
+      assertContains(
+        """
+        |  public static final class Supergroup {
+        |    public final Module2. @NonNull Group owner;
+        """,
+        it
+      )
+    }
+  }
+
   private fun assertContains(part: String, code: String) {
     val trimmedPart = part.trim().trimMargin()
     if (!code.contains(trimmedPart)) {

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
@@ -215,7 +215,7 @@ class CliJavaCodeGeneratorTest {
           }
         """
       )
-    
+
     val module1PklFile = module1.writeToDisk(tempDir.resolve("org/foo/Module1.pkl"))
     val module2PklFile = module2.writeToDisk(tempDir.resolve("org/bar/Module2.pkl"))
     val module3PklFile = module3.writeToDisk(tempDir.resolve("org/baz/Module3.pkl"))
@@ -231,11 +231,11 @@ class CliJavaCodeGeneratorTest {
       )
 
     generator.run()
-    
+
     val module1JavaFile = outputDir.resolve("java/com/foo/x/Module1.java")
     module1JavaFile.readString().let {
       assertContains("package com.foo.x;", it)
-      
+
       assertContains("public final class Module1 {", it)
 
       assertContains(
@@ -246,15 +246,15 @@ class CliJavaCodeGeneratorTest {
         it
       )
     }
-    
+
     val module2JavaFile = outputDir.resolve("java/org/bar/Module2.java")
     module2JavaFile.readString().let {
       assertContains("package org.bar;", it)
-      
+
       assertContains("import com.foo.x.Module1;", it)
-      
+
       assertContains("public final class Module2 {", it)
-      
+
       assertContains(
         """
         |  public static final class Group {
@@ -263,7 +263,7 @@ class CliJavaCodeGeneratorTest {
         it
       )
     }
-    
+
     val module3JavaFile = outputDir.resolve("java/com/baz/a/b/Module3.java")
     module3JavaFile.readString().let {
       assertContains("package com.baz.a.b;", it)

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
@@ -226,7 +226,7 @@ class CliJavaCodeGeneratorTest {
         CliJavaCodeGeneratorOptions(
           CliBaseOptions(listOf(module1PklFile, module2PklFile, module3PklFile).map { it.toUri() }),
           outputDir,
-          packageMapping = "org.foo:com.foo.x ; org.baz : com.baz.a.b"
+          packageMapping = mapOf("org.foo" to "com.foo.x", "org.baz" to "com.baz.a.b")
         )
       )
 

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/InMemoryJavaCompiler.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/InMemoryJavaCompiler.kt
@@ -29,8 +29,9 @@ object InMemoryJavaCompiler {
     val diagnosticsCollector = DiagnosticCollector<JavaFileObject>()
     val fileManager =
       InMemoryFileManager(compiler.getStandardFileManager(diagnosticsCollector, null, null))
-    val sourceObjects =
-      sourceFiles.map { (filename, contents) -> ReadableSourceFileObject(filename, contents) }
+    val sourceObjects = sourceFiles
+      .filter { (filename, _) -> filename.endsWith(".java") }
+      .map { (filename, contents) -> ReadableSourceFileObject(filename, contents) }
     val task = compiler.getTask(null, fileManager, diagnosticsCollector, null, null, sourceObjects)
     val result = task.call()
     if (!result) {

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/InMemoryJavaCompiler.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/InMemoryJavaCompiler.kt
@@ -29,9 +29,10 @@ object InMemoryJavaCompiler {
     val diagnosticsCollector = DiagnosticCollector<JavaFileObject>()
     val fileManager =
       InMemoryFileManager(compiler.getStandardFileManager(diagnosticsCollector, null, null))
-    val sourceObjects = sourceFiles
-      .filter { (filename, _) -> filename.endsWith(".java") }
-      .map { (filename, contents) -> ReadableSourceFileObject(filename, contents) }
+    val sourceObjects =
+      sourceFiles
+        .filter { (filename, _) -> filename.endsWith(".java") }
+        .map { (filename, contents) -> ReadableSourceFileObject(filename, contents) }
     val task = compiler.getTask(null, fileManager, diagnosticsCollector, null, null, sourceObjects)
     val result = task.call()
     if (!result) {

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
@@ -35,8 +35,8 @@ class JavaCodeGeneratorTest {
   companion object {
     private val simpleClass by lazy {
       compileJavaCode(
-        generateJavaCode(
-          """
+          generateJavaCode(
+            """
             module my.mod
 
             class Simple {
@@ -44,8 +44,8 @@ class JavaCodeGeneratorTest {
               list: List<Int>
             }
           """
+          )
         )
-      )
         .getValue("my.Mod\$Simple")
     }
 
@@ -129,8 +129,7 @@ class JavaCodeGeneratorTest {
     }
   }
 
-  @TempDir
-  lateinit var tempDir: Path
+  @TempDir lateinit var tempDir: Path
 
   @Test
   fun testEquals() {
@@ -771,16 +770,16 @@ class JavaCodeGeneratorTest {
 
     val fooClass =
       compileJavaCode(
-        generateJavaCode(
-          """
+          generateJavaCode(
+            """
       module my.mod
 
       class Foo {
         $props
       }
     """
+          )
         )
-      )
         .getValue("my.Mod\$Foo")
 
     assertThat(fooClass.declaredFields).allSatisfy(Consumer { it.name.startsWith("_") })
@@ -851,14 +850,12 @@ class JavaCodeGeneratorTest {
   @Test
   fun `module class`() {
     val javaCode =
-      generateJavaCode(
-        """
+      generateJavaCode("""
       module my.mod
 
       pigeon: String
       parrot: String
-    """
-      )
+    """)
 
     assertContains(
       """
@@ -1286,13 +1283,11 @@ class JavaCodeGeneratorTest {
   @Test
   fun `union of string literals`() {
     val javaCode =
-      generateJavaCode(
-        """
+      generateJavaCode("""
       module mod
 
       x: "Pigeon"|"Barn Owl"|"Parrot"
-    """
-      )
+    """)
 
     assertContains("public final @NonNull String x;", javaCode)
 
@@ -1303,13 +1298,11 @@ class JavaCodeGeneratorTest {
   fun `other union type`() {
     val e =
       assertThrows<JavaCodeGeneratorException> {
-        generateJavaCode(
-          """
+        generateJavaCode("""
         module mod
 
         x: "Pigeon"|Int|"Parrot"
-      """
-        )
+      """)
       }
     assertThat(e).hasMessageContaining("Pkl union types are not supported")
   }
@@ -1405,11 +1398,9 @@ class JavaCodeGeneratorTest {
       javaCode
     )
 
-    assertContains(
-      """
+    assertContains("""
       |  public final @NonNull Server server;
-    """, javaCode
-    )
+    """, javaCode)
 
     assertContains(
       """
@@ -1723,22 +1714,22 @@ class JavaCodeGeneratorTest {
       var restoredInstance: Any? = null
 
       assertThatCode {
-        // serialize
-        val baos = ByteArrayOutputStream()
-        val oos = ObjectOutputStream(baos)
-        oos.writeObject(instance)
-        oos.flush()
+          // serialize
+          val baos = ByteArrayOutputStream()
+          val oos = ObjectOutputStream(baos)
+          oos.writeObject(instance)
+          oos.flush()
 
-        // deserialize
-        val bais = ByteArrayInputStream(baos.toByteArray())
-        val ois =
-          object : ObjectInputStream(bais) {
-            override fun resolveClass(desc: ObjectStreamClass?): Class<*> {
-              return Class.forName(desc!!.name, false, instance.javaClass.classLoader)
+          // deserialize
+          val bais = ByteArrayInputStream(baos.toByteArray())
+          val ois =
+            object : ObjectInputStream(bais) {
+              override fun resolveClass(desc: ObjectStreamClass?): Class<*> {
+                return Class.forName(desc!!.name, false, instance.javaClass.classLoader)
+              }
             }
-          }
-        restoredInstance = ois.readObject()
-      }
+          restoredInstance = ois.readObject()
+        }
         .doesNotThrowAnyException()
 
       assertThat(restoredInstance!!).isEqualTo(instance)
@@ -1839,17 +1830,17 @@ class JavaCodeGeneratorTest {
 
   @Test
   fun `override package names in a standalone module`() {
-    val files = JavaCodegenOptions(
-      packageMapping = mapOf(
-        "a.b.c" to "x.y.z"
-      )
-    ).generateFiles(
-      "MyModule.pkl" to """
+    val files =
+      JavaCodegenOptions(packageMapping = mapOf("a.b.c." to "x.y.z."))
+        .generateFiles(
+          "MyModule.pkl" to
+            """
         module a.b.c.MyModule
         
         foo: String = "abc"
-      """.trimIndent()
-    )
+      """
+              .trimIndent()
+        )
 
     val javaCode = files["java/x/y/z/MyModule.java"]
     assertThat(javaCode).contains("package x.y.z;")
@@ -1859,23 +1850,78 @@ class JavaCodeGeneratorTest {
     assertThat(propertiesCode)
       .contains("org.pkl.config.java.mapper.a.b.c.MyModule\\#ModuleClass=x.y.z.MyModule")
   }
-  
+
+  @Test
+  fun `override package names based on the longest prefix`() {
+    val files =
+      JavaCodegenOptions(
+          packageMapping =
+            mapOf("com.foo.bar." to "x.", "com.foo." to "y.", "com." to "z.", "" to "w.")
+        )
+        .generateFiles(
+          "com/foo/bar/Module1" to
+            """
+        module com.foo.bar.Module1
+        
+        bar: String
+      """
+              .trimIndent(),
+          "com/Module2" to
+            """
+        module com.Module2
+        
+        com: String
+      """
+              .trimIndent(),
+          "org/baz/Module3" to
+            """
+        module org.baz.Module3
+        
+        baz: String
+      """
+              .trimIndent()
+        )
+        .toMutableMap()
+
+    val mapperPrefix = "resources/META-INF/org/pkl/config/java/mapper/classes"
+
+    assertThat(files.remove("java/x/Module1.java"))
+      .contains("package x;", "public final class Module1 {")
+    assertThat(files.remove("$mapperPrefix/com.foo.bar.Module1.properties"))
+      .contains("org.pkl.config.java.mapper.com.foo.bar.Module1\\#ModuleClass=x.Module1")
+
+    assertThat(files.remove("java/z/Module2.java"))
+      .contains("package z;", "public final class Module2 {")
+    assertThat(files.remove("$mapperPrefix/com.Module2.properties"))
+      .contains("org.pkl.config.java.mapper.com.Module2\\#ModuleClass=z.Module2")
+
+    assertThat(files.remove("java/w/org/baz/Module3.java"))
+      .contains("package w.org.baz;", "public final class Module3 {")
+    assertThat(files.remove("$mapperPrefix/org.baz.Module3.properties"))
+      .contains("org.pkl.config.java.mapper.org.baz.Module3\\#ModuleClass=w.org.baz.Module3")
+
+    // No more files.
+    assertThat(files).isEmpty()
+  }
+
   @Test
   fun `override package names in multiple modules using each other`() {
-    val files = JavaCodegenOptions(
-      packageMapping = mapOf(
-        "org.foo" to "com.foo.x",
-        "org.baz" to "com.baz.a.b"
-      )
-    ).generateFiles(
-      "org/foo/Module1" to """
+    val files =
+      JavaCodegenOptions(
+          packageMapping = mapOf("org.foo." to "com.foo.x.", "org.baz." to "com.baz.a.b.")
+        )
+        .generateFiles(
+          "org/foo/Module1" to
+            """
         module org.foo.Module1
         
         class Person {
           name: String
         }
-      """.trimIndent(),
-      "org/bar/Module2" to """
+      """
+              .trimIndent(),
+          "org/bar/Module2" to
+            """
         module org.bar.Module2
         
         import "../../org/foo/Module1.pkl"
@@ -1884,8 +1930,10 @@ class JavaCodeGeneratorTest {
           owner: Module1.Person
           name: String
         }
-      """.trimIndent(),
-      "org/baz/Module3" to """
+      """
+              .trimIndent(),
+          "org/baz/Module3" to
+            """
         module org.baz.Module3
         
         import "../../org/bar/Module2.pkl"
@@ -1893,42 +1941,47 @@ class JavaCodeGeneratorTest {
         class Supergroup {
           owner: Module2.Group
         }
-      """.trimIndent()
-    ).toMutableMap()
-    
+      """
+              .trimIndent()
+        )
+        .toMutableMap()
+
     val mapperPrefix = "resources/META-INF/org/pkl/config/java/mapper/classes"
 
-    assertThat(files.remove("java/com/foo/x/Module1.java")).contains(
-      "package com.foo.x;",
-      "public final class Module1 {"
-    )
-    assertThat(files.remove("$mapperPrefix/org.foo.Module1.properties")).contains(
-      "org.pkl.config.java.mapper.org.foo.Module1\\#ModuleClass=com.foo.x.Module1",
-      "org.pkl.config.java.mapper.org.foo.Module1\\#Person=com.foo.x.Module1${'$'}Person",
-    )
+    assertThat(files.remove("java/com/foo/x/Module1.java"))
+      .contains("package com.foo.x;", "public final class Module1 {")
+    assertThat(files.remove("$mapperPrefix/org.foo.Module1.properties"))
+      .contains(
+        "org.pkl.config.java.mapper.org.foo.Module1\\#ModuleClass=com.foo.x.Module1",
+        "org.pkl.config.java.mapper.org.foo.Module1\\#Person=com.foo.x.Module1${'$'}Person",
+      )
 
-    assertThat(files.remove("java/org/bar/Module2.java")).contains(
-      "package org.bar;",
-      "import com.foo.x.Module1;",
-      "public final class Module2 {",
-      "public final Module1. @NonNull Person owner;"
-    )
-    assertThat(files.remove("$mapperPrefix/org.bar.Module2.properties")).contains(
-      "org.pkl.config.java.mapper.org.bar.Module2\\#ModuleClass=org.bar.Module2",
-      "org.pkl.config.java.mapper.org.bar.Module2\\#Group=org.bar.Module2${'$'}Group",
-    )
+    assertThat(files.remove("java/org/bar/Module2.java"))
+      .contains(
+        "package org.bar;",
+        "import com.foo.x.Module1;",
+        "public final class Module2 {",
+        "public final Module1. @NonNull Person owner;"
+      )
+    assertThat(files.remove("$mapperPrefix/org.bar.Module2.properties"))
+      .contains(
+        "org.pkl.config.java.mapper.org.bar.Module2\\#ModuleClass=org.bar.Module2",
+        "org.pkl.config.java.mapper.org.bar.Module2\\#Group=org.bar.Module2${'$'}Group",
+      )
 
-    assertThat(files.remove("java/com/baz/a/b/Module3.java")).contains(
-      "package com.baz.a.b;",
-      "import org.bar.Module2;",
-      "public final class Module3 {",
-      "public final Module2. @NonNull Group owner;"
-    )
-    assertThat(files.remove("$mapperPrefix/org.baz.Module3.properties")).contains(
-      "org.pkl.config.java.mapper.org.baz.Module3\\#ModuleClass=com.baz.a.b.Module3",
-      "org.pkl.config.java.mapper.org.baz.Module3\\#Supergroup=com.baz.a.b.Module3${'$'}Supergroup",
-    )
-    
+    assertThat(files.remove("java/com/baz/a/b/Module3.java"))
+      .contains(
+        "package com.baz.a.b;",
+        "import org.bar.Module2;",
+        "public final class Module3 {",
+        "public final Module2. @NonNull Group owner;"
+      )
+    assertThat(files.remove("$mapperPrefix/org.baz.Module3.properties"))
+      .contains(
+        "org.pkl.config.java.mapper.org.baz.Module3\\#ModuleClass=com.baz.a.b.Module3",
+        "org.pkl.config.java.mapper.org.baz.Module3\\#Supergroup=com.baz.a.b.Module3${'$'}Supergroup",
+      )
+
     // No more files.
     assertThat(files).isEmpty()
   }
@@ -1943,7 +1996,9 @@ class JavaCodeGeneratorTest {
     }
   }
 
-  private fun JavaCodegenOptions.generateFiles(vararg pklModules: kotlin.Pair<String, String>): Map<String, String> =
+  private fun JavaCodegenOptions.generateFiles(
+    vararg pklModules: kotlin.Pair<String, String>
+  ): Map<String, String> =
     generateFiles(*pklModules.map { (name, text) -> PklModule(name, text) }.toTypedArray())
 
   private fun generateFiles(vararg pklModules: PklModule): Map<String, String> =

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
@@ -35,8 +35,8 @@ class JavaCodeGeneratorTest {
   companion object {
     private val simpleClass by lazy {
       compileJavaCode(
-          generateJavaCode(
-            """
+        generateJavaCode(
+          """
             module my.mod
 
             class Simple {
@@ -44,8 +44,8 @@ class JavaCodeGeneratorTest {
               list: List<Int>
             }
           """
-          )
         )
+      )
         .getValue("my.Mod\$Simple")
     }
 
@@ -101,7 +101,8 @@ class JavaCodeGeneratorTest {
       generateJavadoc: Boolean = false,
       generateSpringBootConfig: Boolean = false,
       nonNullAnnotation: String? = null,
-      implementSerializable: Boolean = false
+      implementSerializable: Boolean = false,
+      packageMapping: Map<String, String> = emptyMap()
     ): String {
       val module = Evaluator.preconfigured().evaluateSchema(text(pklCode))
       val generator =
@@ -113,6 +114,7 @@ class JavaCodeGeneratorTest {
             generateSpringBootConfig = generateSpringBootConfig,
             nonNullAnnotation = nonNullAnnotation,
             implementSerializable = implementSerializable,
+            packageMapping = packageMapping
           )
         )
       return generator.javaFile
@@ -126,6 +128,9 @@ class JavaCodeGeneratorTest {
       compileJavaCode(sourceText)
     }
   }
+
+  @TempDir
+  lateinit var tempDir: Path
 
   @Test
   fun testEquals() {
@@ -766,16 +771,16 @@ class JavaCodeGeneratorTest {
 
     val fooClass =
       compileJavaCode(
-          generateJavaCode(
-            """
+        generateJavaCode(
+          """
       module my.mod
 
       class Foo {
         $props
       }
     """
-          )
         )
+      )
         .getValue("my.Mod\$Foo")
 
     assertThat(fooClass.declaredFields).allSatisfy(Consumer { it.name.startsWith("_") })
@@ -846,12 +851,14 @@ class JavaCodeGeneratorTest {
   @Test
   fun `module class`() {
     val javaCode =
-      generateJavaCode("""
+      generateJavaCode(
+        """
       module my.mod
 
       pigeon: String
       parrot: String
-    """)
+    """
+      )
 
     assertContains(
       """
@@ -1279,11 +1286,13 @@ class JavaCodeGeneratorTest {
   @Test
   fun `union of string literals`() {
     val javaCode =
-      generateJavaCode("""
+      generateJavaCode(
+        """
       module mod
 
       x: "Pigeon"|"Barn Owl"|"Parrot"
-    """)
+    """
+      )
 
     assertContains("public final @NonNull String x;", javaCode)
 
@@ -1294,11 +1303,13 @@ class JavaCodeGeneratorTest {
   fun `other union type`() {
     val e =
       assertThrows<JavaCodeGeneratorException> {
-        generateJavaCode("""
+        generateJavaCode(
+          """
         module mod
 
         x: "Pigeon"|Int|"Parrot"
-      """)
+      """
+        )
       }
     assertThat(e).hasMessageContaining("Pkl union types are not supported")
   }
@@ -1394,9 +1405,11 @@ class JavaCodeGeneratorTest {
       javaCode
     )
 
-    assertContains("""
+    assertContains(
+      """
       |  public final @NonNull Server server;
-    """, javaCode)
+    """, javaCode
+    )
 
     assertContains(
       """
@@ -1420,7 +1433,7 @@ class JavaCodeGeneratorTest {
   }
 
   @Test
-  fun `import module`(@TempDir tempDir: Path) {
+  fun `import module`() {
     val library =
       PklModule(
         "library",
@@ -1449,7 +1462,7 @@ class JavaCodeGeneratorTest {
           .trimIndent()
       )
 
-    val javaSourceFiles = generateJavaFiles(tempDir, library, client)
+    val javaSourceFiles = generateFiles(library, client)
     val javaClientCode =
       javaSourceFiles.entries.find { (fileName, _) -> fileName.endsWith("Client.java") }!!.value
 
@@ -1467,7 +1480,7 @@ class JavaCodeGeneratorTest {
   }
 
   @Test
-  fun `extend module`(@TempDir tempDir: Path) {
+  fun `extend module`() {
     val base =
       PklModule(
         "base",
@@ -1496,7 +1509,7 @@ class JavaCodeGeneratorTest {
           .trimIndent()
       )
 
-    val javaSourceFiles = generateJavaFiles(tempDir, base, derived)
+    val javaSourceFiles = generateFiles(base, derived)
     val javaDerivedCode =
       javaSourceFiles.entries.find { (filename, _) -> filename.endsWith("Derived.java") }!!.value
 
@@ -1520,7 +1533,7 @@ class JavaCodeGeneratorTest {
   }
 
   @Test
-  fun `extend module that only contains type aliases`(@TempDir tempDir: Path) {
+  fun `extend module that only contains type aliases`() {
     val base =
       PklModule(
         "base",
@@ -1545,7 +1558,7 @@ class JavaCodeGeneratorTest {
           .trimIndent()
       )
 
-    val javaSourceFiles = generateJavaFiles(tempDir, base, derived)
+    val javaSourceFiles = generateFiles(base, derived)
     val javaDerivedCode =
       javaSourceFiles.entries.find { (filename, _) -> filename.endsWith("Derived.java") }!!.value
 
@@ -1561,7 +1574,7 @@ class JavaCodeGeneratorTest {
   }
 
   @Test
-  fun `generated properties files`(@TempDir tempDir: Path) {
+  fun `generated properties files`() {
     val pklModule =
       PklModule(
         "Mod.pkl",
@@ -1582,7 +1595,7 @@ class JavaCodeGeneratorTest {
     """
           .trimIndent()
       )
-    val generated = generateFiles(tempDir, pklModule)
+    val generated = generateFiles(pklModule)
     val expectedPropertyFile =
       "resources/META-INF/org/pkl/config/java/mapper/classes/org.pkl.Mod.properties"
     assertThat(generated).containsKey(expectedPropertyFile)
@@ -1596,7 +1609,7 @@ class JavaCodeGeneratorTest {
   }
 
   @Test
-  fun `generated properties files with normalized java name`(@TempDir tempDir: Path) {
+  fun `generated properties files with normalized java name`() {
     val pklModule =
       PklModule(
         "mod.pkl",
@@ -1617,7 +1630,7 @@ class JavaCodeGeneratorTest {
     """
           .trimIndent()
       )
-    val generated = generateFiles(tempDir, pklModule)
+    val generated = generateFiles(pklModule)
     val expectedPropertyFile =
       "resources/META-INF/org/pkl/config/java/mapper/classes/my.mod.properties"
     assertThat(generated).containsKey(expectedPropertyFile)
@@ -1710,22 +1723,22 @@ class JavaCodeGeneratorTest {
       var restoredInstance: Any? = null
 
       assertThatCode {
-          // serialize
-          val baos = ByteArrayOutputStream()
-          val oos = ObjectOutputStream(baos)
-          oos.writeObject(instance)
-          oos.flush()
+        // serialize
+        val baos = ByteArrayOutputStream()
+        val oos = ObjectOutputStream(baos)
+        oos.writeObject(instance)
+        oos.flush()
 
-          // deserialize
-          val bais = ByteArrayInputStream(baos.toByteArray())
-          val ois =
-            object : ObjectInputStream(bais) {
-              override fun resolveClass(desc: ObjectStreamClass?): Class<*> {
-                return Class.forName(desc!!.name, false, instance.javaClass.classLoader)
-              }
+        // deserialize
+        val bais = ByteArrayInputStream(baos.toByteArray())
+        val ois =
+          object : ObjectInputStream(bais) {
+            override fun resolveClass(desc: ObjectStreamClass?): Class<*> {
+              return Class.forName(desc!!.name, false, instance.javaClass.classLoader)
             }
-          restoredInstance = ois.readObject()
-        }
+          }
+        restoredInstance = ois.readObject()
+      }
         .doesNotThrowAnyException()
 
       assertThat(restoredInstance!!).isEqualTo(instance)
@@ -1824,24 +1837,117 @@ class JavaCodeGeneratorTest {
     assertCompilesSuccessfully(javaCode)
   }
 
-  private fun generateFiles(tempDir: Path, vararg pklModules: PklModule): Map<String, String> {
+  @Test
+  fun `override package names in a standalone module`() {
+    val files = JavaCodegenOptions(
+      packageMapping = mapOf(
+        "a.b.c" to "x.y.z"
+      )
+    ).generateFiles(
+      "MyModule.pkl" to """
+        module a.b.c.MyModule
+        
+        foo: String = "abc"
+      """.trimIndent()
+    )
+
+    val javaCode = files["java/x/y/z/MyModule.java"]
+    assertThat(javaCode).contains("package x.y.z;")
+
+    val propertiesCode =
+      files["resources/META-INF/org/pkl/config/java/mapper/classes/a.b.c.MyModule.properties"]
+    assertThat(propertiesCode)
+      .contains("org.pkl.config.java.mapper.a.b.c.MyModule\\#ModuleClass=x.y.z.MyModule")
+  }
+  
+  @Test
+  fun `override package names in multiple modules using each other`() {
+    val files = JavaCodegenOptions(
+      packageMapping = mapOf(
+        "org.foo" to "com.foo.x",
+        "org.baz" to "com.baz.a.b"
+      )
+    ).generateFiles(
+      "org/foo/Module1" to """
+        module org.foo.Module1
+        
+        class Person {
+          name: String
+        }
+      """.trimIndent(),
+      "org/bar/Module2" to """
+        module org.bar.Module2
+        
+        import "../../org/foo/Module1.pkl"
+
+        class Group {
+          owner: Module1.Person
+          name: String
+        }
+      """.trimIndent(),
+      "org/baz/Module3" to """
+        module org.baz.Module3
+        
+        import "../../org/bar/Module2.pkl"
+
+        class Supergroup {
+          owner: Module2.Group
+        }
+      """.trimIndent()
+    ).toMutableMap()
+    
+    val mapperPrefix = "resources/META-INF/org/pkl/config/java/mapper/classes"
+
+    assertThat(files.remove("java/com/foo/x/Module1.java")).contains(
+      "package com.foo.x;",
+      "public final class Module1 {"
+    )
+    assertThat(files.remove("$mapperPrefix/org.foo.Module1.properties")).contains(
+      "org.pkl.config.java.mapper.org.foo.Module1\\#ModuleClass=com.foo.x.Module1",
+      "org.pkl.config.java.mapper.org.foo.Module1\\#Person=com.foo.x.Module1${'$'}Person",
+    )
+
+    assertThat(files.remove("java/org/bar/Module2.java")).contains(
+      "package org.bar;",
+      "import com.foo.x.Module1;",
+      "public final class Module2 {",
+      "public final Module1. @NonNull Person owner;"
+    )
+    assertThat(files.remove("$mapperPrefix/org.bar.Module2.properties")).contains(
+      "org.pkl.config.java.mapper.org.bar.Module2\\#ModuleClass=org.bar.Module2",
+      "org.pkl.config.java.mapper.org.bar.Module2\\#Group=org.bar.Module2${'$'}Group",
+    )
+
+    assertThat(files.remove("java/com/baz/a/b/Module3.java")).contains(
+      "package com.baz.a.b;",
+      "import org.bar.Module2;",
+      "public final class Module3 {",
+      "public final Module2. @NonNull Group owner;"
+    )
+    assertThat(files.remove("$mapperPrefix/org.baz.Module3.properties")).contains(
+      "org.pkl.config.java.mapper.org.baz.Module3\\#ModuleClass=com.baz.a.b.Module3",
+      "org.pkl.config.java.mapper.org.baz.Module3\\#Supergroup=com.baz.a.b.Module3${'$'}Supergroup",
+    )
+    
+    // No more files.
+    assertThat(files).isEmpty()
+  }
+
+  private fun JavaCodegenOptions.generateFiles(vararg pklModules: PklModule): Map<String, String> {
     val pklFiles = pklModules.map { it.writeToDisk(tempDir.resolve("pkl/${it.name}.pkl")) }
     val evaluator = Evaluator.preconfigured()
     return pklFiles.fold(mapOf()) { acc, pklFile ->
       val pklSchema = evaluator.evaluateSchema(path(pklFile))
-      acc + JavaCodeGenerator(pklSchema, JavaCodegenOptions()).output
+      val generator = JavaCodeGenerator(pklSchema, this)
+      acc + generator.output
     }
   }
 
-  private fun generateJavaFiles(tempDir: Path, vararg pklModules: PklModule): Map<String, String> {
-    val pklFiles = pklModules.map { it.writeToDisk(tempDir.resolve("pkl/${it.name}.pkl")) }
-    val evaluator = Evaluator.preconfigured()
-    return pklFiles.fold(mapOf()) { acc, pklFile ->
-      val pklSchema = evaluator.evaluateSchema(path(pklFile))
-      val generator = JavaCodeGenerator(pklSchema, JavaCodegenOptions())
-      acc + arrayOf(generator.javaFileName to generator.javaFile)
-    }
-  }
+  private fun JavaCodegenOptions.generateFiles(vararg pklModules: kotlin.Pair<String, String>): Map<String, String> =
+    generateFiles(*pklModules.map { (name, text) -> PklModule(name, text) }.toTypedArray())
+
+  private fun generateFiles(vararg pklModules: PklModule): Map<String, String> =
+    JavaCodegenOptions().generateFiles(*pklModules)
 
   private fun instantiateOtherAndPropertyTypes(): kotlin.Pair<Any, Any> {
     val otherCtor = propertyTypesClasses.getValue("my.Mod\$Other").constructors.first()

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
@@ -36,8 +36,22 @@ data class CliKotlinCodeGeneratorOptions(
   val generateSpringBootConfig: Boolean = false,
 
   /** Whether to make generated classes implement [java.io.Serializable] */
-  val implementSerializable: Boolean = false
+  val implementSerializable: Boolean = false,
+  
+  /**
+   * A mapping of packages.
+   *
+   * When you need to have Kotlin package names different from the default package
+   * names derived from Pkl module names, you can define a package mapping, where the key
+   * is the original Pkl module name, and the value is its replacement.
+   */
+  val packageMapping: Map<String, String> = emptyMap()
 ) {
-  fun toKotlinCodegenOptions(): KotlinCodegenOptions =
-    KotlinCodegenOptions(indent, generateKdoc, generateSpringBootConfig, implementSerializable)
+  fun toKotlinCodegenOptions(): KotlinCodegenOptions = KotlinCodegenOptions(
+    indent,
+    generateKdoc,
+    generateSpringBootConfig,
+    implementSerializable,
+    packageMapping
+  )
 }

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
@@ -39,13 +39,13 @@ data class CliKotlinCodeGeneratorOptions(
   val implementSerializable: Boolean = false,
 
   /**
-   * A mapping of packages.
+   * A rename mapping for class names.
    *
-   * When you need to have Kotlin package names different from the default package names derived
-   * from Pkl module names, you can define a package mapping, where the key is the original Pkl
-   * module name, and the value is its replacement.
+   * When you need to have Kotlin class or package names different from the default names derived
+   * from Pkl module names, you can define a rename mapping, where the key is a prefix of the
+   * original Pkl module name, and the value is the desired replacement.
    */
-  val packageMapping: Map<String, String> = emptyMap()
+  val renames: Map<String, String> = emptyMap()
 ) {
   fun toKotlinCodegenOptions(): KotlinCodegenOptions =
     KotlinCodegenOptions(
@@ -53,6 +53,6 @@ data class CliKotlinCodeGeneratorOptions(
       generateKdoc,
       generateSpringBootConfig,
       implementSerializable,
-      packageMapping
+      renames
     )
 }

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
@@ -37,21 +37,22 @@ data class CliKotlinCodeGeneratorOptions(
 
   /** Whether to make generated classes implement [java.io.Serializable] */
   val implementSerializable: Boolean = false,
-  
+
   /**
    * A mapping of packages.
    *
-   * When you need to have Kotlin package names different from the default package
-   * names derived from Pkl module names, you can define a package mapping, where the key
-   * is the original Pkl module name, and the value is its replacement.
+   * When you need to have Kotlin package names different from the default package names derived
+   * from Pkl module names, you can define a package mapping, where the key is the original Pkl
+   * module name, and the value is its replacement.
    */
   val packageMapping: Map<String, String> = emptyMap()
 ) {
-  fun toKotlinCodegenOptions(): KotlinCodegenOptions = KotlinCodegenOptions(
-    indent,
-    generateKdoc,
-    generateSpringBootConfig,
-    implementSerializable,
-    packageMapping
-  )
+  fun toKotlinCodegenOptions(): KotlinCodegenOptions =
+    KotlinCodegenOptions(
+      indent,
+      generateKdoc,
+      generateSpringBootConfig,
+      implementSerializable,
+      packageMapping
+    )
 }

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
@@ -790,9 +790,14 @@ class KotlinCodeGenerator(
   private val nameMapper = NameMapper(options.renames)
 
   private fun mapModuleName(name: String): kotlin.Pair<String, String> {
-    val mappedName = nameMapper.map(name)
-    val packageName = mappedName.substringBeforeLast('.', "")
-    val className = mappedName.substringAfterLast('.').replaceFirstChar { it.titlecaseChar() }
+    val mappedName = nameMapper.mapToClassName(name)
+    val packageName = mappedName.packageName
+    val className =
+      if (mappedName.classNameWasChanged(name)) {
+        mappedName.className
+      } else {
+        mappedName.className.replaceFirstChar { it.titlecaseChar() }
+      }
     return packageName to className
   }
 }

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
@@ -20,6 +20,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import java.io.StringWriter
 import java.net.URI
 import java.util.*
+import org.pkl.commons.PackageMapper
 import org.pkl.core.*
 import org.pkl.core.util.CodeGeneratorUtils
 import org.pkl.core.util.IoUtils
@@ -184,7 +185,7 @@ class KotlinCodeGenerator(
       }
 
       val moduleName = moduleSchema.moduleName
-      
+
       val (packageName, moduleTypeName) = mapModuleName(moduleName)
 
       val fileSpec = FileSpec.builder(packageName, moduleTypeName).indent(options.indent)
@@ -785,10 +786,11 @@ class KotlinCodeGenerator(
 
   private fun List<PType>.toKotlinPoet(): Array<TypeName> =
     map { it.toKotlinPoetName() }.toTypedArray()
-  
-  private fun mapPackageName(name: String): String =
-    options.packageMapping[name] ?: name
-  
+
+  private val packageMapper = PackageMapper(options.packageMapping)
+
+  private fun mapPackageName(name: String): String = packageMapper.map("$name.").removeSuffix(".")
+
   private fun mapModuleName(name: String): kotlin.Pair<String, String> {
     val packageName = mapPackageName(name.substringBeforeLast('.', ""))
     val className = name.substringAfterLast('.').replaceFirstChar { it.titlecaseChar() }

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
@@ -115,9 +115,9 @@ class KotlinCodeGenerator(
         .toString()
     }
 
-  val kotlinFileName: String
+  private val kotlinFileName: String
     get() = buildString {
-      val (packageName, className) = mapModuleName(moduleSchema.moduleName)
+      val (packageName, className) = nameMapper.map(moduleSchema.moduleName)
       val dirPath = packageName.split('.').joinToString("/", transform = IoUtils::encodePath)
       val fileName = IoUtils.encodePath(className)
       append("kot")
@@ -186,7 +186,7 @@ class KotlinCodeGenerator(
 
       val moduleName = moduleSchema.moduleName
 
-      val (packageName, moduleTypeName) = mapModuleName(moduleName)
+      val (packageName, moduleTypeName) = nameMapper.map(moduleName)
 
       val fileSpec = FileSpec.builder(packageName, moduleTypeName).indent(options.indent)
 
@@ -640,7 +640,7 @@ class KotlinCodeGenerator(
       .endControlFlow()
 
   private fun PClass.toKotlinPoetName(): ClassName {
-    val (packageName, moduleTypeName) = mapModuleName(moduleName)
+    val (packageName, moduleTypeName) = nameMapper.map(moduleName)
     return if (isModuleClass) {
       ClassName(packageName, moduleTypeName)
     } else {
@@ -649,7 +649,7 @@ class KotlinCodeGenerator(
   }
 
   private fun TypeAlias.toKotlinPoetName(): ClassName {
-    val (packageName, moduleTypeName) = mapModuleName(moduleName)
+    val (packageName, moduleTypeName) = nameMapper.map(moduleName)
 
     return when {
       aliasedType is PType.Alias -> {
@@ -788,16 +788,4 @@ class KotlinCodeGenerator(
     map { it.toKotlinPoetName() }.toTypedArray()
 
   private val nameMapper = NameMapper(options.renames)
-
-  private fun mapModuleName(name: String): kotlin.Pair<String, String> {
-    val mappedName = nameMapper.mapToClassName(name)
-    val packageName = mappedName.packageName
-    val className =
-      if (mappedName.classNameWasChanged(name)) {
-        mappedName.className
-      } else {
-        mappedName.className.replaceFirstChar { it.titlecaseChar() }
-      }
-    return packageName to className
-  }
 }

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
@@ -17,6 +17,7 @@
 
 package org.pkl.codegen.kotlin
 
+import com.github.ajalt.clikt.parameters.options.associate
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -80,6 +81,18 @@ class PklKotlinCodegenCommand :
         help = "Whether to make generated classes implement java.io.Serializable"
       )
       .flag()
+  
+  private val packageMapping: Map<String, String> by
+    option(
+      names = arrayOf("-m", "--package-mapping"),
+      metavar = "<module_name=package_name>",
+      help = """
+          Replace the default package name of the generated Kotlin classes (repeatable).
+          By default, the package name of generated classes is derived from the Pkl module name.
+          With this option, you can override the name for the given modules with custom names.
+        """.trimIndent()
+    )
+    .associate()
 
   override fun run() {
     val options =
@@ -89,7 +102,8 @@ class PklKotlinCodegenCommand :
         indent = indent,
         generateKdoc = generateKdoc,
         generateSpringBootConfig = generateSpringboot,
-        implementSerializable = implementSerializable
+        implementSerializable = implementSerializable,
+        packageMapping = packageMapping
       )
     CliKotlinCodeGenerator(options).run()
   }

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
@@ -85,7 +85,7 @@ class PklKotlinCodegenCommand :
   private val renames: Map<String, String> by
     option(
         names = arrayOf("--rename"),
-        metavar = "<module_prefix=class_prefix>",
+        metavar = "<old_name=new_name>",
         help =
           """
             Replace a prefix in the names of the generated Kotlin classes (repeatable).

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
@@ -82,15 +82,16 @@ class PklKotlinCodegenCommand :
       )
       .flag()
 
-  private val packageMapping: Map<String, String> by
+  private val renames: Map<String, String> by
     option(
-        names = arrayOf("--package-mapping"),
-        metavar = "<module_prefix=package_prefix>",
+        names = arrayOf("--rename"),
+        metavar = "<module_prefix=class_prefix>",
         help =
           """
-            Replace the default package name of the generated Kotlin classes (repeatable).
-            By default, the package name of generated classes is derived from the Pkl module name.
-            With this option, you can override the name for the given modules with custom names.
+            Replace a prefix in the names of the generated Kotlin classes (repeatable).
+            By default, the names of generated classes are derived from the Pkl module names.
+            With this option, you can override the modify the default names, renaming entire
+            classes or just their packages.
           """
             .trimIndent()
       )
@@ -105,7 +106,7 @@ class PklKotlinCodegenCommand :
         generateKdoc = generateKdoc,
         generateSpringBootConfig = generateSpringboot,
         implementSerializable = implementSerializable,
-        packageMapping = packageMapping
+        renames = renames
       )
     CliKotlinCodeGenerator(options).run()
   }

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
@@ -81,18 +81,20 @@ class PklKotlinCodegenCommand :
         help = "Whether to make generated classes implement java.io.Serializable"
       )
       .flag()
-  
+
   private val packageMapping: Map<String, String> by
     option(
-      names = arrayOf("-m", "--package-mapping"),
-      metavar = "<module_name=package_name>",
-      help = """
-          Replace the default package name of the generated Kotlin classes (repeatable).
-          By default, the package name of generated classes is derived from the Pkl module name.
-          With this option, you can override the name for the given modules with custom names.
-        """.trimIndent()
-    )
-    .associate()
+        names = arrayOf("--package-mapping"),
+        metavar = "<module_prefix=package_prefix>",
+        help =
+          """
+            Replace the default package name of the generated Kotlin classes (repeatable).
+            By default, the package name of generated classes is derived from the Pkl module name.
+            With this option, you can override the name for the given modules with custom names.
+          """
+            .trimIndent()
+      )
+      .associate()
 
   override fun run() {
     val options =

--- a/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorTest.kt
+++ b/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorTest.kt
@@ -205,7 +205,7 @@ class CliKotlinCodeGeneratorTest {
         CliKotlinCodeGeneratorOptions(
           CliBaseOptions(listOf(module1PklFile, module2PklFile, module3PklFile).map { it.toUri() }),
           outputDir,
-          packageMapping = mapOf("org.foo" to "com.foo.x", "org.baz" to "com.baz.a.b")
+          renames = mapOf("org.foo" to "com.foo.x", "org.baz" to "com.baz.a.b")
         )
       )
 

--- a/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorTest.kt
+++ b/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorTest.kt
@@ -151,7 +151,7 @@ class CliKotlinCodeGeneratorTest {
       module2KotlinFile.readString()
     )
   }
-  
+
   @Test
   fun `custom package names`(@TempDir tempDir: Path) {
     val module1 =
@@ -199,7 +199,7 @@ class CliKotlinCodeGeneratorTest {
     val module2PklFile = module2.writeToDisk(tempDir.resolve("org/bar/Module2.pkl"))
     val module3PklFile = module3.writeToDisk(tempDir.resolve("org/baz/Module3.pkl"))
     val outputDir = tempDir.resolve("output")
-    
+
     val generator =
       CliKotlinCodeGenerator(
         CliKotlinCodeGeneratorOptions(
@@ -210,13 +210,13 @@ class CliKotlinCodeGeneratorTest {
       )
 
     generator.run()
-    
+
     val module1KotlinFile = outputDir.resolve("kotlin/com/foo/x/Module1.kt")
-    module1KotlinFile.readString().let { 
+    module1KotlinFile.readString().let {
       assertContains("package com.foo.x", it)
-      
+
       assertContains("object Module1 {", it)
-      
+
       assertContains(
         """
         |  data class Person(
@@ -245,7 +245,7 @@ class CliKotlinCodeGeneratorTest {
         it
       )
     }
-    
+
     val module3KotlinFile = outputDir.resolve("kotlin/com/baz/a/b/Module3.kt")
     module3KotlinFile.readString().let {
       assertContains("package com.baz.a.b", it)

--- a/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/InMemoryKotlinCompiler.kt
+++ b/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/InMemoryKotlinCompiler.kt
@@ -56,6 +56,7 @@ object InMemoryKotlinCompiler {
 
     val (importLines, remainder) =
       sourceFiles.entries
+        .filter { (filename, _) -> filename.endsWith(".kt") }
         .flatMap { (_, text) -> text.lines() }
         .partition { it.startsWith("import") }
     val importBlock = importLines.sorted().distinct()

--- a/pkl-commons/src/main/kotlin/org/pkl/commons/NameMapper.kt
+++ b/pkl-commons/src/main/kotlin/org/pkl/commons/NameMapper.kt
@@ -16,30 +16,31 @@
 package org.pkl.commons
 
 /**
- * A helper class for translating package names of Pkl modules to package names of classes and/or
- * objects in the target language of a code generation execution.
+ * A helper class for translating names of Pkl modules to different names of classes and/or objects
+ * in the target language of a code generation execution.
  *
- * The `mapping` parameter is expected to contain valid prefixes of Pkl package names, with an
- * optional dot at the end, and values should be valid package names in the language for which code
+ * The `mapping` parameter is expected to contain valid prefixes of Pkl module names, with an
+ * optional dot at the end, and values should be valid class names in the language for which code
  * generation is performed.
  *
- * When computing the appropriate target package name, the longest matching prefix is used. For
- * example:
+ * When computing the appropriate target name, the longest matching prefix is used. For example:
  * ```kotlin
  * val mapper = PackageMapper(mapOf(
+ *   "com.foo.Main" to "w.Main",
  *   "com.foo." to "x.",
  *   "com." to "y.",
  *   "" to "z."
  * ))
  *
+ * assert(mapper.map("com.foo.Main") == "w.Main")
  * assert(mapper.map("com.foo.bar") == "x.bar")
  * assert(mapper.map("com.baz.qux") == "y.baz.qux")
  * assert(mapper.map("org.foo.bar") == "z.org.foo.bar")
  * ```
  *
- * Prefix replacements are literal, and therefore dots are important: in most cases, you must ensure
- * that you have an ending dot on both sides of a mapping (except for the empty mapping, if you use
- * it), otherwise you may get unexpected results:
+ * Prefix replacements are literal, and therefore dots are important. When renaming packages, in
+ * most cases, you must ensure that you have an ending dot on both sides of a mapping (except for
+ * the empty mapping, if you use it), otherwise you may get unexpected results:
  * ```kotlin
  * val mapper = PackageMapper(mapOf(
  *   "com.foo." to "x",  // Dot on the left only
@@ -53,7 +54,7 @@ package org.pkl.commons
  * assert(mapper.map("net.bazqux") == "zqux")     // ...may cut the package name in the middle.
  * ```
  */
-class PackageMapper(mapping: Map<String, String>) {
+class NameMapper(mapping: Map<String, String>) {
   private val sortedMapping = mapping.toList().sortedBy { -it.first.length }
 
   fun map(sourceName: String): String {

--- a/pkl-commons/src/main/kotlin/org/pkl/commons/NameMapper.kt
+++ b/pkl-commons/src/main/kotlin/org/pkl/commons/NameMapper.kt
@@ -65,4 +65,17 @@ class NameMapper(mapping: Map<String, String>) {
     }
     return sourceName
   }
+
+  data class MapResult(val packageName: String, val className: String) {
+    fun classNameWasChanged(sourceName: String): Boolean =
+      sourceName != className && !sourceName.endsWith(".$className")
+  }
+
+  fun mapToClassName(sourceName: String): MapResult {
+    val mappedName = map(sourceName)
+    return MapResult(
+      packageName = mappedName.substringBeforeLast('.', ""),
+      className = mappedName.substringAfterLast('.')
+    )
+  }
 }

--- a/pkl-commons/src/main/kotlin/org/pkl/commons/PackageMapper.kt
+++ b/pkl-commons/src/main/kotlin/org/pkl/commons/PackageMapper.kt
@@ -1,0 +1,67 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.commons
+
+/**
+ * A helper class for translating package names of Pkl modules to package names of classes and/or
+ * objects in the target language of a code generation execution.
+ *
+ * The `mapping` parameter is expected to contain valid prefixes of Pkl package names, with an
+ * optional dot at the end, and values should be valid package names in the language for which code
+ * generation is performed.
+ *
+ * When computing the appropriate target package name, the longest matching prefix is used. For
+ * example:
+ * ```kotlin
+ * val mapper = PackageMapper(mapOf(
+ *   "com.foo." to "x.",
+ *   "com." to "y.",
+ *   "" to "z."
+ * ))
+ *
+ * assert(mapper.map("com.foo.bar") == "x.bar")
+ * assert(mapper.map("com.baz.qux") == "y.baz.qux")
+ * assert(mapper.map("org.foo.bar") == "z.org.foo.bar")
+ * ```
+ *
+ * Prefix replacements are literal, and therefore dots are important: in most cases, you must ensure
+ * that you have an ending dot on both sides of a mapping (except for the empty mapping, if you use
+ * it), otherwise you may get unexpected results:
+ * ```kotlin
+ * val mapper = PackageMapper(mapOf(
+ *   "com.foo." to "x",  // Dot on the left only
+ *   "org.bar" to "y.",  // Dot on the right only
+ *   "net.baz" to "z"    // No dots
+ * ))
+ *
+ * assert(mapper.map("com.foo.bar") == "xbar")    // Target prefix merged into the suffix
+ * assert(mapper.map("org.bar.baz") == "y..baz")  // Double dot, invalid package name
+ * assert(mapper.map("net.baz.qux") == "z.qux")   // Looks okay, but...
+ * assert(mapper.map("net.bazqux") == "zqux")     // ...may cut the package name in the middle.
+ * ```
+ */
+class PackageMapper(mapping: Map<String, String>) {
+  private val sortedMapping = mapping.toList().sortedBy { -it.first.length }
+
+  fun map(sourceName: String): String {
+    for ((sourcePrefix, targetPrefix) in sortedMapping) {
+      if (sourceName.startsWith(sourcePrefix)) {
+        return targetPrefix + sourceName.substring(sourcePrefix.length)
+      }
+    }
+    return sourceName
+  }
+}

--- a/pkl-commons/src/test/kotlin/org/pkl/commons/NameMapperTest.kt
+++ b/pkl-commons/src/test/kotlin/org/pkl/commons/NameMapperTest.kt
@@ -1,0 +1,59 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.commons
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class NameMapperTest {
+  @Test
+  fun `empty prefixes everything`() {
+    val mapper = NameMapper(mapOf("" to "bar."))
+    assertThat(mapper.map("foo.bar.Baz")).isEqualTo("bar.foo.bar" to "Baz")
+    assertThat(mapper.map("Baz")).isEqualTo("bar" to "Baz")
+  }
+
+  @Test
+  fun `longest prefix wins`() {
+    val mapper = NameMapper(mapOf("bar." to "com.bar.", "bar.baz." to "foo.bar."))
+    assertThat(mapper.map("bar.baz.Buzzy")).isEqualTo("foo.bar" to "Buzzy")
+  }
+
+  @Test
+  fun `implicit uppercase classname`() {
+    val mapper = NameMapper(mapOf("foo." to "bar."))
+    assertThat(mapper.map("foo.bar.baz")).isEqualTo("bar.bar" to "Baz")
+    assertThat(mapper.map("foo.bar")).isEqualTo("bar" to "Bar")
+    assertThat(mapper.map("baz")).isEqualTo("" to "Baz")
+    assertThat(mapper.map("baz")).isEqualTo("" to "Baz")
+  }
+
+  @Test
+  fun `no implicit uppercased classname if explicitly renamed`() {
+    val mapper =
+      NameMapper(
+        mapOf(
+          "foo.bar" to "bar.bar",
+          "foo.c" to "foo.z",
+          "com.foo." to "x",
+        )
+      )
+    assertThat(mapper.map("foo.bar")).isEqualTo("bar" to "bar")
+    assertThat(mapper.map("foo.bar")).isEqualTo("bar" to "bar")
+    assertThat(mapper.map("foo.cow")).isEqualTo("foo" to "zow")
+    assertThat(mapper.map("com.foo.bar")).isEqualTo("" to "xbar")
+  }
+}

--- a/pkl-gradle/pkl-gradle.gradle.kts
+++ b/pkl-gradle/pkl-gradle.gradle.kts
@@ -26,7 +26,11 @@ dependencies {
   //
   // To debug shaded code in IntelliJ, temporarily remove the conditional.
   if (System.getProperty("idea.sync.active") == null) {
-    runtimeOnly(project(":pkl-tools", "fatJar"))
+    runtimeOnly(projects.pklTools) {
+      attributes {
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
+      }
+    }
   }
 
   testImplementation(projects.pklCommonsTest)

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -410,6 +410,7 @@ public class PklPlugin implements Plugin<Project> {
     task.getOutputDir().set(spec.getOutputDir());
     task.getGenerateSpringBootConfig().set(spec.getGenerateSpringBootConfig());
     task.getImplementSerializable().set(spec.getImplementSerializable());
+    task.getPackageMapping().set(spec.getPackageMapping());
   }
 
   private <T extends BasePklTask, S extends BasePklSpec> void configureBaseTask(T task, S spec) {

--- a/pkl-gradle/src/main/java/org/pkl/gradle/spec/CodeGenSpec.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/spec/CodeGenSpec.java
@@ -16,6 +16,7 @@
 package org.pkl.gradle.spec;
 
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 
@@ -30,4 +31,6 @@ public interface CodeGenSpec extends ModulesSpec {
   Property<Boolean> getGenerateSpringBootConfig();
 
   Property<Boolean> getImplementSerializable();
+
+  MapProperty<String, String> getPackageMapping();
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/CodeGenTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/CodeGenTask.java
@@ -33,7 +33,7 @@ public abstract class CodeGenTask extends ModulesTask {
 
   @Input
   public abstract Property<Boolean> getImplementSerializable();
-  
+
   @Input
   public abstract MapProperty<String, String> getPackageMapping();
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/CodeGenTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/CodeGenTask.java
@@ -16,6 +16,7 @@
 package org.pkl.gradle.task;
 
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
@@ -32,4 +33,7 @@ public abstract class CodeGenTask extends ModulesTask {
 
   @Input
   public abstract Property<Boolean> getImplementSerializable();
+  
+  @Input
+  public abstract MapProperty<String, String> getPackageMapping();
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/JavaCodeGenTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/JavaCodeGenTask.java
@@ -52,7 +52,8 @@ public abstract class JavaCodeGenTask extends CodeGenTask {
                 getGenerateSpringBootConfig().get(),
                 getParamsAnnotation().getOrNull(),
                 getNonNullAnnotation().getOrNull(),
-                getImplementSerializable().get()))
+                getImplementSerializable().get(),
+                getPackageMapping().get()))
         .run();
   }
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/KotlinCodeGenTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/KotlinCodeGenTask.java
@@ -37,7 +37,8 @@ public abstract class KotlinCodeGenTask extends CodeGenTask {
                 getIndent().get(),
                 getGenerateKdoc().get(),
                 getGenerateSpringBootConfig().get(),
-                getImplementSerializable().get()))
+                getImplementSerializable().get(),
+                getPackageMapping().get()))
         .run();
   }
 }

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/JavaCodeGeneratorsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/JavaCodeGeneratorsTest.kt
@@ -13,7 +13,7 @@ class JavaCodeGeneratorsTest : AbstractTest() {
 
     runTask("configClasses")
     
-    val baseDir = testProjectDir.resolve("build/generated/java/org")
+    val baseDir = testProjectDir.resolve("build/generated/java/foo/bar")
     val moduleFile = baseDir.resolve("Mod.java")
 
     assertThat(baseDir.listDirectoryEntries().count()).isEqualTo(1)
@@ -36,7 +36,7 @@ class JavaCodeGeneratorsTest : AbstractTest() {
       |  public static final class Person {
       |    public final @Nonnull String name;
       |
-      |    public final @Nonnull List<@Nonnull Address> addresses;
+      |    public final @Nonnull List<Address> addresses;
     """
     )
 
@@ -53,28 +53,14 @@ class JavaCodeGeneratorsTest : AbstractTest() {
   @Test
   fun `compile generated code`() {
     writeBuildFile()
-    writeFile("mod.pkl", """
-      module org.mod
-      
-      class Person {
-        name: String
-        addresses: List<Address?>
-      }
-      
-      class Address {
-        street: String
-        zip: Int
-      }
-      
-      other: Any = 42
-    """.trimIndent())
+    writePklFile()
     
     runTask("compileJava")
 
     val classesDir = testProjectDir.resolve("build/classes/java/main")
-    val moduleClassFile = classesDir.resolve("org/Mod.class")
-    val personClassFile = classesDir.resolve("org/Mod\$Person.class")
-    val addressClassFile = classesDir.resolve("org/Mod\$Address.class")
+    val moduleClassFile = classesDir.resolve("foo/bar/Mod.class")
+    val personClassFile = classesDir.resolve("foo/bar/Mod\$Person.class")
+    val addressClassFile = classesDir.resolve("foo/bar/Mod\$Address.class")
     assertThat(moduleClassFile).exists()
     assertThat(personClassFile).exists()
     assertThat(addressClassFile).exists()
@@ -127,6 +113,9 @@ class JavaCodeGeneratorsTest : AbstractTest() {
             paramsAnnotation = "javax.inject.Named"
             nonNullAnnotation = "javax.annotation.Nonnull"
             settingsModule = "pkl:settings"
+            packageMapping = [
+              'org': 'foo.bar'
+            ]
           }
         }
       }
@@ -134,18 +123,6 @@ class JavaCodeGeneratorsTest : AbstractTest() {
     )
   }
 
-  private fun writeGradlePropertiesFile() {
-    writeFile("gradle.properties", """
-      systemProp.http.proxyHost=proxy.config.pcp.local
-      systemProp.http.proxyPort=3128
-      systemProp.http.nonProxyHosts=localhost|*.apple.com
-      
-      systemProp.https.proxyHost=proxy.config.pcp.local
-      systemProp.https.proxyPort=3128
-      systemProp.https.nonProxyHosts=localhost|*.apple.com
-    """)
-  }
-  
   private fun writePklFile() {
     writeFile(
       "mod.pkl", """
@@ -153,7 +130,7 @@ class JavaCodeGeneratorsTest : AbstractTest() {
   
         class Person {
           name: String
-          addresses: List<Address>
+          addresses: List<Address?>
         }
   
         class Address {

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/KotlinCodeGeneratorsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/KotlinCodeGeneratorsTest.kt
@@ -13,7 +13,7 @@ class KotlinCodeGeneratorsTest : AbstractTest() {
 
     runTask("configClasses")
 
-    val baseDir = testProjectDir.resolve("build/generated/kotlin/org")
+    val baseDir = testProjectDir.resolve("build/generated/kotlin/foo/bar")
     val kotlinFile = baseDir.resolve("Mod.kt")
 
     assertThat(baseDir.listDirectoryEntries().count()).isEqualTo(1)
@@ -58,9 +58,9 @@ class KotlinCodeGeneratorsTest : AbstractTest() {
     runTask("compileKotlin")
 
     val classesDir = testProjectDir.resolve("build/classes/kotlin/main")
-    val moduleClassFile = classesDir.resolve("org/Mod.class")
-    val personClassFile = classesDir.resolve("org/Mod\$Person.class")
-    val addressClassFile = classesDir.resolve("org/Mod\$Address.class")
+    val moduleClassFile = classesDir.resolve("foo/bar/Mod.class")
+    val personClassFile = classesDir.resolve("foo/bar/Mod\$Person.class")
+    val addressClassFile = classesDir.resolve("foo/bar/Mod\$Address.class")
     assertThat(moduleClassFile).exists()
     assertThat(personClassFile).exists()
     assertThat(addressClassFile).exists()
@@ -125,6 +125,9 @@ class KotlinCodeGeneratorsTest : AbstractTest() {
             sourceModules = ["mod.pkl"]
             outputDir = file("build/generated")
             settingsModule = "pkl:settings"
+            packageMapping = [
+              'org': 'foo.bar'
+            ]
           }
         }
       }

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/KotlinCodeGeneratorsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/KotlinCodeGeneratorsTest.kt
@@ -126,7 +126,7 @@ class KotlinCodeGeneratorsTest : AbstractTest() {
             outputDir = file("build/generated")
             settingsModule = "pkl:settings"
             packageMapping = [
-              'org': 'foo.bar'
+              'org.': 'foo.bar.'
             ]
           }
         }


### PR DESCRIPTION
See #456 for motivation.

- [x] Implement package mapping in Java codegen, add tests
- [x] Implement package mapping in Kotlin codegen, add tests
- [x] Propagate configuration to the Gradle plugin

Closes #456