### PR TITLE
Fix property parsing bug in the cli

### DIFF
--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -65,16 +65,14 @@ class BaseOptions : OptionGroup() {
           }
       }
 
-    fun RawOption.splitProps(): NullableOption<Pair<String, String>, Pair<String, String>> {
-      return convert {
-        val parts = it.split("=")
-        if (parts.size <= 1) parts[0] to "true" else parts[0] to parts[1]
-      }
-    }
-
     fun RawOption.associateProps():
       OptionWithValues<Map<String, String>, Pair<String, String>, Pair<String, String>> {
-      return splitProps().multiple().toMap()
+      return convert {
+          val parts = it.split("=")
+          if (parts.size <= 1) parts[0] to "true" else parts[0] to parts[1]
+        }
+        .multiple()
+        .toMap()
     }
   }
 

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -64,6 +64,18 @@ class BaseOptions : OptionGroup() {
             throw CliException(message)
           }
       }
+
+    fun RawOption.splitProps(): NullableOption<Pair<String, String>, Pair<String, String>> {
+      return convert {
+        val parts = it.split("=")
+        if (parts.size <= 1) parts[0] to "true" else parts[0] to parts[1]
+      }
+    }
+
+    fun RawOption.associateProps():
+      OptionWithValues<Map<String, String>, Pair<String, String>, Pair<String, String>> {
+      return splitProps().multiple().toMap()
+    }
   }
 
   private val defaults = CliBaseOptions()
@@ -116,7 +128,7 @@ class BaseOptions : OptionGroup() {
         metavar = "<name=value>",
         help = "External property to set (repeatable)."
       )
-      .associate()
+      .associateProps()
 
   val noCache: Boolean by
     option(names = arrayOf("--no-cache"), help = "Disable caching of packages")
@@ -214,7 +226,7 @@ class BaseOptions : OptionGroup() {
       allowedModules = allowedModules.ifEmpty { null },
       allowedResources = allowedResources.ifEmpty { null },
       environmentVariables = envVars.ifEmpty { null },
-      externalProperties = properties.mapValues { it.value.ifBlank { "true" } }.ifEmpty { null },
+      externalProperties = properties.ifEmpty { null },
       modulePath = modulePath.ifEmpty { null },
       workingDir = workingDir,
       settings = settings,

--- a/pkl-commons-cli/src/test/kotlin/org/pkl/commons/cli/BaseCommandTest.kt
+++ b/pkl-commons-cli/src/test/kotlin/org/pkl/commons/cli/BaseCommandTest.kt
@@ -45,10 +45,10 @@ class BaseCommandTest {
 
   @Test
   fun `external properties without value default to 'true'`() {
-    cmd.parse(arrayOf("-p", "flag1", "-p", "flag2", "-p", "FOO=bar"))
+    cmd.parse(arrayOf("-p", "flag1", "-p", "flag2=", "-p", "FOO=bar"))
     val props = cmd.baseOptions.baseOptions(emptyList()).externalProperties
 
-    assertThat(props).isEqualTo(mapOf("flag1" to "true", "flag2" to "true", "FOO" to "bar"))
+    assertThat(props).isEqualTo(mapOf("flag1" to "true", "flag2" to "", "FOO" to "bar"))
   }
 
   @Test


### PR DESCRIPTION
This fixes a bug where a property set as `-p foo=` would be parsed as `"true"` instead of `""`.