### PR TITLE
Set lower limit for glob pattern resolution in test mode

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
@@ -531,7 +531,7 @@ public final class IoUtils {
     return ServiceLoader.load(serviceClass, IoUtils.class.getClassLoader());
   }
 
-  // not a static property to avoid compile-time evaluation by native-image
+  // not a static field to avoid compile-time evaluation by native-image
   public static boolean isTestMode() {
     return Boolean.getBoolean("org.pkl.testMode");
   }


### PR DESCRIPTION
Motivation:
Speed up the test that verifies enforcement of the limit for glob pattern resolution (invalidGlobImport6.pkl).

Changes:
- Set a lower limit if test mode is enabled.
- Change static field to static method to prevent compile-time evaluation by native-image.

Result:
Test takes 0.5 instead of 15 seconds to run (on my machine).

Fixes #691.