### PR TITLE
Add ResourceReaderFactory abstraction

### DIFF
--- a/docs/src/test/kotlin/DocSnippetTests.kt
+++ b/docs/src/test/kotlin/DocSnippetTests.kt
@@ -26,6 +26,7 @@ import org.pkl.core.resource.ResourceReaders
 import org.pkl.core.util.IoUtils
 import org.antlr.v4.runtime.ParserRuleContext
 import org.pkl.core.http.HttpClient
+import org.pkl.core.resource.ResourceReaderFactories
 import java.nio.file.Files
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
@@ -87,8 +88,8 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
         ModuleKeyFactories.file
       ),
       listOf(
-        ResourceReaders.environmentVariable(),
-        ResourceReaders.externalProperty()
+        ResourceReaderFactories.environmentVariable(),
+        ResourceReaderFactories.externalProperty()
       ),
       System.getenv(),
       emptyMap(),

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliRepl.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliRepl.kt
@@ -22,7 +22,7 @@ import org.pkl.core.SecurityManagers
 import org.pkl.core.module.ModuleKeyFactories
 import org.pkl.core.module.ModulePathResolver
 import org.pkl.core.repl.ReplServer
-import org.pkl.core.resource.ResourceReaders
+import org.pkl.core.resource.ResourceReaderFactories
 
 internal class CliRepl(private val options: CliEvaluatorOptions) : CliCommand(options.base) {
   override fun doRun() {
@@ -51,14 +51,14 @@ internal class CliRepl(private val options: CliEvaluatorOptions) : CliCommand(op
               ModuleKeyFactories.genericUrl
             ),
           listOf(
-            ResourceReaders.environmentVariable(),
-            ResourceReaders.externalProperty(),
-            ResourceReaders.modulePath(modulePathResolver),
-            ResourceReaders.file(),
-            ResourceReaders.http(),
-            ResourceReaders.https(),
-            ResourceReaders.pkg(),
-            ResourceReaders.projectpackage()
+            ResourceReaderFactories.environmentVariable(),
+            ResourceReaderFactories.externalProperty(),
+            ResourceReaderFactories.modulePath(modulePathResolver),
+            ResourceReaderFactories.file(),
+            ResourceReaderFactories.http(),
+            ResourceReaderFactories.https(),
+            ResourceReaderFactories.pkg(),
+            ResourceReaderFactories.projectpackage()
           ),
           environmentVariables,
           externalProperties,

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -26,8 +26,8 @@ import org.pkl.core.module.ModuleKeyFactories
 import org.pkl.core.module.ModuleKeyFactory
 import org.pkl.core.module.ModulePathResolver
 import org.pkl.core.project.Project
-import org.pkl.core.resource.ResourceReader
-import org.pkl.core.resource.ResourceReaders
+import org.pkl.core.resource.ResourceReaderFactories
+import org.pkl.core.resource.ResourceReaderFactory
 import org.pkl.core.settings.PklSettings
 import org.pkl.core.util.IoUtils
 
@@ -224,16 +224,18 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
     }
   }
 
