### PR TITLE
Remove documentation references to `packageInfos`

### DIFF
--- a/pkl-doc/src/main/kotlin/org/pkl/doc/DocGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/DocGenerator.kt
@@ -45,7 +45,7 @@ class DocGenerator(
   modules: Map<DocPackageInfo, Collection<ModuleSchema>>,
 
   /**
-   * A function to resolve imports in [modules], [packageInfos], and [docsiteInfo].
+   * A function to resolve imports in [modules] and [docsiteInfo].
    *
    * Module `pkl.base` is resolved with this function even if not explicitly imported.
    */


### PR DESCRIPTION
It references something that isn't present and should be removed.

```
❯ rg packageInfos
pkl-doc/src/main/kotlin/org/pkl/doc/DocGenerator.kt
48:   * A function to resolve imports in [modules], [packageInfos], and [docsiteInfo].
```