### PR TITLE
Handle `null` contents gracefully in message passing API

### DIFF
--- a/docs/modules/bindings-specification/pages/message-passing-api.adoc
+++ b/docs/modules/bindings-specification/pages/message-passing-api.adoc
@@ -414,6 +414,8 @@ The response to <<read-resource-request>>.
 If successful, `contents` is set.
 Otherwise, `error` is set.
 
+If neither is set, `contents` defaults to an empty byte array.
+
 [source,pkl]
 ----
 /// A number identifying this request.
@@ -462,6 +464,8 @@ Type: <<client-message,Client>> <<response-message,Response>>
 The response to <<read-module-request>>.
 If successful, `contents` is set.
 Otherwise, `error` is set.
+
+If neither is set, `contents` defaults to an empty string.
 
 [source,pkl]
 ----

--- a/pkl-server/src/main/kotlin/org/pkl/server/ClientModuleKeyFactory.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ClientModuleKeyFactory.kt
@@ -74,7 +74,7 @@ internal class ClientModuleKeyFactory(
                     if (response.error != null) {
                       completeExceptionally(IOException(response.error))
                     } else {
-                      complete(response.contents!!)
+                      complete(response.contents ?: "")
                     }
                   }
                   else -> {

--- a/pkl-server/src/main/kotlin/org/pkl/server/ClientResourceReader.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ClientResourceReader.kt
@@ -91,7 +91,7 @@ internal class ClientResourceReader(
                 if (response.error != null) {
                   completeExceptionally(IOException(response.error))
                 } else {
-                  complete(response.contents!!)
+                  complete(response.contents ?: ByteArray(0))
                 }
               }
               else -> {

--- a/pkl-server/src/test/kotlin/org/pkl/server/AbstractServerTest.kt
+++ b/pkl-server/src/test/kotlin/org/pkl/server/AbstractServerTest.kt
@@ -181,6 +181,43 @@ abstract class AbstractServerTest {
   }
 
   @Test
+  fun `read resource -- null contents and null error`() {
+    val reader =
+      ResourceReaderSpec(scheme = "bahumbug", hasHierarchicalUris = true, isGlobbable = false)
+    val evaluatorId = client.sendCreateEvaluatorRequest(resourceReaders = listOf(reader))
+
+    client.send(
+      EvaluateRequest(
+        requestId = 1,
+        evaluatorId = evaluatorId,
+        moduleUri = URI("repl:text"),
+        moduleText = """res = read("bahumbug:/foo.pkl").text""",
+        expr = "res"
+      )
+    )
+
+    val readResourceMsg = client.receive<ReadResourceRequest>()
+    assertThat(readResourceMsg.uri.toString()).isEqualTo("bahumbug:/foo.pkl")
+    assertThat(readResourceMsg.evaluatorId).isEqualTo(evaluatorId)
+
+    client.send(
+      ReadResourceResponse(
+        requestId = readResourceMsg.requestId,
+        evaluatorId = evaluatorId,
+        contents = null,
+        error = null
+      )
+    )
+
+    val evaluateResponse = client.receive<EvaluateResponse>()
+    assertThat(evaluateResponse.error).isNull()
+
+    val unpacker = MessagePack.newDefaultUnpacker(evaluateResponse.result)
+    val value = unpacker.unpackValue()
+    assertThat(value.asStringValue().asString()).isEqualTo("")
+  }
+
+  @Test
   fun `read resource error`() {
     val reader =
       ResourceReaderSpec(scheme = "bahumbug", hasHierarchicalUris = true, isGlobbable = false)
@@ -389,6 +426,49 @@ abstract class AbstractServerTest {
     val unpacker = MessagePack.newDefaultUnpacker(evaluateResponse.result)
     val value = unpacker.unpackValue()
     assertThat(value.asIntegerValue().asInt()).isEqualTo(5)
+  }
+
+  @Test
+  fun `read module -- null contents and null error`() {
+    val reader =
+      ModuleReaderSpec(
+        scheme = "bird",
+        hasHierarchicalUris = true,
+        isLocal = true,
+        isGlobbable = false
+      )
+    val evaluatorId = client.sendCreateEvaluatorRequest(moduleReaders = listOf(reader))
+
+    client.send(
+      EvaluateRequest(
+        requestId = 1,
+        evaluatorId = evaluatorId,
+        moduleUri = URI("repl:text"),
+        moduleText = """res = import("bird:/pigeon.pkl")""",
+        expr = "res"
+      )
+    )
+
+    val readModuleMsg = client.receive<ReadModuleRequest>()
+    assertThat(readModuleMsg.uri.toString()).isEqualTo("bird:/pigeon.pkl")
+    assertThat(readModuleMsg.evaluatorId).isEqualTo(evaluatorId)
+
+    client.send(
+      ReadModuleResponse(
+        requestId = readModuleMsg.requestId,
+        evaluatorId = evaluatorId,
+        contents = null,
+        error = null
+      )
+    )
+
+    val evaluateResponse = client.receive<EvaluateResponse>()
+    assertThat(evaluateResponse.error).isNull()
+    val unpacker = MessagePack.newDefaultUnpacker(evaluateResponse.result)
+    val value = unpacker.unpackValue().asArrayValue().list()
+    assertThat(value[0].asIntegerValue().asLong()).isEqualTo(0x1)
+    assertThat(value[1].asStringValue().asString()).isEqualTo("pigeon")
+    assertThat(value[3].asArrayValue().list()).isEmpty()
   }
 
   @Test


### PR DESCRIPTION
In messages "Read Resource Response" and "Read Module Response", if `contents` and `error` are both null, default to an empty byte array/string.

This resolves one of the issues reported in #656