### PR TITLE
Use compatible architecture in native executables

### DIFF
--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -232,6 +232,7 @@ fun Exec.configureExecutable(
       if (!buildInfo.isReleaseBuild) {
         add("-Ob")
       }
+      add("-march=compatibility")
       // native-image rejects non-existing class path entries -> filter
       add("--class-path")
       val pathInput = sourceSets.main.get().output + configurations.runtimeClasspath.get()
@@ -318,7 +319,7 @@ val windowsExecutableAmd64: TaskProvider<Exec> by tasks.registering(Exec::class)
   configureExecutable(
     buildInfo.graalVmAmd64,
     layout.buildDirectory.file("executable/pkl-windows-amd64"),
-    listOf("-Dfile.encoding=UTF-8", "-march=compatibility")
+    listOf("-Dfile.encoding=UTF-8")
   )
 }
 


### PR DESCRIPTION
Use the most compatible architecture; for example, x86-64 instead of x86-64-v3.