### PR TITLE
Refactor ResourceReader to support multiple schemes

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/resource/ResourceReader.java
+++ b/pkl-core/src/main/java/org/pkl/core/resource/ResourceReader.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
+import java.util.Set;
 import org.pkl.core.SecurityManagerException;
 import org.pkl.core.runtime.ReaderBase;
 
@@ -31,7 +32,7 @@ import org.pkl.core.runtime.ReaderBase;
  */
 public interface ResourceReader extends ReaderBase {
   /** The URI scheme associated with resources read by this resource reader. */
-  String getUriScheme();
+  Set<String> getUriSchemes();
 
   /**
    * Reads the resource with the given URI. Returns {@code Optional.empty()} if a resource with the

--- a/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaders.java
+++ b/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaders.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.Set;
 import org.pkl.core.SecurityManager;
 import org.pkl.core.SecurityManagerException;
 import org.pkl.core.module.FileResolver;
@@ -141,8 +142,8 @@ public final class ResourceReaders {
     static final ResourceReader INSTANCE = new EnvironmentVariable();
 
     @Override
-    public String getUriScheme() {
-      return "env";
+    public Set<String> getUriSchemes() {
+      return Set.of("env");
     }
 
     @Override
@@ -184,8 +185,8 @@ public final class ResourceReaders {
     static final ResourceReader INSTANCE = new ExternalProperty();
 
     @Override
-    public String getUriScheme() {
-      return "prop";
+    public Set<String> getUriSchemes() {
+      return Set.of("prop");
     }
 
     @Override
@@ -224,8 +225,8 @@ public final class ResourceReaders {
     static final ResourceReader INSTANCE = new FileResource();
 
     @Override
-    public String getUriScheme() {
-      return "file";
+    public Set<String> getUriSchemes() {
+      return Set.of("file");
     }
 
     @Override
@@ -257,8 +258,8 @@ public final class ResourceReaders {
     static final ResourceReader INSTANCE = new HttpResource();
 
     @Override
-    public String getUriScheme() {
-      return "http";
+    public Set<String> getUriSchemes() {
+      return Set.of("http");
     }
 
     @Override
@@ -276,8 +277,8 @@ public final class ResourceReaders {
     static final ResourceReader INSTANCE = new HttpsResource();
 
     @Override
-    public String getUriScheme() {
-      return "https";
+    public Set<String> getUriSchemes() {
+      return Set.of("https");
     }
 
     @Override
@@ -320,8 +321,8 @@ public final class ResourceReaders {
     }
 
     @Override
-    public String getUriScheme() {
-      return "modulepath";
+    public Set<String> getUriSchemes() {
+      return Set.of("modulepath");
     }
 
     @Override
@@ -375,8 +376,8 @@ public final class ResourceReaders {
     }
 
     @Override
-    public String getUriScheme() {
-      return "modulepath";
+    public Set<String> getUriSchemes() {
+      return Set.of("modulepath");
     }
 
     @Override
@@ -421,8 +422,8 @@ public final class ResourceReaders {
     static final PackageResource INSTANCE = new PackageResource();
 
     @Override
-    public String getUriScheme() {
-      return "package";
+    public Set<String> getUriSchemes() {
+      return Set.of("package");
     }
 
     @Override
@@ -477,8 +478,8 @@ public final class ResourceReaders {
     static final ProjectPackageResource INSTANCE = new ProjectPackageResource();
 
     @Override
-    public String getUriScheme() {
-      return "projectpackage";
+    public Set<String> getUriSchemes() {
+      return Set.of("projectpackage");
     }
 
     @Override

--- a/pkl-core/src/test/kotlin/org/pkl/core/resource/TestResourceReader.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/resource/TestResourceReader.kt
@@ -23,7 +23,7 @@ class TestResourceReader : ResourceReader {
 
   override fun isGlobbable(): Boolean = false
 
-  override fun getUriScheme(): String = "test"
+  override fun getUriSchemes(): Set<String> = setOf("test")
 
   override fun read(uri: URI): Optional<Any> = Optional.of("success")
 }

--- a/pkl-server/src/main/kotlin/org/pkl/server/ClientResourceReader.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ClientResourceReader.kt
@@ -41,7 +41,7 @@ internal class ClientResourceReader(
 
   override fun isGlobbable(): Boolean = readerSpec.isGlobbable
 
-  override fun getUriScheme() = readerSpec.scheme
+  override fun getUriSchemes() = setOf(readerSpec.scheme)
 
   override fun read(uri: URI): Optional<Any> = Optional.of(Resource(uri, doRead(uri)))
 


### PR DESCRIPTION
This is preparatory work for [SPICE-0009](https://github.com/apple/pkl-evolution/pull/10). It is being contributed in a separate pull request to ease review.

This is required to allow deferred launch of external reader processes without requiring up-front configuration of scheme->process mappings. More details on why this is required here: https://github.com/apple/pkl-evolution/pull/10#discussion_r1724145677

One concern here (which applies before this change as well) is that the semantics of module key factories and resource readers is reversed. For module key factories, the first factory that answers for a URI scheme "wins", while for resource readers, the _last_ reader that answers for a URI scheme "wins". This PR preserves that behavior, but it may be worth reconsidering this design at this time.

This behavior can be observed in practice in <code>ResourceReadersEvaluatorTest.\`module path\`</code> where `ResourceReaders.modulePath` is added after the pre-configured `ResourceReaders.classPath` and takes precedence.