### PR TITLE
Change CLI flag and Gradle name for proxy options

### DIFF
--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -841,12 +841,12 @@ When determining proxy settings, Pkl will look at the following locations, in or
 1. OS settings (on macOS, Windows, and GNOME environments)
 2. <<settings-file,Settings file>>
 3. xref:language-reference:index.adoc#projects[PklProject file]
-4. `--proxy` and `--no-proxy` CLI flags
+4. `--http-proxy` and `--http-no-proxy` CLI flags
 
 [NOTE]
 ====
 The proxy and noproxy values are individually set.
-For example, using the `--no-proxy` flag but not the `--proxy` flag will cause Pkl to look at the PklProject file, then the settings file, then system settings for the proxy address.
+For example, using the `--http-no-proxy` flag but not the `--http-proxy` flag will cause Pkl to look at the PklProject file, then the settings file, then system settings for the proxy address.
 
 One exception to this rule is that setting a proxy address will cause Pkl to ignore any noproxy values set at the OS level.
 ====
@@ -858,10 +858,10 @@ When specifying a proxy address, it must have scheme `http`, and may not contain
 
 === Proxy exclusions
 
-Pkl can be configured to bypass the proxy for specific requests via a proxy exclusion rule (i.e. the `--no-proxy` flag).
+Pkl can be configured to bypass the proxy for specific requests via a proxy exclusion rule (i.e. the `--http-no-proxy` flag).
 It may be provided either as a hostname, an IP address, or an IP range via https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation[CIDR notation].
 When determining whether a proxy should be excluded, hostnames do not get resolved to their IP address.
-For example, a request to `localhost` will not match `--no-proxy=127.0.0.1`.
+For example, a request to `localhost` will not match `--http-no-proxy=127.0.0.1`.
 
 For individual hosts (not CIDRs), ports can be specified.
 When no port is specified for a given host, connections to all ports bypass the proxy.

--- a/docs/modules/pkl-cli/partials/cli-common-options.adoc
+++ b/docs/modules/pkl-cli/partials/cli-common-options.adoc
@@ -123,7 +123,7 @@ Certificates need to be X.509 certificates in PEM format.
 For other methods of configuring certificates, see xref:pkl-cli:index.adoc#ca-certs[CA Certificates].
 ====
 
-.--proxy
+.--http-proxy
 [%collapsible]
 ====
 Default: (none) +
@@ -132,7 +132,7 @@ Configures HTTP connections to connect to the provided proxy address.
 The URI must have scheme `http`, and may not contain anything other than a host and port.
 ====
 
-.--no-proxy
+.--http-no-proxy
 [%collapsible]
 ====
 Default: (none) +

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
@@ -1276,7 +1276,7 @@ result = someLib.x
       CliEvaluatorOptions(
         CliBaseOptions(
           sourceModules = listOf(URI("http://not.a.valid.host/bar.pkl")),
-          proxyAddress = URI("http://localhost:${wwRuntimeInfo.httpPort}"),
+          httpProxy = URI("http://localhost:${wwRuntimeInfo.httpPort}"),
           allowedModules = SecurityManagers.defaultAllowedModules + Pattern.compile("http:"),
         ),
       )
@@ -1295,8 +1295,8 @@ result = someLib.x
         CliBaseOptions(
           // use loopback address to prevent test from making outbound http connection.
           sourceModules = listOf(URI("$targetAddress/foo.pkl")),
-          proxyAddress = URI(wwRuntimeInfo.httpBaseUrl),
-          noProxy = listOf("*"),
+          httpProxy = URI(wwRuntimeInfo.httpBaseUrl),
+          httpNoProxy = listOf("*"),
           allowedModules = SecurityManagers.defaultAllowedModules + Pattern.compile("http:"),
         )
       )
