### PR TITLE
Use Pkl syntax highlighting instead of Groovy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,9 @@
 
 /docs/** linguist-documentation
 
-*.pkl linguist-language=Groovy
+*.pcf linguist-language=Pkl
+PklProject linguist-language=Pkl
+
 * text eol=lf
 *.bat text eol=crlf
 


### PR DESCRIPTION
Now that Pkl syntax highlighting is available on GitHub, we can remove the Groovy association with these files.

This also adds changes to mark `*.pcf` and `PklProject` files as Pkl.