### PR TITLE
Fix default value evaluation in toTyped()

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/member/DelegateToExtraStorageMapOrParentNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/DelegateToExtraStorageMapOrParentNode.java
@@ -19,12 +19,14 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import org.pkl.core.ast.ExpressionNode;
 import org.pkl.core.runtime.Identifier;
 import org.pkl.core.runtime.VmMap;
+import org.pkl.core.runtime.VmObjectLike;
 import org.pkl.core.runtime.VmUtils;
 
 /** Delegates to the equally named key of the map stored in extra storage. */
 public final class DelegateToExtraStorageMapOrParentNode extends ExpressionNode {
   @Override
   public Object executeGeneric(VirtualFrame frame) {
+    var receiver = (VmObjectLike) VmUtils.getReceiver(frame);
     var owner = VmUtils.getOwner(frame);
     var delegate = (VmMap) owner.getExtraStorage();
     var memberKey = VmUtils.getMemberKey(frame);
@@ -33,6 +35,6 @@ public final class DelegateToExtraStorageMapOrParentNode extends ExpressionNode 
     if (result != null) return result;
     var parent = owner.getParent();
     assert parent != null;
-    return VmUtils.readMember(parent, memberKey);
+    return VmUtils.readMember(receiver, parent, memberKey);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/DelegateToExtraStorageObjOrParentNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/DelegateToExtraStorageObjOrParentNode.java
@@ -27,6 +27,7 @@ import org.pkl.core.runtime.VmUtils;
 public final class DelegateToExtraStorageObjOrParentNode extends ExpressionNode {
   @Override
   public Object executeGeneric(VirtualFrame frame) {
+    var receiver = (VmObjectLike) VmUtils.getReceiver(frame);
     var owner = VmUtils.getOwner(frame);
     var delegate = (VmObjectLike) owner.getExtraStorage();
     var memberKey = VmUtils.getMemberKey(frame);
@@ -34,6 +35,6 @@ public final class DelegateToExtraStorageObjOrParentNode extends ExpressionNode 
     if (result != null) return result;
     var parent = owner.getParent();
     assert parent != null;
-    return VmUtils.readMember(parent, memberKey);
+    return VmUtils.readMember(receiver, parent, memberKey);
   }
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/toTypedWithDefault.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/toTypedWithDefault.pkl
@@ -1,0 +1,25 @@
+amends "../snippetTest.pkl"
+
+examples {
+  ["toTyped()"] {
+    pigeonDyn.toTyped(Person)
+    pigeonMap.toTyped(Person)
+  }
+  
+  ["toTyped() and amends"] {
+    (pigeonDyn.toTyped(Person)) { name = "NewPigeon"}
+    (pigeonMap.toTyped(Person)) { name = "NewPigeon"}
+  }
+}
+
+local class Person {
+  name: String = "Default"
+  nick = name
+}
+
+local pigeonDyn = new Dynamic {
+  local n = "Pigeon"
+  name = n
+}
+
+local pigeonMap = Map("name", "Pigeon")

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/toTypedWithDefault.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/toTypedWithDefault.pcf
@@ -1,0 +1,22 @@
+examples {
+  ["toTyped()"] {
+    new {
+      name = "Pigeon"
+      nick = "Pigeon"
+    }
+    new {
+      name = "Pigeon"
+      nick = "Pigeon"
+    }
+  }
+  ["toTyped() and amends"] {
+    new {
+      name = "NewPigeon"
+      nick = "NewPigeon"
+    }
+    new {
+      name = "NewPigeon"
+      nick = "NewPigeon"
+    }
+  }
+}


### PR DESCRIPTION
Fix the issue where default values defined in the class are not properly
generated when converting Dynamic or Map objects to Typed objects.
Also, fix the issue where values are not properly generated for amended
properties when making amends to the converted Typed objects.