### PR TITLE
[docs] Correct the link for `ANTLR 4 Documentation` (404 - page not found).

### DIFF
--- a/DEVELOPMENT.adoc
+++ b/DEVELOPMENT.adoc
@@ -83,7 +83,7 @@ For automated build setup examples see our https://github.com/apple/pkl/blob/mai
 
 === ANTLR
 
-* https://github.com/antlr/antlr4/blob/main/doc/index.md[Documentation]
+* https://github.com/antlr/antlr4/blob/master/doc/index.md[Documentation]
 * https://groups.google.com/forum/#!forum/antlr-discussion[Forums]
 * https://github.com/mobileink/lab.clj.antlr/tree/main/doc[Some third-party docs]
 


### PR DESCRIPTION
Correct the link for `ANTLR 4 Documentation` (404 - page not found).