### PR TITLE
[docs] Improve searchability of "Methods" section

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -1992,11 +1992,10 @@ pigeon: ParentBird = new {
 [[methods]]
 == Functions and Methods
 
-Modules and classes can define methods.
-Submodules and subclasses can override them.
+Pkl does not have true functions; anything defined with the keyword `function` is a _method_ on the class or module it is defined in and may access properties of those types.
+When modules and classes define methods, submodules and subclasses can override them.
 
 Like Java and most other object-oriented languages, Pkl uses _single dispatch_ -- methods are dynamically dispatched based on the receiver's runtime type.
-Pkl does not have true functions; all methods are defined in the context of a module or class and may access properties of those types. 
 
 [source%tested,{pkl}]
 ----

--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -1990,10 +1990,10 @@ pigeon: ParentBird = new {
 ----
 
 [[methods]]
-== Functions and Methods
+== Methods
 
-Pkl does not have pure functions; anything defined with the keyword `function` is a _method_ on the class or module it is defined in and may access properties of those types.
-When modules and classes define methods, submodules and subclasses can override them.
+Pkl methods can be defined on classes and modules using the `function` keyword.
+Methods may access properties of their containing type.
 
 Like Java and most other object-oriented languages, Pkl uses _single dispatch_ -- methods are dynamically dispatched based on the receiver's runtime type.
 

--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -1990,12 +1990,13 @@ pigeon: ParentBird = new {
 ----
 
 [[methods]]
-== Methods
+== Functions and Methods
 
 Modules and classes can define methods.
 Submodules and subclasses can override them.
 
 Like Java and most other object-oriented languages, Pkl uses _single dispatch_ -- methods are dynamically dispatched based on the receiver's runtime type.
+Pkl does not have true functions; all methods are defined in the context of a module or class and may access properties of those types. 
 
 [source%tested,{pkl}]
 ----

--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -1992,7 +1992,7 @@ pigeon: ParentBird = new {
 [[methods]]
 == Functions and Methods
 
-Pkl does not have true functions; anything defined with the keyword `function` is a _method_ on the class or module it is defined in and may access properties of those types.
+Pkl does not have pure functions; anything defined with the keyword `function` is a _method_ on the class or module it is defined in and may access properties of those types.
 When modules and classes define methods, submodules and subclasses can override them.
 
 Like Java and most other object-oriented languages, Pkl uses _single dispatch_ -- methods are dynamically dispatched based on the receiver's runtime type.

--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -1994,6 +1994,7 @@ pigeon: ParentBird = new {
 
 Pkl methods can be defined on classes and modules using the `function` keyword.
 Methods may access properties of their containing type.
+Submodules and subclasses can override them.
 
 Like Java and most other object-oriented languages, Pkl uses _single dispatch_ -- methods are dynamically dispatched based on the receiver's runtime type.
 


### PR DESCRIPTION
The primary goal here is to have this section appear first (or at least high) when using the docs search for "function". I'm not fully satisfied with this solution, so open to alternative suggestions.