### PR TITLE
Fix usage of `file()` notation with Pkl Gradle plugin on Windows

### DIFF
--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
@@ -134,6 +134,9 @@ public abstract class ModulesTask extends BasePklTask {
    */
   private URI parsedModuleNotationToUri(Object notation) {
     if (notation instanceof File file) {
+      if (file.isAbsolute()) {
+        return file.toPath().toUri();
+      }
       return IoUtils.createUri(IoUtils.toNormalizedPathString(file.toPath()));
     } else if (notation instanceof URI uri) {
       return uri;


### PR DESCRIPTION
This is a port of a fix that was included in https://github.com/apple/pkl/pull/403.

Note: this is intentionally landing directly in the release/0.26 branch.