### PR TITLE
Add `String.splitLimit` API

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/StringNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/StringNodes.java
@@ -739,6 +739,22 @@ public final class StringNodes {
     }
   }
 
+  public abstract static class splitLimit extends ExternalMethod2Node {
+    @TruffleBoundary
+    @Specialization
+    protected VmList eval(String self, String separator, long limit) {
+      var parts = self.split(Pattern.quote(separator), (int) limit);
+      return VmList.create(parts);
+    }
+
+    @TruffleBoundary
+    @Specialization
+    protected VmList eval(String self, VmRegex separator, long limit) {
+      var parts = separator.getPattern().split(self, (int) limit);
+      return VmList.create(parts);
+    }
+  }
+
   public abstract static class capitalize extends ExternalMethod0Node {
     @TruffleBoundary
     @Specialization

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/string.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/string.pkl
@@ -138,6 +138,19 @@ examples {
     str4.split("cc")
   }
 
+  local str7 = "aabbccaabbccaabbccaabbcc"
+
+  ["splitLimit()"] {
+    str7.splitLimit(Regex("b+c"), 1)
+    str7.splitLimit(Regex("b+c"), 2)
+    str7.splitLimit(Regex("b+c"), 4)
+    str7.splitLimit("cc", 1)
+    str7.splitLimit("cc", 2)
+    str7.splitLimit("cc", 4)
+    module.catch(() -> str7.splitLimit(Regex("b+c"), 0))
+    module.catch(() -> str7.splitLimit(Regex("b+c"), -1))
+  }
+
   ["replaceAll()"] {
     str4.replaceAll("aa", "xx")
     str4.replaceAll(Regex("(b+)c"), "($0|$1)")

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflectedDeclaration.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflectedDeclaration.pcf
@@ -1333,11 +1333,33 @@ alias {
           parameters = Map("pattern", new {
             name = "pattern"
           })
+        }, "splitLimit", new {
+          location {
+            line = 1374
+            column = 3
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1374"
+          }
+          docComment = """
+            Splits this string matches of [pattern], up to [limit] substrings.
+            
+            Returns a [List] with at most [limit] elements.
+            """
+          annotations = List(new {
+            version = "0.27.0"
+          })
+          modifiers = Set()
+          name = "splitLimit"
+          typeParameters = List()
+          parameters = Map("pattern", new {
+            name = "pattern"
+          }, "limit", new {
+            name = "limit"
+          })
         }, "capitalize", new {
           location {
-            line = 1378
+            line = 1384
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1378"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1384"
           }
           docComment = """
             Converts the first character of this string to title case.
@@ -1356,9 +1378,9 @@ alias {
           parameters = Map()
         }, "decapitalize", new {
           location {
-            line = 1388
+            line = 1394
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1388"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1394"
           }
           docComment = """
             Converts the first character of this string to lower case.
@@ -1377,9 +1399,9 @@ alias {
           parameters = Map()
         }, "toInt", new {
           location {
-            line = 1394
+            line = 1400
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1394"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1400"
           }
           docComment = """
             Parses this string as a signed decimal (base 10) integer.
@@ -1394,9 +1416,9 @@ alias {
           parameters = Map()
         }, "toIntOrNull", new {
           location {
-            line = 1400
+            line = 1406
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1400"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1406"
           }
           docComment = """
             Parses this string as a signed decimal (base 10) integer.
@@ -1411,9 +1433,9 @@ alias {
           parameters = Map()
         }, "toFloat", new {
           location {
-            line = 1405
+            line = 1411
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1405"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1411"
           }
           docComment = """
             Parses this string as a floating point number.
@@ -1427,9 +1449,9 @@ alias {
           parameters = Map()
         }, "toFloatOrNull", new {
           location {
-            line = 1410
+            line = 1416
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1410"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1416"
           }
           docComment = """
             Parses this string as a floating point number.
@@ -1443,9 +1465,9 @@ alias {
           parameters = Map()
         }, "toBoolean", new {
           location {
-            line = 1415
+            line = 1421
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1415"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1421"
           }
           docComment = """
             Parses `"true"` to [true] and `"false"` to [false] (case-insensitive).
@@ -1459,9 +1481,9 @@ alias {
           parameters = Map()
         }, "toBooleanOrNull", new {
           location {
-            line = 1420
+            line = 1426
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1420"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1426"
           }
           docComment = """
             Parses `"true"` to [true] and `"false"` to [false] (case-insensitive).
@@ -1493,9 +1515,9 @@ rec {
     typeParameters = List()
     superclass {
       location {
-        line = 1706
+        line = 1712
         column = 1
-        displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1706"
+        displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1712"
       }
       docComment = """
         Base class for objects whose members are described by a class definition.
@@ -1508,9 +1530,9 @@ rec {
       typeParameters = List()
       superclass {
         location {
-          line = 1701
+          line = 1707
           column = 1
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1701"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1707"
         }
         docComment = """
           A composite value containing members (properties, elements, entries).
@@ -1734,9 +1756,9 @@ rec {
       supertype {
         referent {
           location {
-            line = 1701
+            line = 1707
             column = 1
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1701"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1707"
           }
           docComment = """
             A composite value containing members (properties, elements, entries).
@@ -1962,9 +1984,9 @@ rec {
       properties = Map()
       methods = Map("hasProperty", new {
         location {
-          line = 1708
+          line = 1714
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1708"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1714"
         }
         docComment = "Tells if this object has a property with the given [name]."
         annotations = List()
@@ -1976,9 +1998,9 @@ rec {
         })
       }, "getProperty", new {
         location {
-          line = 1713
+          line = 1719
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1713"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1719"
         }
         docComment = """
           Returns the value of the property with the given [name].
@@ -1994,9 +2016,9 @@ rec {
         })
       }, "getPropertyOrNull", new {
         location {
-          line = 1718
+          line = 1724
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1718"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1724"
         }
         docComment = """
           Returns the value of the property with the given [name].
@@ -2012,9 +2034,9 @@ rec {
         })
       }, "toDynamic", new {
         location {
-          line = 1721
+          line = 1727
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1721"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1727"
         }
         docComment = "Converts this object to a [Dynamic] object."
         annotations = List()
@@ -2024,9 +2046,9 @@ rec {
         parameters = Map()
       }, "toMap", new {
         location {
-          line = 1724
+          line = 1730
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1724"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1730"
         }
         docComment = "Converts this object to a [Map]."
         annotations = List()
@@ -2039,9 +2061,9 @@ rec {
     supertype {
       referent {
         location {
-          line = 1706
+          line = 1712
           column = 1
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1706"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1712"
         }
         docComment = """
           Base class for objects whose members are described by a class definition.
@@ -2054,9 +2076,9 @@ rec {
         typeParameters = List()
         superclass {
           location {
-            line = 1701
+            line = 1707
             column = 1
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1701"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1707"
           }
           docComment = """
             A composite value containing members (properties, elements, entries).
@@ -2280,9 +2302,9 @@ rec {
         supertype {
           referent {
             location {
-              line = 1701
+              line = 1707
               column = 1
-              displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1701"
+              displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1707"
             }
             docComment = """
               A composite value containing members (properties, elements, entries).
@@ -2508,9 +2530,9 @@ rec {
         properties = Map()
         methods = Map("hasProperty", new {
           location {
-            line = 1708
+            line = 1714
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1708"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1714"
           }
           docComment = "Tells if this object has a property with the given [name]."
           annotations = List()
@@ -2522,9 +2544,9 @@ rec {
           })
         }, "getProperty", new {
           location {
-            line = 1713
+            line = 1719
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1713"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1719"
           }
           docComment = """
             Returns the value of the property with the given [name].
@@ -2540,9 +2562,9 @@ rec {
           })
         }, "getPropertyOrNull", new {
           location {
-            line = 1718
+            line = 1724
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1718"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1724"
           }
           docComment = """
             Returns the value of the property with the given [name].
@@ -2558,9 +2580,9 @@ rec {
           })
         }, "toDynamic", new {
           location {
-            line = 1721
+            line = 1727
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1721"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1727"
           }
           docComment = "Converts this object to a [Dynamic] object."
           annotations = List()
@@ -2570,9 +2592,9 @@ rec {
           parameters = Map()
         }, "toMap", new {
           location {
-            line = 1724
+            line = 1730
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1724"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1730"
           }
           docComment = "Converts this object to a [Map]."
           annotations = List()

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflectedDeclaration.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflectedDeclaration.pcf
@@ -1335,14 +1335,23 @@ alias {
           })
         }, "splitLimit", new {
           location {
-            line = 1374
+            line = 1383
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1374"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1383"
           }
           docComment = """
             Splits this string matches of [pattern], up to [limit] substrings.
             
             Returns a [List] with at most [limit] elements.
+            If the limit has been reached, the last entry will contain the un-split remainder of this string.
+            
+            Facts:
+            ```
+            "a.b.c".splitLimit(".", 2) == List("a", "b.c")
+            "a.b.c".splitLimit(".", 1) == List("a.b.c")
+            "a.b.c".splitLimit(".", 50) == List("a", "b", "c")
+            "a.b:c".splitLimit(Regex("[.:]"), 3) == List("a", "b", "c")
+            ```
             """
           annotations = List(new {
             version = "0.27.0"
@@ -1357,9 +1366,9 @@ alias {
           })
         }, "capitalize", new {
           location {
-            line = 1384
+            line = 1393
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1384"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1393"
           }
           docComment = """
             Converts the first character of this string to title case.
@@ -1378,9 +1387,9 @@ alias {
           parameters = Map()
         }, "decapitalize", new {
           location {
-            line = 1394
+            line = 1403
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1394"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1403"
           }
           docComment = """
             Converts the first character of this string to lower case.
@@ -1399,9 +1408,9 @@ alias {
           parameters = Map()
         }, "toInt", new {
           location {
-            line = 1400
+            line = 1409
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1400"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1409"
           }
           docComment = """
             Parses this string as a signed decimal (base 10) integer.
@@ -1416,9 +1425,9 @@ alias {
           parameters = Map()
         }, "toIntOrNull", new {
           location {
-            line = 1406
+            line = 1415
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1406"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1415"
           }
           docComment = """
             Parses this string as a signed decimal (base 10) integer.
@@ -1433,9 +1442,9 @@ alias {
           parameters = Map()
         }, "toFloat", new {
           location {
-            line = 1411
+            line = 1420
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1411"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1420"
           }
           docComment = """
             Parses this string as a floating point number.
@@ -1449,9 +1458,9 @@ alias {
           parameters = Map()
         }, "toFloatOrNull", new {
           location {
-            line = 1416
+            line = 1425
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1416"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1425"
           }
           docComment = """
             Parses this string as a floating point number.
@@ -1465,9 +1474,9 @@ alias {
           parameters = Map()
         }, "toBoolean", new {
           location {
-            line = 1421
+            line = 1430
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1421"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1430"
           }
           docComment = """
             Parses `"true"` to [true] and `"false"` to [false] (case-insensitive).
@@ -1481,9 +1490,9 @@ alias {
           parameters = Map()
         }, "toBooleanOrNull", new {
           location {
-            line = 1426
+            line = 1435
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1426"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1435"
           }
           docComment = """
             Parses `"true"` to [true] and `"false"` to [false] (case-insensitive).
@@ -1515,9 +1524,9 @@ rec {
     typeParameters = List()
     superclass {
       location {
-        line = 1712
+        line = 1721
         column = 1
-        displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1712"
+        displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1721"
       }
       docComment = """
         Base class for objects whose members are described by a class definition.
@@ -1530,9 +1539,9 @@ rec {
       typeParameters = List()
       superclass {
         location {
-          line = 1707
+          line = 1716
           column = 1
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1707"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1716"
         }
         docComment = """
           A composite value containing members (properties, elements, entries).
@@ -1756,9 +1765,9 @@ rec {
       supertype {
         referent {
           location {
-            line = 1707
+            line = 1716
             column = 1
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1707"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1716"
           }
           docComment = """
             A composite value containing members (properties, elements, entries).
@@ -1984,9 +1993,9 @@ rec {
       properties = Map()
       methods = Map("hasProperty", new {
         location {
-          line = 1714
+          line = 1723
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1714"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1723"
         }
         docComment = "Tells if this object has a property with the given [name]."
         annotations = List()
@@ -1998,9 +2007,9 @@ rec {
         })
       }, "getProperty", new {
         location {
-          line = 1719
+          line = 1728
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1719"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1728"
         }
         docComment = """
           Returns the value of the property with the given [name].
@@ -2016,9 +2025,9 @@ rec {
         })
       }, "getPropertyOrNull", new {
         location {
-          line = 1724
+          line = 1733
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1724"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1733"
         }
         docComment = """
           Returns the value of the property with the given [name].
@@ -2034,9 +2043,9 @@ rec {
         })
       }, "toDynamic", new {
         location {
-          line = 1727
+          line = 1736
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1727"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1736"
         }
         docComment = "Converts this object to a [Dynamic] object."
         annotations = List()
@@ -2046,9 +2055,9 @@ rec {
         parameters = Map()
       }, "toMap", new {
         location {
-          line = 1730
+          line = 1739
           column = 3
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1730"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1739"
         }
         docComment = "Converts this object to a [Map]."
         annotations = List()
@@ -2061,9 +2070,9 @@ rec {
     supertype {
       referent {
         location {
-          line = 1712
+          line = 1721
           column = 1
-          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1712"
+          displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1721"
         }
         docComment = """
           Base class for objects whose members are described by a class definition.
@@ -2076,9 +2085,9 @@ rec {
         typeParameters = List()
         superclass {
           location {
-            line = 1707
+            line = 1716
             column = 1
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1707"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1716"
           }
           docComment = """
             A composite value containing members (properties, elements, entries).
@@ -2302,9 +2311,9 @@ rec {
         supertype {
           referent {
             location {
-              line = 1707
+              line = 1716
               column = 1
-              displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1707"
+              displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1716"
             }
             docComment = """
               A composite value containing members (properties, elements, entries).
@@ -2530,9 +2539,9 @@ rec {
         properties = Map()
         methods = Map("hasProperty", new {
           location {
-            line = 1714
+            line = 1723
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1714"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1723"
           }
           docComment = "Tells if this object has a property with the given [name]."
           annotations = List()
@@ -2544,9 +2553,9 @@ rec {
           })
         }, "getProperty", new {
           location {
-            line = 1719
+            line = 1728
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1719"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1728"
           }
           docComment = """
             Returns the value of the property with the given [name].
@@ -2562,9 +2571,9 @@ rec {
           })
         }, "getPropertyOrNull", new {
           location {
-            line = 1724
+            line = 1733
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1724"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1733"
           }
           docComment = """
             Returns the value of the property with the given [name].
@@ -2580,9 +2589,9 @@ rec {
           })
         }, "toDynamic", new {
           location {
-            line = 1727
+            line = 1736
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1727"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1736"
           }
           docComment = "Converts this object to a [Dynamic] object."
           annotations = List()
@@ -2592,9 +2601,9 @@ rec {
           parameters = Map()
         }, "toMap", new {
           location {
-            line = 1730
+            line = 1739
             column = 3
-            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1730"
+            displayUri = "https://github.com/apple/pkl/blob/$commitId/stdlib/base.pkl#L1739"
           }
           docComment = "Converts this object to a [Map]."
           annotations = List()

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/string.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/string.pcf
@@ -109,6 +109,16 @@ examples {
     List("aa", "caa", "c")
     List("aabb", "aabb")
   }
+  ["splitLimit()"] {
+    List("aabbccaabbccaabbccaabbcc")
+    List("aa", "caabbccaabbccaabbcc")
+    List("aa", "caa", "caa", "caabbcc")
+    List("aabbccaabbccaabbccaabbcc")
+    List("aabb", "aabbccaabbccaabbcc")
+    List("aabb", "aabb", "aabb", "aabbcc")
+    "Type constraint `this > 0` violated. Value: 0"
+    "Type constraint `this > 0` violated. Value: -1"
+  }
   ["replaceAll()"] {
     "xxbbccxxbbcc"
     "aa(bbc|bb)caa(bbc|bb)c"

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -1370,6 +1370,15 @@ external class String extends Any {
   /// Splits this string matches of [pattern], up to [limit] substrings.
   /// 
   /// Returns a [List] with at most [limit] elements.
+  /// If the limit has been reached, the last entry will contain the un-split remainder of this string.
+  ///
+  /// Facts:
+  /// ```
+  /// "a.b.c".splitLimit(".", 2) == List("a", "b.c")
+  /// "a.b.c".splitLimit(".", 1) == List("a.b.c")
+  /// "a.b.c".splitLimit(".", 50) == List("a", "b", "c")
+  /// "a.b:c".splitLimit(Regex("[.:]"), 3) == List("a", "b", "c")
+  /// ```
   @Since { version = "0.27.0" } 
   external function splitLimit(pattern: String|Regex, limit: Int(this > 0)): List<String>
 

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -1367,6 +1367,12 @@ external class String extends Any {
   /// Splits this string around matches of [pattern].
   external function split(pattern: String|Regex): List<String>
 
+  /// Splits this string matches of [pattern], up to [limit] substrings.
+  /// 
+  /// Returns a [List] with at most [limit] elements.
+  @Since { version = "0.27.0" } 
+  external function splitLimit(pattern: String|Regex, limit: Int(this > 0)): List<String>
+
   /// Converts the first character of this string to title case.
   ///
   /// Facts:


### PR DESCRIPTION
Open to naming input here!
* Java, Kotlin, and Swift use an overload of `String.split` for this
* Golang calls this [`SplitN`](https://pkg.go.dev/strings#SplitN)
* Python uses a defaulted argument on `str.split`