### PR TITLE
Restore late-binding for constraints within typealiases

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/type/ResolveQualifiedDeclaredTypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/ResolveQualifiedDeclaredTypeNode.java
@@ -19,6 +19,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 import org.pkl.core.runtime.*;
+import org.pkl.core.util.Pair;
 
 public final class ResolveQualifiedDeclaredTypeNode extends ResolveDeclaredTypeNode {
   private final SourceSection moduleNameSection;
@@ -54,7 +55,7 @@ public final class ResolveQualifiedDeclaredTypeNode extends ResolveDeclaredTypeN
     // (type declared in base module is accessible through extending and amending modules)
     for (var currModule = importedModule; currModule != null; currModule = currModule.getParent()) {
       var result = getType(currModule, typeName, sourceSection);
-      if (result != null) return result;
+      if (result != null) return Pair.of(importedModule, result);
     }
 
     throw exceptionBuilder()

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmTyped.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmTyped.java
@@ -64,6 +64,16 @@ public final class VmTyped extends VmObject {
     return (VmTyped) parent;
   }
 
+  public boolean isAmending(VmTyped other) {
+    if (this == other) {
+      return true;
+    }
+    if (parent == null) {
+      return false;
+    }
+    return ((VmTyped) parent).isAmending(other);
+  }
+
   @Override
   public boolean isPrototype() {
     return this == getPrototype();

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/types/helpers/someModule2.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/types/helpers/someModule2.pkl
@@ -1,0 +1,3 @@
+typealias IsValid = Any(isValid)
+
+isValid: Boolean = false

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/types/helpers/someModule3.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/types/helpers/someModule3.pkl
@@ -1,0 +1,3 @@
+amends "someModule2.pkl"
+
+isValid = true

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAliasConstraint3.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAliasConstraint3.pkl
@@ -1,0 +1,25 @@
+typealias IsValid = Any(isValid)
+
+hidden isValid = false
+
+prop: Boolean = 5 is IsValid
+
+hidden obj1 = (module) {
+  isValid = false
+}
+
+hidden obj2 = (module) {
+  isValid = true
+}
+
+hidden obj3 = (module) {
+  local isValid = throw("nuh uh")
+}
+
+output {
+  value = new Dynamic {
+    prop1 = obj1
+    prop2 = obj2
+    prop3 = obj3
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAliasConstraint4.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAliasConstraint4.pkl
@@ -1,0 +1,5 @@
+import "helpers/someModule2.pkl"
+import "helpers/someModule3.pkl"
+
+res1 = 5 is someModule2.IsValid
+res2 = 5 is someModule3.IsValid

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/helpers/someModule2.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/helpers/someModule2.pcf
@@ -1,0 +1,1 @@
+isValid = false

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/helpers/someModule3.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/helpers/someModule3.pcf
@@ -1,0 +1,1 @@
+isValid = true

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAliasConstraint3.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAliasConstraint3.pcf
@@ -1,0 +1,9 @@
+prop1 {
+  prop = false
+}
+prop2 {
+  prop = true
+}
+prop3 {
+  prop = false
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAliasConstraint4.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAliasConstraint4.pcf
@@ -1,0 +1,2 @@
+res1 = false
+res2 = true


### PR DESCRIPTION
This is one proposal to fix https://github.com/apple/pkl/issues/446.

This changes the behavior of typealiases such that:

* If the current frame's receiver is amending the typealias's declared module, set the constraint to the current receiver.
* Otherwise, set it to either the receiver of a qualified type declaration, or the typealias's enclosing receiver.

This implies that the meaning of a typealias can change depending on where it is resolved from. Given the following:

```groovy
// module1.pkl
typealias MyTypeAlias = Any(isValid)

isValid = false
```

```groovy
// module2.pkl
amends "module1.pkl"

isValid = true
```

These two properties have different type checks:

```groovy
import "module1.pkl"
import "module2.pkl"

propA: module1.MyTypeAlias // always fails
propB: module2.MyTypeAlias // always passes
```

Despite this, they are considered the same typealias.

```groovy
import "module1.pkl"
import "module2.pkl"

res = module1.MyTypeAlias == module2.MyTypeAlias // true
```

This is somewhat quirky. An alternative solution to this problem is to require any references from a constraint to be `const`. This is just like how classes work. However, this solution would limit the usefulness of typealiases.