-  private fun resourceReaders(modulePathResolver: ModulePathResolver): List<ResourceReader> {
+  private fun resourceReaderFactories(
+    modulePathResolver: ModulePathResolver
+  ): List<ResourceReaderFactory> {
     return buildList {
-      add(ResourceReaders.environmentVariable())
-      add(ResourceReaders.externalProperty())
-      add(ResourceReaders.modulePath(modulePathResolver))
-      add(ResourceReaders.pkg())
-      add(ResourceReaders.projectpackage())
-      add(ResourceReaders.file())
-      add(ResourceReaders.http())
-      add(ResourceReaders.https())
+      add(ResourceReaderFactories.environmentVariable())
+      add(ResourceReaderFactories.externalProperty())
+      add(ResourceReaderFactories.modulePath(modulePathResolver))
+      add(ResourceReaderFactories.pkg())
+      add(ResourceReaderFactories.projectpackage())
+      add(ResourceReaderFactories.file())
+      add(ResourceReaderFactories.http())
+      add(ResourceReaderFactories.https())
     }
   }
 
@@ -253,7 +255,7 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
       .setExternalProperties(externalProperties)
       .setEnvironmentVariables(environmentVariables)
       .addModuleKeyFactories(moduleKeyFactories(modulePathResolver))
-      .addResourceReaders(resourceReaders(modulePathResolver))
+      .addResourceReaderFactories(resourceReaderFactories(modulePathResolver))
       .setLogger(Loggers.stdErr())
       .setTimeout(cliOptions.timeout)
       .setModuleCacheDir(moduleCacheDir)

--- a/pkl-core/src/main/java/org/pkl/core/EvaluatorImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/EvaluatorImpl.java
@@ -35,7 +35,7 @@ import org.pkl.core.module.ModuleKeyFactory;
 import org.pkl.core.module.ProjectDependenciesManager;
 import org.pkl.core.packages.PackageResolver;
 import org.pkl.core.project.DeclaredDependencies;
-import org.pkl.core.resource.ResourceReader;
+import org.pkl.core.resource.ResourceReaderFactory;
 import org.pkl.core.runtime.BaseModule;
 import org.pkl.core.runtime.Identifier;
 import org.pkl.core.runtime.ModuleResolver;
@@ -73,7 +73,7 @@ public class EvaluatorImpl implements Evaluator {
       HttpClient httpClient,
       Logger logger,
       Collection<ModuleKeyFactory> factories,
-      Collection<ResourceReader> readers,
+      Collection<ResourceReaderFactory> readerFactories,
       Map<String, String> environmentVariables,
       Map<String, String> externalProperties,
       @Nullable Duration timeout,
@@ -96,7 +96,7 @@ public class EvaluatorImpl implements Evaluator {
                       manager,
                       httpClient,
                       moduleResolver,
-                      new ResourceManager(manager, readers),
+                      new ResourceManager(manager, readerFactories),
                       this.logger,
                       environmentVariables,
                       externalProperties,

--- a/pkl-core/src/main/java/org/pkl/core/project/Project.java
+++ b/pkl-core/src/main/java/org/pkl/core/project/Project.java
@@ -48,7 +48,7 @@ import org.pkl.core.packages.Dependency.RemoteDependency;
 import org.pkl.core.packages.PackageLoadError;
 import org.pkl.core.packages.PackageUri;
 import org.pkl.core.packages.PackageUtils;
-import org.pkl.core.resource.ResourceReaders;
+import org.pkl.core.resource.ResourceReaderFactories;
 import org.pkl.core.util.IoUtils;
 import org.pkl.core.util.Nullable;
 
@@ -82,8 +82,8 @@ public final class Project {
             .setStackFrameTransformer(stackFrameTransformer)
             .addModuleKeyFactory(ModuleKeyFactories.standardLibrary)
             .addModuleKeyFactory(ModuleKeyFactories.file)
-            .addResourceReader(ResourceReaders.environmentVariable())
-            .addResourceReader(ResourceReaders.file())
+            .addResourceReaderFactory(ResourceReaderFactories.environmentVariable())
+            .addResourceReaderFactory(ResourceReaderFactories.file())
             .addEnvironmentVariables(envVars)
             .setTimeout(timeout)
             .build()) {
@@ -115,8 +115,8 @@ public final class Project {
             .addModuleKeyFactory(ModuleKeyFactories.standardLibrary)
             .addModuleKeyFactory(ModuleKeyFactories.file)
             .addModuleKeyFactory(ModuleKeyFactories.classPath(Project.class.getClassLoader()))
-            .addResourceReader(ResourceReaders.environmentVariable())
-            .addResourceReader(ResourceReaders.file())
+            .addResourceReaderFactory(ResourceReaderFactories.environmentVariable())
+            .addResourceReaderFactory(ResourceReaderFactories.file())
             .build()) {
       return load(evaluator, moduleSource);
     }

--- a/pkl-core/src/main/java/org/pkl/core/repl/ReplServer.java
+++ b/pkl-core/src/main/java/org/pkl/core/repl/ReplServer.java
@@ -47,7 +47,7 @@ import org.pkl.core.repl.ReplRequest.Reset;
 import org.pkl.core.repl.ReplResponse.EvalError;
 import org.pkl.core.repl.ReplResponse.EvalSuccess;
 import org.pkl.core.repl.ReplResponse.InvalidRequest;
-import org.pkl.core.resource.ResourceReader;
+import org.pkl.core.resource.ResourceReaderFactory;
 import org.pkl.core.runtime.*;
 import org.pkl.core.util.EconomicMaps;
 import org.pkl.core.util.IoUtils;
@@ -71,7 +71,7 @@ public class ReplServer implements AutoCloseable {
       HttpClient httpClient,
       Logger logger,
       Collection<ModuleKeyFactory> moduleKeyFactories,
-      Collection<ResourceReader> resourceReaders,
+      Collection<ResourceReaderFactory> resourceReaderFactories,
       Map<String, String> environmentVariables,
       Map<String, String> externalProperties,
       @Nullable Path moduleCacheDir,
@@ -103,7 +103,7 @@ public class ReplServer implements AutoCloseable {
                       securityManager,
                       httpClient,
                       moduleResolver,
-                      new ResourceManager(securityManager, resourceReaders),
+                      new ResourceManager(securityManager, resourceReaderFactories),
                       logger,
                       environmentVariables,
                       externalProperties,

--- a/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaderFactories.java
+++ b/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaderFactories.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.resource;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import org.pkl.core.module.ModulePathResolver;
+import org.pkl.core.util.IoUtils;
+
+public final class ResourceReaderFactories {
+
+  private ResourceReaderFactories() {}
+
+  /**
+   * A factory for OS environment variables. If this resource reader is present, Pkl code can read
+   * environment variable {@code FOO_BAR} with {@code read("env:FOO_BAR")}, provided that resource
+   * URI {@code env:FOO_BAR} matches an entry in the resource allowlist ({@code
+   * --allowed-resources}).
+   */
+  public static ResourceReaderFactory environmentVariable() {
+    return EnvironmentVariable.INSTANCE;
+  }
+
+  /**
+   * A factory for external properties. If this resource reader is present, Pkl code can read
+   * external property {@code foo.bar} with {@code read("prop:foo.bar")}, provided that resource URI
+   * {@code prop:foo.bar} matches an entry in the resource allowlist ({@code --allowed-resources}).
+   */
+  public static ResourceReaderFactory externalProperty() {
+    return ExternalProperty.INSTANCE;
+  }
+
+  public static ResourceReaderFactory file() {
+    return FileResourceFactory.INSTANCE;
+  }
+
+  /**
+   * A factory for HTTP resources. If this resource reader is present, Pkl code can read HTTP
+   * resource {@code http://apple.com/foo/bar.txt} with {@code
+   * read("http://apple.com/foo/bar.txt")}, provided that resource URI {@code
+   * "http://apple.com/foo/bar.txt"} matches an entry in the resource allowlist ({@code
+   * --allowed-resources}).
+   */
+  public static ResourceReaderFactory http() {
+    return HttpResourceFactory.INSTANCE;
+  }
+
+  /**
+   * A factory for HTTPS resources. If this resource reader is present, Pkl code can read HTTPS
+   * resource {@code https://apple.com/foo/bar.txt} with {@code
+   * read("https://apple.com/foo/bar.txt")}, provided that resource URI {@code
+   * "https://apple.com/foo/bar.txt"} matches an entry in the resource allowlist ({@code
+   * --allowed-resources}).
+   */
+  public static ResourceReaderFactory https() {
+    return HttpsResourceFactory.INSTANCE;
+  }
+
+  /**
+   * A factory for JVM class path resources. If this resource reader is present, Pkl code can read
+   * class path resource {@code /foo/bar.txt} with {@code read("modulepath:foo/bar.txt")}, provided
+   * that resource URI {@code "modulepath:foo/bar.txt"} matches an entry in the resource allowlist
+   * ({@code --allowed-resources}).
+   */
+  public static ResourceReaderFactory classPath(ClassLoader classLoader) {
+    return new ClassPathResourceFactory(classLoader);
+  }
+
+  /**
+   * A factory for Pkl module path ({@code --module-path}) resources. If this resource reader is
+   * present, Pkl code can read module path resource {@code /foo/bar.txt} with {@code
+   * read("modulepath:foo/bar.txt")}, provided that resource URI {@code "modulepath:foo/bar.txt"}
+   * matches an entry in the resource allowlist ({@code --allowed-resources}).
+   */
+  public static ResourceReaderFactory modulePath(ModulePathResolver resolver) {
+    return new ModulePathResourceFactory(resolver);
+  }
+
+  /**
+   * A factory for {@code package:} resources. If this resource reader is present, Pkl code can read
+   * resources from within packages with {@code read("package://example.com/foo@1.0.0#/foo.txt")},
+   * or using dependency notation with {@code read("@foo/foo.txt")} assuming that the Pkl module is
+   * within a project that declares a dependency named {@code foo}.
+   */
+  public static ResourceReaderFactory pkg() {
+    return PackageResourceFactory.INSTANCE;
+  }
+
+  public static ResourceReaderFactory projectpackage() {
+    return ProjectPackageResourceFactory.INSTANCE;
+  }
+
+  /**
+   * Returns a factory resource readers registered as {@link ServiceLoader service providers} of
+   * type {@code org.pkl.core.resource.ResourceReader}.
+   */
+  public static ResourceReaderFactory fromServiceProviders() {
+    return FromServiceProviders.INSTANCE;
+  }
+
+  private static final class EnvironmentVariable implements ResourceReaderFactory {
+    static final ResourceReaderFactory INSTANCE = new EnvironmentVariable();
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      if (!uri.getScheme().equalsIgnoreCase("env")) return Optional.empty();
+      return Optional.of(ResourceReaders.environmentVariable());
+    }
+  }
+
+  private static final class ExternalProperty implements ResourceReaderFactory {
+    static final ResourceReaderFactory INSTANCE = new ExternalProperty();
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      if (!uri.getScheme().equalsIgnoreCase("prop")) return Optional.empty();
+      return Optional.of(ResourceReaders.externalProperty());
+    }
+  }
+
+  private static final class FileResourceFactory implements ResourceReaderFactory {
+    static final ResourceReaderFactory INSTANCE = new FileResourceFactory();
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      if (!uri.getScheme().equalsIgnoreCase("file")) return Optional.empty();
+      return Optional.of(ResourceReaders.file());
+    }
+  }
+
+  private static final class HttpResourceFactory implements ResourceReaderFactory {
+    static final ResourceReaderFactory INSTANCE = new HttpResourceFactory();
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      if (!uri.getScheme().equalsIgnoreCase("http")) return Optional.empty();
+      return Optional.of(ResourceReaders.http());
+    }
+  }
+
+  private static final class HttpsResourceFactory implements ResourceReaderFactory {
+    static final ResourceReaderFactory INSTANCE = new HttpsResourceFactory();
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      if (!uri.getScheme().equalsIgnoreCase("https")) return Optional.empty();
+      return Optional.of(ResourceReaders.https());
+    }
+  }
+
+  private static final class ClassPathResourceFactory implements ResourceReaderFactory {
+    private final ClassLoader classLoader;
+
+    public ClassPathResourceFactory(ClassLoader classLoader) {
+      this.classLoader = classLoader;
+    }
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      if (!uri.getScheme().equalsIgnoreCase("modulepath")) return Optional.empty();
+      return Optional.of(ResourceReaders.classPath(classLoader));
+    }
+  }
+
+  private static final class ModulePathResourceFactory implements ResourceReaderFactory {
+    private final ModulePathResolver resolver;
+
+    public ModulePathResourceFactory(ModulePathResolver resolver) {
+      this.resolver = resolver;
+    }
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      if (!uri.getScheme().equalsIgnoreCase("modulepath")) return Optional.empty();
+      return Optional.of(ResourceReaders.modulePath(resolver));
+    }
+  }
+
+  private static final class PackageResourceFactory implements ResourceReaderFactory {
+    static final ResourceReaderFactory INSTANCE = new PackageResourceFactory();
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      if (!uri.getScheme().equalsIgnoreCase("package")) return Optional.empty();
+      return Optional.of(ResourceReaders.pkg());
+    }
+  }
+
+  private static final class ProjectPackageResourceFactory implements ResourceReaderFactory {
+    static final ResourceReaderFactory INSTANCE = new ProjectPackageResourceFactory();
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      if (!uri.getScheme().equalsIgnoreCase("projectpackage")) return Optional.empty();
+      return Optional.of(ResourceReaders.projectpackage());
+    }
+  }
+
+  private static class FromServiceProviders implements ResourceReaderFactory {
+    private static final FromServiceProviders INSTANCE = new FromServiceProviders();
+
+    @Override
+    public Optional<ResourceReader> create(URI uri) {
+      var loader = IoUtils.createServiceLoader(ResourceReader.class);
+      for (var reader : loader) {
+        if (uri.getScheme().equalsIgnoreCase(reader.getUriScheme())) {
+          return Optional.of(reader);
+        }
+      }
+      return Optional.empty();
+    }
+  }
+}

