### PR TITLE
Allow to `String#toInt()` to parse a string including "__"

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/StringNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/StringNodes.java
@@ -768,7 +768,7 @@ public final class StringNodes {
     @Specialization
     protected long eval(String self) {
       try {
-        return Long.parseLong(self);
+        return Long.parseLong(self.replaceAll("_", ""));
       } catch (NumberFormatException e) {
         throw exceptionBuilder()
             .evalError("cannotParseStringAs", "Int")
@@ -783,7 +783,7 @@ public final class StringNodes {
     @Specialization
     protected Object eval(String self) {
       try {
-        return Long.parseLong(self);
+        return Long.parseLong(self.replaceAll("_", ""));
       } catch (NumberFormatException e) {
         return VmNull.withoutDefault();
       }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/string.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/string.pkl
@@ -225,6 +225,8 @@ examples {
   ["toInt()"] {
     "123".toInt()
     "-123".toInt()
+    "1_2__3___".toInt()
+    "-1_2__3___".toInt()
     "0".toInt()
     "-0".toInt()
     module.catch(() -> "1.2".toInt())
@@ -236,6 +238,8 @@ examples {
   ["toIntOrNull()"] {
     "123".toIntOrNull()
     "-123".toIntOrNull()
+    "1_2__3___".toInt()
+    "-1_2__3___".toInt()
     "0".toIntOrNull()
     "-0".toIntOrNull()
     "1.2".toIntOrNull()
@@ -445,7 +449,7 @@ examples {
     "".sha256
     quickBrownFox.sha256
   }
-  
+
   ["sha256Int"] {
     "".sha256Int
     quickBrownFox.sha256Int
@@ -460,7 +464,7 @@ examples {
     "".base64
     quickBrownFox.base64
   }
-  
+
   ["base64Decoded"] {
     module.catch(() -> "~~~".base64Decoded)
   }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/string.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/string.pcf
@@ -183,6 +183,8 @@ examples {
   ["toInt()"] {
     123
     -123
+    123
+    -123
     0
     0
     "Cannot parse string as `Int`. String: \"1.2\""
@@ -191,6 +193,8 @@ examples {
     "Cannot parse string as `Int`. String: \"abc\""
   }
   ["toIntOrNull()"] {
+    123
+    -123
     123
     -123
     0


### PR DESCRIPTION
A Int literal can include sequence of "_" like below.

```pkl
a = 1_2__3___
```

However, `String#toInt()` method cannot parse such string.

```pkl
a = "1_2__3__".toInt()
```
![image](https://github.com/user-attachments/assets/05819ba3-a623-44ea-9e5d-0744064a2ac3)

This PR is to fix this issue.

Refs: https://github.com/apple/pkl/discussions/577#discussion-6927552