### PR TITLE
Pass `HOMEBREW_*` environment variables on through `native_image`

### DIFF
--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -241,6 +241,8 @@ fun Exec.configureExecutable(
       val processors = Runtime.getRuntime().availableProcessors() /
         if (buildInfo.os.isMacOsX && !buildInfo.isCiBuild) 4 else 1
       add("-J-XX:ActiveProcessorCount=${processors}")
+      // Pass through all `HOMEBREW_` prefixed environment variables to allow build with shimmed tools.
+      addAll(environment.keys.filter { it.startsWith("HOMEBREW_") }.map { "-E$it" })
       addAll(extraArgs)
     }
   })


### PR DESCRIPTION
We currently have to use `NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION` to let builds pass in Homebrew. This is because `native-image` runs its child processes (such as the platform-dependent C compiler) in a "clean" environment. In Homebrew, such compilers (`clang`, `gcc`, etc) are wrapper scripts that first check the Homebrew environment is intact.

GraalVM folks have warned that `NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION` will go away.

This PR preserves all environment variables starting with `HOMEBREW_` for the inner `native-image` environment.