### PR TITLE
Omit showing stdlib as dependency in pkldoc

### DIFF
--- a/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
@@ -518,10 +518,12 @@ internal abstract class PageGenerator<out S>(
       }
     }
 
-    if (docPackage.docPackageInfo.dependencies.isNotEmpty()) {
+    // Every package implicitly depends on `pkl`; omit to reduce noise.
+    val dependencies = docPackage.docPackageInfo.dependencies.filter { it.name != "pkl" }
+    if (dependencies.isNotEmpty()) {
       result[MemberInfoKey("Dependencies")] = {
         var first = true
-        for (dep in docPackage.docPackageInfo.dependencies) {
+        for (dep in dependencies) {
           if (first) first = false else +", "
           a {
             href =

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/RuntimeDataGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/RuntimeDataGenerator.kt
@@ -45,6 +45,9 @@ internal class RuntimeDataGenerator(
     for (pkg in packages) {
       packageVersions.add(pkg.ref.pkg, pkg.ref.version)
       for (dependency in pkg.dependencies) {
+        if (dependency.isStdlib()) continue
+        // Every package implicitly depends on the stdlib. Showing this dependency adds unwanted
+        // noise.
         packageUsages.add(dependency.ref, pkg.ref)
       }
       for (module in pkg.modules) {
@@ -240,3 +243,5 @@ internal class RuntimeDataGenerator(
     put(key, newValue)
   }
 }
+
+private fun DependencyData.isStdlib(): Boolean = ref.pkg == "pkl"

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package1/1.2.3/index.html
@@ -39,7 +39,7 @@
           <dt class="">Issue tracker:</dt>
           <dd><a href="https://issues.apple.com/package1/">https://issues.apple.com/package1/</a></dd>
           <dt class="">Dependencies:</dt>
-          <dd><a href="../../com.package2/4.5.6/index.html">com.package2:4.5.6</a>, <a href="https://example.com/docs/externalpackage/">com.externalpackage:7.8.9</a>, <a href="https://pages.github.com/apple/pkl/stdlib/pkl/0.24.0/">pkl:0.24.0</a></dd>
+          <dd><a href="../../com.package2/4.5.6/index.html">com.package2:4.5.6</a>, <a href="https://example.com/docs/externalpackage/">com.externalpackage:7.8.9</a></dd>
           <dt class="runtime-data hidden">Known usages:</dt>
           <dd id="known-usages" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">All versions:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/com.package2/4.5.6/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/com.package2/4.5.6/index.html
@@ -35,8 +35,6 @@
           <dd><a href="https://sources.apple.com/package2/">https://sources.apple.com/package2/</a></dd>
           <dt class="">Issue tracker:</dt>
           <dd><a href="https://issues.apple.com/package2/">https://issues.apple.com/package2/</a></dd>
-          <dt class="">Dependencies:</dt>
-          <dd><a href="https://pkl-lang.org/stdlib/pkl/0.24.0/">pkl:0.24.0</a></dd>
           <dt class="runtime-data hidden">Known usages:</dt>
           <dd id="known-usages" class="runtime-data hidden"></dd>
           <dt class="runtime-data hidden">All versions:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/localhost(3a)0/birds/0.5.0/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/localhost(3a)0/birds/0.5.0/index.html
@@ -37,7 +37,7 @@
           <dt class="">Issue tracker:</dt>
           <dd><a href="https://example.com/birds/issues">https://example.com/birds/issues</a></dd>
           <dt class="">Dependencies:</dt>
-          <dd><a href="https://example.com/fruit-docs">fruit:1.0.5</a>, <a href="https://pages.github.com/apple/pkl/stdlib/pkl/0.24.0/">pkl:0.24.0</a></dd>
+          <dd><a href="https://example.com/fruit-docs">fruit:1.0.5</a></dd>
           <dt class="">Checksum:</dt>
           <dd>bfaf5281613d170a740505cc87561041f4e0cad1f0e6938bf94f7609f9a4673d</dd>
           <dt class="runtime-data hidden">Known usages:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/localhost(3a)0/fruit/1.1.0/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/localhost(3a)0/fruit/1.1.0/index.html
@@ -36,8 +36,6 @@
           <dd><a href="https://example.com/fruit">https://example.com/fruit</a></dd>
           <dt class="">Issue tracker:</dt>
           <dd><a href="https://example.com/fruit/issues">https://example.com/fruit/issues</a></dd>
-          <dt class="">Dependencies:</dt>
-          <dd><a href="https://pages.github.com/apple/pkl/stdlib/pkl/0.24.0/">pkl:0.24.0</a></dd>
           <dt class="">Checksum:</dt>
           <dd>8d982761d182f2185e4180c82190791d9a60c721cb3393bb2e946fab90131e8c</dd>
           <dt class="runtime-data hidden">Known usages:</dt>


### PR DESCRIPTION
The stdlib is an implicit dependency for every package. Showing this as a dependency is unnecessary noise.

Before:
![Screenshot 2024-05-22 at 4 43 05 PM](https://github.com/apple/pkl/assets/4590460/e8d7eba2-29c0-4de8-a9f6-97c5b7dcf5d5)


After:
![Screenshot 2024-05-22 at 4 42 43 PM](https://github.com/apple/pkl/assets/4590460/fba81fc0-3112-4106-a9a9-d435de2d783f)
