### PR TITLE
Fix parsing of external property values containing `=`

### DIFF
--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -68,8 +68,8 @@ class BaseOptions : OptionGroup() {
     fun RawOption.associateProps():
       OptionWithValues<Map<String, String>, Pair<String, String>, Pair<String, String>> {
       return convert {
-          val parts = it.split("=")
-          if (parts.size <= 1) parts[0] to "true" else parts[0] to parts[1]
+          val eq = it.indexOf('=')
+          if (eq == -1) it to "true" else it.substring(0, eq) to it.substring(eq + 1)
         }
         .multiple()
         .toMap()

--- a/pkl-commons-cli/src/test/kotlin/org/pkl/commons/cli/BaseCommandTest.kt
+++ b/pkl-commons-cli/src/test/kotlin/org/pkl/commons/cli/BaseCommandTest.kt
@@ -44,11 +44,12 @@ class BaseCommandTest {
   }
 
   @Test
-  fun `external properties without value default to 'true'`() {
-    cmd.parse(arrayOf("-p", "flag1", "-p", "flag2=", "-p", "FOO=bar"))
+  fun `difficult cases for external properties`() {
+    cmd.parse(arrayOf("-p", "flag1", "-p", "flag2=", "-p", "FOO=bar", "-p", "baz=qux=quux"))
     val props = cmd.baseOptions.baseOptions(emptyList()).externalProperties
 
-    assertThat(props).isEqualTo(mapOf("flag1" to "true", "flag2" to "", "FOO" to "bar"))
+    assertThat(props).isEqualTo(
+      mapOf("flag1" to "true", "flag2" to "", "FOO" to "bar", "baz" to "qux=quux"))
   }
 
   @Test

--- a/pkl-commons-cli/src/test/kotlin/org/pkl/commons/cli/BaseCommandTest.kt
+++ b/pkl-commons-cli/src/test/kotlin/org/pkl/commons/cli/BaseCommandTest.kt
@@ -48,8 +48,8 @@ class BaseCommandTest {
     cmd.parse(arrayOf("-p", "flag1", "-p", "flag2=", "-p", "FOO=bar", "-p", "baz=qux=quux"))
     val props = cmd.baseOptions.baseOptions(emptyList()).externalProperties
 
-    assertThat(props).isEqualTo(
-      mapOf("flag1" to "true", "flag2" to "", "FOO" to "bar", "baz" to "qux=quux"))
+    assertThat(props)
+      .isEqualTo(mapOf("flag1" to "true", "flag2" to "", "FOO" to "bar", "baz" to "qux=quux"))
   }
 
   @Test


### PR DESCRIPTION
Fixes #630 