### PR TITLE
Add a --color flag to the CLI and disable colors for Pkl test

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/commands/TestCommand.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/commands/TestCommand.kt
@@ -39,7 +39,7 @@ class TestCommand(helpLink: String) :
 
   override fun run() {
     CliTestRunner(
-        options = baseOptions.baseOptions(modules, projectOptions),
+        options = baseOptions.baseOptions(modules, projectOptions, disableColors = true),
         testOptions = testOptions.cliTestOptions
       )
       .run()

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
@@ -134,6 +134,7 @@ data class CliBaseOptions(
 
   /** Hostnames, IP addresses, or CIDR blocks to not proxy. */
   val httpNoProxy: List<String>? = null,
+  val colors: String = "auto"
 ) {
 
   companion object {

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -19,6 +19,9 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.regex.Pattern
 import kotlin.io.path.isRegularFile
+import org.fusesource.jansi.Ansi
+import org.fusesource.jansi.AnsiConsole
+import org.fusesource.jansi.AnsiMode
 import org.pkl.core.*
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings
 import org.pkl.core.http.HttpClient
@@ -37,6 +40,20 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
   fun run() {
     if (cliOptions.testMode) {
       IoUtils.setTestMode()
+    }
+    when (cliOptions.colors) {
+      "never" -> {
+        // Configure Jansi to not even inject Ansi codes
+        System.setProperty(Ansi.DISABLE, "true")
+
+        // But also strip anything that might end up in the output
+        AnsiConsole.err().mode = AnsiMode.Strip
+        AnsiConsole.out().mode = AnsiMode.Strip
+      }
+      "always" -> {
+        AnsiConsole.err().mode = AnsiMode.Force
+        AnsiConsole.out().mode = AnsiMode.Force
+      }
     }
 
     try {

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -17,6 +17,7 @@ package org.pkl.commons.cli.commands
 
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.options.*
+import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.long
 import com.github.ajalt.clikt.parameters.types.path
@@ -198,6 +199,11 @@ class BaseOptions : OptionGroup() {
       .single()
       .split(",")
 
+  val colors: String by
+    option(names = arrayOf("--colors"), help = "Enable or disable colour output in the terminal")
+      .choice("auto", "never", "always")
+      .default("auto")
+
   // hidden option used by native tests
   private val testPort: Int by
     option(names = arrayOf("--test-port"), help = "Internal test option", hidden = true)
@@ -208,7 +214,8 @@ class BaseOptions : OptionGroup() {
   fun baseOptions(
     modules: List<URI>,
     projectOptions: ProjectOptions? = null,
-    testMode: Boolean = false
+    testMode: Boolean = false,
+    disableColors: Boolean = false,
   ): CliBaseOptions {
     return CliBaseOptions(
       sourceModules = modules,
@@ -230,7 +237,8 @@ class BaseOptions : OptionGroup() {
       noProject = projectOptions?.noProject ?: false,
       caCertificates = caCertificates,
       httpProxy = proxy,
-      httpNoProxy = noProxy ?: emptyList()
+      httpNoProxy = noProxy ?: emptyList(),
+      colors = if (disableColors) "never" else colors,
     )
   }
 }

--- a/pkl-commons-test/src/main/kotlin/org/pkl/commons/test/InputOutputTestEngine.kt
+++ b/pkl-commons-test/src/main/kotlin/org/pkl/commons/test/InputOutputTestEngine.kt
@@ -162,7 +162,6 @@ abstract class InputOutputTestEngine :
       context: ExecutionContext,
       dynamicTestExecutor: DynamicTestExecutor
     ): ExecutionContext {
-
       val (success, actualOutput) = generateOutputFor(inputFile)
       val expectedOutputFile = expectedOutputFileFor(inputFile)
 

--- a/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt
@@ -219,6 +219,7 @@ abstract class AbstractNativeLanguageSnippetTestsEngine : AbstractLanguageSnippe
       add(pklExecutablePath.toString())
       add("eval")
       add("--no-cache")
+      add("--colors=never")
       if (inputFile.startsWith(projectsDir)) {
         val projectDir = inputFile.getProjectDir()
         if (projectDir != null) {

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
@@ -166,7 +166,8 @@ public abstract class BasePklTask extends DefaultTask {
               getTestPort().getOrElse(-1),
               Collections.emptyList(),
               getHttpProxy().getOrNull(),
-              getHttpNoProxy().getOrElse(List.of()));
+              getHttpNoProxy().getOrElse(List.of()),
+              "auto");
     }
     return cachedOptions;
   }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
@@ -180,7 +180,8 @@ public abstract class ModulesTask extends BasePklTask {
               getTestPort().getOrElse(-1),
               Collections.emptyList(),
               null,
-              List.of());
+              List.of(),
+              "auto");
     }
     return cachedOptions;
   }


### PR DESCRIPTION
The --colors flag makes it possible to forcefully disable colour output, and also forcefully enable it. We make use of this in the native Pkl test engines by passing --colors=never into the pkl commands, which ensures we get a predictable output.

Additionally the pkl test command also sets --colors=never to ensure that pkl test output isn't accidentially contaminated with ansi escape chars, which will break example based tests.