### PR TITLE
[docs] Add mention of "optional" to nullable types section

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -3721,6 +3721,7 @@ bird2: Bird? = null // <2>
 The only class types that admit `null` values despite not ending in `?` are `Any` and `Null`.
 (`Null` is not very useful as a type because it _only_ admits `null` values.)
 `Any?` and `Null?` are equivalent to `Any` and `Null`, respectively.
+In some languages, nullable types are also known as _optional types_.
 
 [[generic-types]]
 ==== Generic Types


### PR DESCRIPTION
I've experience a few users missing this section of the documentation because they searched "optional". This terminology is common in other languages (eg. Swift, Python). This adds a sentence to the documentation to ease search-ability.