### PR TITLE
Catch PklException errors coming from project load

### DIFF
--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -39,9 +39,8 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
       IoUtils.setTestMode()
     }
 
-    proxyAddress?.let(IoUtils::setSystemProxy)
-
     try {
+      proxyAddress?.let(IoUtils::setSystemProxy)
       doRun()
     } catch (e: PklException) {
       throw CliException(e.message!!)
@@ -160,13 +159,15 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
     )
   }
 
-  private val proxyAddress =
+  private val proxyAddress by lazy {
     cliOptions.proxyAddress
       ?: project?.evaluatorSettings?.http?.proxy?.address ?: settings.http?.proxy?.address
+  }
 
-  private val noProxy =
+  private val noProxy by lazy {
     cliOptions.noProxy
       ?: project?.evaluatorSettings?.http?.proxy?.noProxy ?: settings.http?.proxy?.noProxy
+  }
 
   private fun HttpClient.Builder.addDefaultCliCertificates() {
     val caCertsDir = IoUtils.getPklHomeDir().resolve("cacerts")


### PR DESCRIPTION
This fixes an issue where an error coming from loading a project file is shown as a PklBugException.

There were two problems here:
1. `proxyAddress` needs to be a lazy value, because it can try to load a PklProject
2. accessing `proxyAddress` can throw a `PklException`, so it needs to be within the try/catch
