### PR TITLE
Remove `const` from reserved keywords (remnant)

### DIFF
--- a/pkl-core/src/main/antlr/PklParser.g4
+++ b/pkl-core/src/main/antlr/PklParser.g4
@@ -251,5 +251,4 @@ reservedKeyword
   | 'case'
   | 'switch'
   | 'vararg'
-  | 'const'
   ;


### PR DESCRIPTION
`const` has been implemented and is no longer a "reserved" (for the future) keyword.