### PR TITLE
Add CSS to make top doc box have a fade, rather than hard cutoff

### DIFF
--- a/pkl-doc/src/main/resources/org/pkl/doc/styles/pkldoc.css
+++ b/pkl-doc/src/main/resources/org/pkl/doc/styles/pkldoc.css
@@ -518,6 +518,20 @@ because the entire .member.with-page-link is effectively a link (via JS).
   display: none;
 }
 
+#_declaration .expandable {
+  transform: none;
+  transition: none;
+}
+
+#_declaration .expandable.collapsed {
+  mask: linear-gradient(rgb(0 0 0), transparent) content-box;
+  height: 100px;
+}
+
+#_declaration .expandable.hidden {
+  display: block;
+}
+
 /* show an otherwise hidden inherited member if it's a link target */
 .anchor:target + .expandable.collapsed.hidden {
   display: inherit;

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/styles/pkldoc.css
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/styles/pkldoc.css
@@ -518,6 +518,20 @@ because the entire .member.with-page-link is effectively a link (via JS).
   display: none;
 }
 
+#_declaration .expandable {
+  transform: none;
+  transition: none;
+}
+
+#_declaration .expandable.collapsed {
+  mask: linear-gradient(rgb(0 0 0), transparent) content-box;
+  height: 100px;
+}
+
+#_declaration .expandable.hidden {
+  display: block;
+}
+
 /* show an otherwise hidden inherited member if it's a link target */
 .anchor:target + .expandable.collapsed.hidden {
   display: inherit;


### PR DESCRIPTION
The current hard cutoff in the docs often results in people not realising that the doc box can be expanded, and often resulting in confusion because the most helpful examples are often in the module doc box.

This change uses some simple CSS tweaks to replace the hard cut-off with a visualfade, so it's obvious that there's content hidden out of view. Doing this required removing the CSS transition, as it hard to correctly transition the height property of CSS element of unknown target height. But the improved discoverablility of the doc content seems like a worthwhile tradeoff.

Before:
<img width="1231" alt="image" src="https://github.com/apple/pkl/assets/782311/2e0d60c1-89b8-4fc2-8e4e-ad25a7858512">

After:
<img width="1222" alt="image" src="https://github.com/apple/pkl/assets/782311/4d036327-56b4-4ca1-9c73-2ee47cd37263">
