### PR TITLE
Separate the cache check and member lookup into different methods

### DIFF
--- a/bench/bench.gradle.kts
+++ b/bench/bench.gradle.kts
@@ -30,6 +30,10 @@ dependencies {
   jmh(libs.antlrRuntime)
   truffle(libs.truffleApi)
   graal(libs.graalCompiler)
+
+  implementation(libs.truffleApi)
+  implementation(libs.graalSdk)
+  compileOnly(libs.jsr305)
 }
 
 jmh {

--- a/bench/gradle.lockfile
+++ b/bench/gradle.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.google.code.findbugs:jsr305:3.0.2=compileClasspath,compileOnlyDependenciesMetadata,jmhCompileClasspath
 com.tunnelvisionlabs:antlr4-runtime:4.9.0=jmh,jmhCompileClasspath,jmhImplementationDependenciesMetadata,jmhRuntimeClasspath
 net.bytebuddy:byte-buddy:1.14.16=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 net.java.dev.jna:jna:5.6.0=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
@@ -9,8 +10,8 @@ org.apache.commons:commons-math3:3.6.1=jmh,jmhCompileClasspath,jmhImplementation
 org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeOnlyDependenciesMetadata
 org.assertj:assertj-core:3.26.0=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 org.graalvm.compiler:compiler:23.0.2=graal
-org.graalvm.sdk:graal-sdk:23.0.2=graal,jmh,jmhRuntimeClasspath,truffle
-org.graalvm.truffle:truffle-api:23.0.2=graal,jmh,jmhRuntimeClasspath,truffle
+org.graalvm.sdk:graal-sdk:23.0.2=compileClasspath,graal,implementationDependenciesMetadata,jmh,jmhCompileClasspath,jmhRuntimeClasspath,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath,truffle
+org.graalvm.truffle:truffle-api:23.0.2=compileClasspath,graal,implementationDependenciesMetadata,jmh,jmhCompileClasspath,jmhRuntimeClasspath,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath,truffle
 org.jetbrains.intellij.deps:trove4j:1.0.20200330=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
 org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
 org.jetbrains.kotlin:kotlin-daemon-embeddable:1.7.10=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath

--- a/bench/src/jmh/java/org/pkl/core/runtime/VmUtilsBenchmarks.java
+++ b/bench/src/jmh/java/org/pkl/core/runtime/VmUtilsBenchmarks.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.runtime;
+
+import com.oracle.truffle.api.nodes.IndirectCallNode;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+@SuppressWarnings("unused")
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 2)
+public class VmUtilsBenchmarks {
+  private VmObjectLike receiver;
+  private Object memberKey;
+  private IndirectCallNode callNode;
+
+  @Setup
+  public void setup() {
+    receiver = VmDynamic.empty();
+    memberKey = "testMember";
+    callNode = IndirectCallNode.create();
+  }
+
+  @Benchmark
+  public void readMemberOrNullCacheHit(Blackhole blackhole) {
+    Object result = VmUtils.readMemberOrNull(receiver, memberKey, true, callNode);
+    blackhole.consume(result);
+  }
+
+  @Benchmark
+  public void readMemberOrNullCacheMiss(Blackhole blackhole) {
+    Object result = VmUtils.readMemberOrNull(receiver, "nonExistentMember", true, callNode);
+    blackhole.consume(result);
+  }
+}

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmUtils.java
@@ -236,9 +236,20 @@ public final class VmUtils {
     assert (!(memberKey instanceof Identifier identifier) || !identifier.isLocalProp())
         : "Must use ReadLocalPropertyNode for local properties.";
 
-    final var cachedValue = receiver.getCachedValue(memberKey);
+    final var cachedValue = getCachedValue(receiver, memberKey);
     if (cachedValue != null) return cachedValue;
 
+    return lookupMember(receiver, memberKey, checkType, callNode);
+  }
+
+  @TruffleBoundary
+  private static @Nullable Object getCachedValue(VmObjectLike receiver, Object memberKey) {
+    return receiver.getCachedValue(memberKey);
+  }
+
+  @TruffleBoundary
+  private static @Nullable Object lookupMember(
+      VmObjectLike receiver, Object memberKey, boolean checkType, IndirectCallNode callNode) {
     for (var owner = receiver; owner != null; owner = owner.getParent()) {
       var member = owner.getMember(memberKey);
       if (member == null) continue;


### PR DESCRIPTION
This allows for better inlining and optimization of the cache check, which is a common path.

Original results
----------------

```
Benchmark                                    Mode  Cnt   Score   Error  Units
VmUtilsBenchmarks.readMemberOrNullCacheHit   avgt    5  18.906 ± 0.726  ns/op
VmUtilsBenchmarks.readMemberOrNullCacheMiss  avgt    5  15.274 ± 0.149  ns/op
```

This change results
-------------------

```
Benchmark                                    Mode  Cnt   Score   Error  Units
VmUtilsBenchmarks.readMemberOrNullCacheHit   avgt    5  16.819 ± 0.837  ns/op
VmUtilsBenchmarks.readMemberOrNullCacheMiss  avgt    5  15.710 ± 0.906  ns/op
```