### PR TITLE
Only run Gradle compatibility tests against releases in CI

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -132,8 +132,7 @@ jobs {
     name = "gradle compatibility"
     command = #"""
       :pkl-gradle:build \
-        :pkl-gradle:compatibilityTestReleases \
-        :pkl-gradle:compatibilityTestCandidate
+        :pkl-gradle:compatibilityTestReleases
       """#
   }.job
   ["deploy-snapshot"] = new DeployJob { command = "publishToSonatype" }.job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -610,8 +610,7 @@ jobs:
     - run:
         command: |-
           ./gradlew --info --stacktrace -DtestReportsDir=${HOME}/test-results :pkl-gradle:build \
-            :pkl-gradle:compatibilityTestReleases \
-            :pkl-gradle:compatibilityTestCandidate
+            :pkl-gradle:compatibilityTestReleases
         name: gradle compatibility
     - store_test_results:
         path: ~/test-results


### PR DESCRIPTION
This fixes our CI tests on main. It mitigates an issue where the current RC is borked right now (see https://github.com/gradle/gradle/issues/29696)