--- a/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaderFactory.java
+++ b/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaderFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.resource;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+/** A factory for {@link ResourceReader}s. */
+public interface ResourceReaderFactory {
+
+  /**
+   * Returns a {@link ResourceReader} for the given absolute normalized URI, or {@code
+   * Optional.empty()} if this factory cannot handle the given URI.
+   *
+   * <p>Implementations must not perform any I/O related to the given URI. For example, they must
+   * not check if the module represented by the given URI exists.
+   *
+   * <p>Throws {@link URISyntaxException} if the given URI has invalid syntax.
+   *
+   * @param uri an absolute normalized URI
+   * @return a resource for the given URI
+   */
+  Optional<ResourceReader> create(URI uri);
+}

--- a/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaders.java
+++ b/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaders.java
@@ -23,10 +23,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.ServiceLoader;
 import org.pkl.core.SecurityManager;
 import org.pkl.core.SecurityManagerException;
 import org.pkl.core.module.FileResolver;
@@ -127,14 +125,6 @@ public final class ResourceReaders {
 
   public static ResourceReader projectpackage() {
     return ProjectPackageResource.INSTANCE;
-  }
-
-  /**
-   * Returns resource readers registered as {@link ServiceLoader service providers} of type {@code
-   * org.pkl.core.resource.ResourceReader}.
-   */
-  public static List<ResourceReader> fromServiceProviders() {
-    return FromServiceProviders.INSTANCE;
   }
 
   private static final class EnvironmentVariable implements ResourceReader {
@@ -581,17 +571,6 @@ public final class ResourceReaders {
       }
       return localDependency.resolveAssetUri(
           getProjectDepsResolver().getProjectBaseUri(), packageAssetUri);
-    }
-  }
-
-  private static class FromServiceProviders {
-    private static final List<ResourceReader> INSTANCE;
-
-    static {
-      var loader = IoUtils.createServiceLoader(ResourceReader.class);
-      var readers = new ArrayList<ResourceReader>();
-      loader.forEach(readers::add);
-      INSTANCE = Collections.unmodifiableList(readers);
     }
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
@@ -32,7 +32,7 @@ import org.pkl.core.http.HttpClient;
 import org.pkl.core.module.ModuleKeyFactories;
 import org.pkl.core.module.ModulePathResolver;
 import org.pkl.core.project.Project;
-import org.pkl.core.resource.ResourceReaders;
+import org.pkl.core.resource.ResourceReaderFactories;
 import org.pkl.executor.spi.v1.ExecutorSpi;
 import org.pkl.executor.spi.v1.ExecutorSpiException;
 import org.pkl.executor.spi.v1.ExecutorSpiOptions;
@@ -94,14 +94,14 @@ public final class ExecutorSpiImpl implements ExecutorSpi {
             .setStackFrameTransformer(transformer)
             .setSecurityManager(securityManager)
             .setHttpClient(getOrCreateHttpClient(options))
-            .addResourceReader(ResourceReaders.environmentVariable())
-            .addResourceReader(ResourceReaders.externalProperty())
-            .addResourceReader(ResourceReaders.modulePath(resolver))
-            .addResourceReader(ResourceReaders.pkg())
-            .addResourceReader(ResourceReaders.projectpackage())
-            .addResourceReader(ResourceReaders.file())
-            .addResourceReader(ResourceReaders.http())
-            .addResourceReader(ResourceReaders.https())
+            .addResourceReaderFactory(ResourceReaderFactories.environmentVariable())
+            .addResourceReaderFactory(ResourceReaderFactories.externalProperty())
+            .addResourceReaderFactory(ResourceReaderFactories.modulePath(resolver))
+            .addResourceReaderFactory(ResourceReaderFactories.pkg())
+            .addResourceReaderFactory(ResourceReaderFactories.projectpackage())
+            .addResourceReaderFactory(ResourceReaderFactories.file())
+            .addResourceReaderFactory(ResourceReaderFactories.http())
+            .addResourceReaderFactory(ResourceReaderFactories.https())
             .addModuleKeyFactory(ModuleKeyFactories.standardLibrary)
             .addModuleKeyFactories(ModuleKeyFactories.fromServiceProviders())
             .addModuleKeyFactory(ModuleKeyFactories.modulePath(resolver))

--- a/pkl-core/src/main/java/org/pkl/core/settings/PklSettings.java
+++ b/pkl-core/src/main/java/org/pkl/core/settings/PklSettings.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 import org.pkl.core.*;
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings;
 import org.pkl.core.module.ModuleKeyFactories;
-import org.pkl.core.resource.ResourceReaders;
+import org.pkl.core.resource.ResourceReaderFactories;
 import org.pkl.core.runtime.VmEvalException;
 import org.pkl.core.runtime.VmExceptionBuilder;
 import org.pkl.core.util.IoUtils;
@@ -67,7 +67,7 @@ public record PklSettings(Editor editor, @Nullable PklEvaluatorSettings.Http htt
             .setStackFrameTransformer(StackFrameTransformers.defaultTransformer)
             .addModuleKeyFactory(ModuleKeyFactories.standardLibrary)
             .addModuleKeyFactory(ModuleKeyFactories.file)
-            .addResourceReader(ResourceReaders.environmentVariable())
+            .addResourceReaderFactory(ResourceReaderFactories.environmentVariable())
             .addEnvironmentVariables(System.getenv())
             .build()) {
       var module = evaluator.evaluateOutputValueAs(moduleSource, PClassInfo.Settings);

--- a/pkl-core/src/test/kotlin/org/pkl/core/ReplServerTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/ReplServerTest.kt
@@ -23,7 +23,7 @@ import org.pkl.core.module.ModuleKeyFactories
 import org.pkl.core.repl.ReplRequest
 import org.pkl.core.repl.ReplResponse
 import org.pkl.core.repl.ReplServer
-import org.pkl.core.resource.ResourceReaders
+import org.pkl.core.resource.ResourceReaderFactories
 
 class ReplServerTest {
   private val server =
@@ -36,7 +36,10 @@ class ReplServerTest {
         ModuleKeyFactories.classPath(this::class.java.classLoader),
         ModuleKeyFactories.file
       ),
-      listOf(ResourceReaders.environmentVariable(), ResourceReaders.externalProperty()),
+      listOf(
+        ResourceReaderFactories.environmentVariable(),
+        ResourceReaderFactories.externalProperty()
+      ),
       mapOf("NAME1" to "value1", "NAME2" to "value2"),
       mapOf("name1" to "value1", "name2" to "value2"),
       null,

--- a/pkl-core/src/test/kotlin/org/pkl/core/resource/ResourceReadersEvaluatorTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/resource/ResourceReadersEvaluatorTest.kt
@@ -52,9 +52,10 @@ class ResourceReadersEvaluatorTest {
     }
 
     ModulePathResolver(listOf(jarFile)).use { resolver ->
-      val reader = ResourceReaders.modulePath(resolver)
+      val readerFactory = ResourceReaderFactories.modulePath(resolver)
 
-      val evaluator = EvaluatorBuilder.preconfigured().addResourceReader(reader).build()
+      val evaluator =
+        EvaluatorBuilder.preconfigured().addResourceReaderFactory(readerFactory).build()
 
       val module =
         evaluator.evaluate(

--- a/pkl-core/src/test/kotlin/org/pkl/core/resource/ResourceReadersTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/resource/ResourceReadersTest.kt
@@ -124,11 +124,14 @@ class ResourceReadersTest {
 
   @Test
   fun `via service provider`() {
-    val readers = ResourceReaders.fromServiceProviders()
-    assertThat(readers).hasSize(1)
+    val factory = ResourceReaderFactories.fromServiceProviders()
 
-    val reader = readers.single()
-    val resource = reader.read(URI("test:foo"))
+    val uri = URI("test:foo")
+    val maybeReader = factory.create(uri)
+    assertThat(maybeReader).isNotEmpty
+
+    val reader = maybeReader.get()
+    val resource = reader.read(uri)
 
     assertThat(resource).contains("success")
   }

--- a/pkl-server/src/main/kotlin/org/pkl/server/BinaryEvaluator.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/BinaryEvaluator.kt
@@ -23,7 +23,7 @@ import org.pkl.core.ast.member.ObjectMember
 import org.pkl.core.http.HttpClient
 import org.pkl.core.module.ModuleKeyFactory
 import org.pkl.core.project.DeclaredDependencies
-import org.pkl.core.resource.ResourceReader
+import org.pkl.core.resource.ResourceReaderFactory
 import org.pkl.core.runtime.*
 
 internal class BinaryEvaluator(
@@ -32,7 +32,7 @@ internal class BinaryEvaluator(
   httpClient: HttpClient,
   logger: Logger,
   factories: Collection<ModuleKeyFactory?>,
-  readers: Collection<ResourceReader?>,
+  readerFactories: Collection<ResourceReaderFactory?>,
   environmentVariables: Map<String, String>,
   externalProperties: Map<String, String>,
   timeout: Duration?,
@@ -46,7 +46,7 @@ internal class BinaryEvaluator(
     httpClient,
     logger,
     factories,
-    readers,
+    readerFactories,
     environmentVariables,
     externalProperties,
     timeout,

--- a/pkl-server/src/main/kotlin/org/pkl/server/ClientResourceReaderFactory.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ClientResourceReaderFactory.kt
@@ -1,0 +1,39 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.server
+
+import java.net.URI
+import java.util.*
+import org.pkl.core.resource.ResourceReader
+import org.pkl.core.resource.ResourceReaderFactory
+
+internal class ClientResourceReaderFactory(
+  private val readerSpecs: Collection<ResourceReaderSpec>,
+  private val transport: MessageTransport,
+  private val evaluatorId: Long
+) : ResourceReaderFactory {
+  private val schemes = readerSpecs.map { it.scheme }
+
+  override fun create(uri: URI): Optional<ResourceReader> =
+    when (uri.scheme) {
+      in schemes -> {
+        val readerSpec = readerSpecs.find { it.scheme == uri.scheme }!!
+        val reader = ClientResourceReader(transport, evaluatorId, readerSpec)
+        Optional.of(reader)
+      }
+      else -> Optional.empty()
+    }
+}

--- a/pkl-server/src/test/kotlin/org/pkl/server/BinaryEvaluatorTest.kt
+++ b/pkl-server/src/test/kotlin/org/pkl/server/BinaryEvaluatorTest.kt
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.assertThrows
 import org.pkl.core.*
 import org.pkl.core.http.HttpClient
 import org.pkl.core.module.ModuleKeyFactories
-import org.pkl.core.resource.ResourceReaders
+import org.pkl.core.resource.ResourceReaderFactories
 
 class BinaryEvaluatorTest {
   private val evaluator =
@@ -38,7 +38,10 @@ class BinaryEvaluatorTest {
       HttpClient.dummyClient(),
       Loggers.noop(),
       listOf(ModuleKeyFactories.standardLibrary),
-      listOf(ResourceReaders.environmentVariable(), ResourceReaders.externalProperty()),
+      listOf(
+        ResourceReaderFactories.environmentVariable(),
+        ResourceReaderFactories.externalProperty()
+      ),
       mapOf(),
       mapOf(),
       null,


### PR DESCRIPTION
This is preparatory work for [SPICE-0009](https://github.com/apple/pkl-evolution/pull/10). It is being contributed in a separate pull request to ease review.

This is required to allow deferred launch of external reader processes without requiring up-front configuration of scheme->process mappings. More details on why this is required here: https://github.com/apple/pkl-evolution/pull/10#discussion_r1724145677

One concern here (which applies before this change as well) is that the semantics of module key factories and resource reader factories is reversed. For module key factories, the first factory that answers for a URI scheme "wins", while for resource reader factories, the _last_ reader factory that answers for a URI scheme "wins". This PR preserves that behavior, but it may be worth reconsidering this design at this time.

This behavior can be observed in practice in <code>ResourceReadersEvaluatorTest.\`module path\`</code> where `ResourceReaders.modulePath` is added after the pre-configured `ResourceReaders.classPath` and takes precedence.

This is a fairly large breaking API change, but in practice most clients will only need to replace a few lines in their calls to `EvaluatorBuilder`, eg.
```java
.addResourceReader(ResourceReaders.environmentVariable())
// becomes
.addResourceReaderFactory(ResourceReaderFactories.environmentVariable())
```