@@ -1315,7 +1315,7 @@ result = someLib.x
         CliBaseOptions(
           sourceModules = listOf(URI("package://localhost:1/birds@0.5.0#/catalog/Ostritch.pkl")),
           noCache = true,
-          proxyAddress = URI(wwRuntimeInfo.httpBaseUrl),
+          httpProxy = URI(wwRuntimeInfo.httpBaseUrl),
           caCertificates = listOf(FileTestUtils.selfSignedCertificate),
           allowedModules = SecurityManagers.defaultAllowedModules + Pattern.compile("http:")
         )

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
@@ -130,10 +130,10 @@ data class CliBaseOptions(
   val caCertificates: List<Path> = listOf(),
 
   /** The proxy to connect to. */
-  val proxyAddress: URI? = null,
+  val httpProxy: URI? = null,
 
   /** Hostnames, IP addresses, or CIDR blocks to not proxy. */
-  val noProxy: List<String>? = null,
+  val httpNoProxy: List<String>? = null,
 ) {
 
   companion object {

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -160,12 +160,12 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
   }
 
   private val proxyAddress by lazy {
-    cliOptions.proxyAddress
+    cliOptions.httpProxy
       ?: project?.evaluatorSettings?.http?.proxy?.address ?: settings.http?.proxy?.address
   }
 
   private val noProxy by lazy {
-    cliOptions.noProxy
+    cliOptions.httpNoProxy
       ?: project?.evaluatorSettings?.http?.proxy?.noProxy ?: settings.http?.proxy?.noProxy
   }
 

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -175,7 +175,7 @@ class BaseOptions : OptionGroup() {
   @Suppress("HttpUrlsUsage")
   val proxy: URI? by
     option(
-        names = arrayOf("--proxy"),
+        names = arrayOf("--http-proxy"),
         metavar = "<address>",
         help = "Proxy to use for HTTP(S) connections."
       )
@@ -191,7 +191,7 @@ class BaseOptions : OptionGroup() {
 
   val noProxy: List<String>? by
     option(
-        names = arrayOf("--no-proxy"),
+        names = arrayOf("--http-no-proxy"),
         metavar = "<pattern1,pattern2>",
         help = "Hostnames that should not be connected to via a proxy."
       )
@@ -229,8 +229,8 @@ class BaseOptions : OptionGroup() {
       omitProjectSettings = projectOptions?.omitProjectSettings ?: false,
       noProject = projectOptions?.noProject ?: false,
       caCertificates = caCertificates,
-      proxyAddress = proxy,
-      noProxy = noProxy ?: emptyList()
+      httpProxy = proxy,
+      httpNoProxy = noProxy ?: emptyList()
     )
   }
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -282,7 +282,7 @@ public class PklPlugin implements Plugin<Project> {
 
     spec.getTestPort().convention(-1);
 
-    spec.getNoProxy().convention(List.of());
+    spec.getHttpNoProxy().convention(List.of());
   }
 
   private void configureCodeGenSpec(CodeGenSpec spec) {
@@ -427,8 +427,8 @@ public class PklPlugin implements Plugin<Project> {
     task.getModuleCacheDir().set(spec.getModuleCacheDir());
     task.getEvalTimeout().set(spec.getEvalTimeout());
     task.getTestPort().set(spec.getTestPort());
-    task.getProxyAddress().set(spec.getProxyAddress());
-    task.getNoProxy().set(spec.getNoProxy());
+    task.getHttpProxy().set(spec.getHttpProxy());
+    task.getHttpNoProxy().set(spec.getHttpNoProxy());
   }
 
   private <T extends ModulesTask, S extends ModulesSpec> void configureModulesTask(T task, S spec) {

--- a/pkl-gradle/src/main/java/org/pkl/gradle/spec/BasePklSpec.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/spec/BasePklSpec.java
@@ -52,7 +52,7 @@ public interface BasePklSpec {
 
   Property<Integer> getTestPort();
 
-  Property<URI> getProxyAddress();
+  Property<URI> getHttpProxy();
 
-  ListProperty<String> getNoProxy();
+  ListProperty<String> getHttpNoProxy();
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
@@ -127,11 +127,11 @@ public abstract class BasePklTask extends DefaultTask {
 
   @Input
   @Optional
-  public abstract Property<URI> getProxyAddress();
+  public abstract Property<URI> getHttpProxy();
 
   @Input
   @Optional
-  public abstract ListProperty<String> getNoProxy();
+  public abstract ListProperty<String> getHttpNoProxy();
 
   @TaskAction
   public void runTask() {
@@ -165,8 +165,8 @@ public abstract class BasePklTask extends DefaultTask {
               false,
               getTestPort().getOrElse(-1),
               Collections.emptyList(),
-              getProxyAddress().getOrNull(),
-              getNoProxy().getOrElse(List.of()));
+              getHttpProxy().getOrNull(),
+              getHttpNoProxy().getOrElse(List.of()));
     }
     return cachedOptions;
   }


### PR DESCRIPTION
Rationale: "proxy" can mean very different things (e.g. [Proxy](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Proxy.html) in Java). This makes the flag name more specific.

CLI:
* `--proxy` -> `--http-proxy`
* `--no-proxy` -> `--http-no-proxy`

Gradle:
* `proxyAddress` -> `httpProxy`
* `noProxy` -> `httpNoProxy`