### PR TITLE
Fix: make Gradle tests compatible with Gradle 8.1

### DIFF
--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/EvaluatorsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/EvaluatorsTest.kt
@@ -569,9 +569,9 @@ class EvaluatorsTest : AbstractTest() {
       pkl {
         evaluators {
           register("doEval") {
-            sourceModules = files("file1.pkl", "file2.pkl")
-            outputFile = layout.projectDirectory.file("%{moduleName}.%{outputFormat}")
-            outputFormat = "yaml"
+            sourceModules.set(files("file1.pkl", "file2.pkl"))
+            outputFile.set(layout.projectDirectory.file("%{moduleName}.%{outputFormat}"))
+            outputFormat.set("yaml")
           }
         }
       }


### PR DESCRIPTION
The tests were using [simple Kotlin DSL assignments](https://blog.gradle.org/simpler-kotlin-dsl-property-assignment), a feature only available in Gradle 8.2 and onwards. Thus, they were breaking our tests on Gradle 8.1 (the minimum Gradle version for the pkl-gradle plugin).

Tested locally:

```
gw :pkl-gradle:compatibilityTestReleases
Type-safe project accessors is an incubating feature.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.7/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 8m 24s
95 actionable tasks: 24 executed, 71 up-to-date
```