### PR TITLE
Add analyze imports libs (SPICE-0001)

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -5404,7 +5404,7 @@ package {
   packageZipUrl = "https://example.com/\(name)/\(name)@\(version).zip" // <4>
 }
 ----
-<1> The display name of the package. For display purposes only.
+<1> The display name of the package.For display purposes only.
 <2> The package URI, without the version part.
 <3> The version of the package.
 <4> The URL to download the package's ZIP file.
@@ -5412,8 +5412,9 @@ package {
 The package itself is created by the command xref:pkl-cli:index.adoc#command-project-package[`pkl project package`].
 
 This command only prepares artifacts to be published.
-Once the artifacts are prepared, they are expected to be uploaded to an HTTPS server such that the ZIP asset can be downloaded at path `packageZipUrl`, and the metadata can be downloaded at `+https://<package uri>+`. 
+Once the artifacts are prepared, they are expected to be uploaded to an HTTPS server such that the ZIP asset can be downloaded at path `packageZipUrl`, and the metadata can be downloaded at `+https://<package uri>+`.
 
+[[local-dependencies]]
 ==== Local dependencies
 
 A project can depend on a local project as a dependency.

--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -591,7 +591,7 @@ The <<command-eval>>, <<command-test>>, <<command-repl>>, <<command-project-reso
 
 include::../../pkl-cli/partials/cli-common-options.adoc[]
 
-The <<command-eval>>, <<command-test>>, <<command-repl>>, and <<command-download-package>>, <<command-analyze-imports>> commands also take the following options:
+The <<command-eval>>, <<command-test>>, <<command-repl>>, <<command-download-package>>, and <<command-analyze-imports>> commands also take the following options:
 
 include::../../pkl-cli/partials/cli-project-options.adoc[]
 

--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -565,6 +565,30 @@ This command accepts <<common-options,common options>>.
 
 This command builds a graph of imports declared in the provided modules.
 
+This is a lower level command that is meant to be useful for Pkl-related tooling.
+For example, this command feeds into the xref:pkl-gradle:index.adoc[] to determine if tasks are considered up-to-date or not.
+
+This command produces an object with two properties, `imports` and `resolvedImports`.
+
+The `imports` property is a mapping of a module's absolute URI, to the set of imports declared within that module.
+
+The `resolvedImports` property is a mapping of a module's absolute URI (as stated in `imports`), to the resolved absolute URI that might be useful for fetching the module's contents.
+For example, a xref:language-reference:index.adoc#local-dependencies[local dependency] import will have an in-language URI with scheme `projectpackage:`, and may have resolved URI with scheme `file:` (assuming that the project is file-based).
+
+Examples:
+
+[source,shell]
+----
+# Analyze the imports of a single module
+pkl analyze imports myModule.pkl
+
+# Same as the previous command, but output in JSON.
+pkl analyze imports -f json myModule.pkl
+
+# Analyze imports of all modules declared within src/
+pkl analyze imports src/*.pkl
+----
+
 <modules>::
 The absolute or relative URIs of the modules to analyze. Relative URIs are resolved against the working directory.
 

--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -444,6 +444,15 @@ Start a REPL session.
 
 This command takes <<common-options, common options>>.
 
+[[command-get-imports]]
+=== `pkl get-imports`
+
+*Synopsis* `pkl get-imports [<options>] [<args>]`
+
+Builds the graph of imports from the given input module(s).
+
+This outputs a JSON object, where each key is a module imported somewhere by the program, and the values are the set of modules imported by the module specified by the key.
+
 [[command-project-package]]
 === `pkl project package`
 

--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -444,15 +444,6 @@ Start a REPL session.
 
 This command takes <<common-options, common options>>.
 
-[[command-get-imports]]
-=== `pkl get-imports`
-
-*Synopsis* `pkl get-imports [<options>] [<args>]`
-
-Builds the graph of imports from the given input module(s).
-
-This outputs a JSON object, where each key is a module imported somewhere by the program, and the values are the set of modules imported by the module specified by the key.
-
 [[command-project-package]]
 === `pkl project package`
 
@@ -567,14 +558,40 @@ package already exists in the cache directory, this command is a no-op.
 
 This command accepts <<common-options,common options>>.
 
+[[command-analyze-imports]]
+=== `pkl analyze imports`
+
+*Synopsis*: `pkl analyze imports [<modules>]`
+
+This command builds a graph of imports declared in the provided modules.
+
+<modules>::
+The absolute or relative URIs of the modules to analyze. Relative URIs are resolved against the working directory.
+
+==== Options
+
+.-f, --format
+[%collapsible]
+====
+Same meaning as <<format>> in <<command-eval>>.
+====
+
+.-o, --output-path
+[%collapsible]
+====
+Same meaning as <<output-path>> in <<command-eval>>.
+====
+
+This command also takes <<common-options,common options>>.
+
 [[common-options]]
 === Common options
 
-The <<command-eval>>, <<command-test>>, <<command-repl>>, <<command-project-resolve>>, <<command-project-package>>, and <<command-download-package>> commands support the following common options:
+The <<command-eval>>, <<command-test>>, <<command-repl>>, <<command-project-resolve>>, <<command-project-package>>, <<command-download-package>>, and <<command-analyze-imports>> commands support the following common options:
 
 include::../../pkl-cli/partials/cli-common-options.adoc[]
 
-The <<command-eval>>, <<command-test>>, <<command-repl>>, and <<command-download-package>> commands also take the following options:
+The <<command-eval>>, <<command-test>>, <<command-repl>>, and <<command-download-package>>, <<command-analyze-imports>> commands also take the following options:
 
 include::../../pkl-cli/partials/cli-project-options.adoc[]
 

--- a/docs/modules/pkl-cli/partials/cli-common-options.adoc
+++ b/docs/modules/pkl-cli/partials/cli-common-options.adoc
@@ -7,7 +7,6 @@ Comma-separated list of URI patterns that determine which modules can be loaded 
 Patterns are matched against the beginning of module URIs.
 (File paths have been converted to `file:` URLs at this stage.)
 At least one pattern needs to match for a module to be loadable.
-Both source modules and transitive modules are subject to this check.
 ====
 
 [[allowed-resources]]

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -692,6 +692,41 @@ include::../partials/gradle-common-properties.adoc[]
 
 This feature is the Gradle analogy for the xref:pkl-cli:index.adoc#command-analyze-imports[analyze imports] command in the CLI. It builds a graph of imports of the provided source modules.
 
+=== Usage
+
+[tabs]
+====
+build.gradle::
++
+[source,groovy]
+----
+pkl {
+  analyzers {
+    imports {
+      appConfig {
+        sourceModules.add(file("src/main/resources/appConfig.pkl"))
+      }
+    }
+  }
+}
+----
+
+build.gradle.kts::
++
+[source,kotlin]
+----
+pkl {
+  analyzers {
+    imports {
+      register("appConfig") {
+        sourceModules.add(file("src/main/resources/appConfig.pkl"))
+      }
+    }
+  }
+}
+----
+====
+
 === Configuration Options
 
 .outputFormat: Property<String>

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -102,7 +102,6 @@ pkl {
   evaluators {
     evalPkl {
       sourceModules.add(file("module1.pkl"))
-      transitiveModules.from file("module2.pkl")
       outputFile = layout.buildDirectory.file("module1.yaml")
       outputFormat = "yaml"
     }
@@ -118,7 +117,6 @@ pkl {
   evaluators {
     register("evalPkl") {
       sourceModules.add(file("module1.pkl"))
-      transitiveModules.from(file("module2.pkl"))
       outputFile.set(layout.buildDirectory.file("module1.yaml"))
       outputFormat.set("yaml")
     }
@@ -126,9 +124,6 @@ pkl {
 }
 ----
 ====
-
-To guarantee correct Gradle up-to-date behavior, 
-`transitiveModules` needs to contain all module files transitively referenced by `sourceModules`.
 
 For each declared evaluator, the Pkl plugin creates an equally named task.
 Hence the above evaluator can be run with:
@@ -691,3 +686,26 @@ The project directories to create packages for.
 Common properties:
 
 include::../partials/gradle-common-properties.adoc[]
+
+[[analyze-imports]]
+== Analyze Imports
+
+This feature is the Gradle analogy for the xref:pkl-cli:index.adoc#command-analyze-imports[analyze imports] command in the CLI. It builds a graph of imports of the provided source modules.
+
+=== Configuration Options
+
+.outputFormat: Property<String>
+[%collapsible]
+====
+Same meaning as <<output-format,outputFormat>> in <<module-evaluation>>.
+====
+
+.outputFile: RegularFileProperty<String>
+[%collapsible]
+====
+Same meaning as <<output-file,outputFile>> in <<module-evaluation>>.
+====
+
+Common properties:
+
+include::../partials/gradle-modules-properties.adoc[]

--- a/docs/modules/pkl-gradle/partials/gradle-common-properties.adoc
+++ b/docs/modules/pkl-gradle/partials/gradle-common-properties.adoc
@@ -7,7 +7,6 @@ URI patterns that determine which modules can be loaded and evaluated.
 Patterns are matched against the beginning of module URIs.
 (File paths have been converted to `file:` URLs at this stage.)
 At least one pattern needs to match for a module to be loadable.
-Both source modules and transitive modules are subject to this check.
 ====
 
 .allowedResources: ListProperty<String>

--- a/docs/modules/pkl-gradle/partials/gradle-modules-properties.adoc
+++ b/docs/modules/pkl-gradle/partials/gradle-modules-properties.adoc
@@ -17,18 +17,6 @@ This property accepts the following types to represent a module:
 * `org.gradle.api.file.FileSystemLocation`
 ====
 
-.transitiveModules: ConfigurableFileCollection
-[%collapsible]
-====
-Default: `files()` (empty collection) +
-Example 1: `transitiveModules.from files("module1.pkl", "module2.pkl")` +
-Example 2: `+transitiveModules.from fileTree("config").include("**/*.pkl")+` +
-File paths of modules that are directly or indirectly used by source modules.
-Setting this option enables correct Gradle up-to-date checks, which ensures that your Pkl tasks are executed if any of the transitive files are modified; it does not affect evaluation otherwise.
-Including source modules in `transitiveModules` is permitted but not required.
-Relative paths are resolved against the project directory.
-====
-
 .projectDir: DirectoryProperty
 [%collapsible]
 ====

--- a/docs/modules/pkl-gradle/partials/gradle-modules-properties.adoc
+++ b/docs/modules/pkl-gradle/partials/gradle-modules-properties.adoc
@@ -17,6 +17,24 @@ This property accepts the following types to represent a module:
 * `org.gradle.api.file.FileSystemLocation`
 ====
 
+.transitiveModules: ConfigurableFileCollection
+[%collapsible]
+====
+Default: [computed by pkl-gradle] +
+Example 1: `transitiveModules.from files("module1.pkl", "module2.pkl")` +
+Example 2: `+transitiveModules.from fileTree("config").include("**/*.pkl")+` +
+
+File paths of modules that are directly or indirectly used by source modules.
+
+This property, along with `sourceModules`, is the set of input files used to determine whether this task is up-to-date or not.
+
+By default, Pkl computes this property by analyzing the imports of the source modules.
+Setting this property explicitly causes Pkl to skip the analyze imports step.
+
+Including source modules in `transitiveModules` is permitted but not required.
+Relative paths are resolved against the project directory.
+====
+
 .projectDir: DirectoryProperty
 [%collapsible]
 ====

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzer.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzer.kt
@@ -44,20 +44,20 @@ constructor(
   private val sourceModule =
     ModuleSource.text(
       """
-    import "pkl:analyze"
+        import "pkl:analyze"
 
-    local importStrings = read*("prop:pkl.analyzeImports.**").toMap().values.toSet()
+        local importStrings = read*("prop:pkl.analyzeImports.**").toMap().values.toSet()
 
-    output {
-      value = analyze.importGraph(importStrings)
-      renderer {
-        converters {
-          [Map] = (it) -> it.toMapping()
-          [Set] = (it) -> it.toListing()
+        output {
+          value = analyze.importGraph(importStrings)
+          renderer {
+            converters {
+              [Map] = (it) -> it.toMapping()
+              [Set] = (it) -> it.toListing()
+            }
+          }
         }
-      }
-    }
-  """
+      """
         .trimIndent()
     )
 

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzer.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzer.kt
@@ -22,7 +22,9 @@ import org.pkl.commons.writeString
 import org.pkl.core.ModuleSource
 import org.pkl.core.module.ModuleKeyFactories
 
-class CliImportAnalyzer(
+class CliImportAnalyzer
+@JvmOverloads
+constructor(
   private val options: CliImportAnalyzerOptions,
   private val consoleWriter: Writer = System.out.writer()
 ) : CliCommand(options.base) {

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzer.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzer.kt
@@ -1,0 +1,77 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.cli
+
+import java.io.Writer
+import org.pkl.commons.cli.CliCommand
+import org.pkl.commons.createParentDirectories
+import org.pkl.commons.writeString
+import org.pkl.core.ModuleSource
+import org.pkl.core.module.ModuleKeyFactories
+
+class CliImportAnalyzer(
+  private val options: CliImportAnalyzerOptions,
+  private val consoleWriter: Writer = System.out.writer()
+) : CliCommand(options.base) {
+
+  override fun doRun() {
+    val rendered = render()
+    if (options.outputPath != null) {
+      options.outputPath.createParentDirectories()
+      options.outputPath.writeString(rendered)
+    } else {
+      consoleWriter.write(rendered)
+      consoleWriter.flush()
+    }
+  }
+
+  // language=pkl
+  private val sourceModule =
+    ModuleSource.text(
+      """
+    import "pkl:analyze"
+
+    local importStrings = read*("prop:pkl.analyzeImports.**").toMap().values.toSet()
+
+    output {
+      value = analyze.importGraph(importStrings)
+      renderer {
+        converters {
+          [Map] = (it) -> it.toMapping()
+          [Set] = (it) -> it.toListing()
+        }
+      }
+    }
+  """
+        .trimIndent()
+    )
+
+  private fun render(): String {
+    val builder = evaluatorBuilder().setOutputFormat(options.outputFormat)
+    try {
+      return builder
+        .apply {
+          for ((idx, sourceModule) in options.base.normalizedSourceModules.withIndex()) {
+            addExternalProperty("pkl.analyzeImports.$idx", sourceModule.toString())
+          }
+        }
+        .build()
+        .use { it.evaluateOutputText(sourceModule) }
+    } finally {
+      ModuleKeyFactories.closeQuietly(builder.moduleKeyFactories)
+    }
+  }
+}

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzerOptions.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzerOptions.kt
@@ -28,15 +28,7 @@ data class CliImportAnalyzerOptions(
   /**
    * The output format to generate.
    *
-   * The default output renderer for a module supports the following formats:
-   * - `"json"`
-   * - `"jsonnet"`
-   * - `"pcf"` (default)
-   * - `"plist"`
-   * - `"properties"`
-   * - `"textproto"`
-   * - `"xml"`
-   * - `"yaml"`
+   * These accept the same options as [CliEvaluatorOptions.outputFormat].
    */
   val outputFormat: String? = null,
 )

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzerOptions.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzerOptions.kt
@@ -1,0 +1,42 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.cli
+
+import java.nio.file.Path
+import org.pkl.commons.cli.CliBaseOptions
+
+data class CliImportAnalyzerOptions(
+  /** Base options shared between CLI commands. */
+  val base: CliBaseOptions,
+
+  /** The file path where the output file is placed. */
+  val outputPath: Path? = null,
+
+  /**
+   * The output format to generate.
+   *
+   * The default output renderer for a module supports the following formats:
+   * - `"json"`
+   * - `"jsonnet"`
+   * - `"pcf"` (default)
+   * - `"plist"`
+   * - `"properties"`
+   * - `"textproto"`
+   * - `"xml"`
+   * - `"yaml"`
+   */
+  val outputFormat: String? = null,
+)

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/Main.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/Main.kt
@@ -34,7 +34,8 @@ internal fun main(args: Array<String>) {
         ServerCommand(helpLink),
         TestCommand(helpLink),
         ProjectCommand(helpLink),
-        DownloadPackageCommand(helpLink)
+        DownloadPackageCommand(helpLink),
+        AnalyzeCommand(helpLink)
       )
       .main(args)
   }

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/Main.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/Main.kt
@@ -35,7 +35,7 @@ internal fun main(args: Array<String>) {
         TestCommand(helpLink),
         ProjectCommand(helpLink),
         DownloadPackageCommand(helpLink),
-        AnalyzeCommand(helpLink)
+        AnalyzeCommand(helpLink),
       )
       .main(args)
   }

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/commands/AnalyzeCommand.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/commands/AnalyzeCommand.kt
@@ -1,0 +1,66 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.cli.commands
+
+import com.github.ajalt.clikt.core.NoOpCliktCommand
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.path
+import java.nio.file.Path
+import org.pkl.cli.CliImportAnalyzer
+import org.pkl.cli.CliImportAnalyzerOptions
+import org.pkl.commons.cli.commands.ModulesCommand
+import org.pkl.commons.cli.commands.single
+
+class AnalyzeCommand(helpLink: String) :
+  NoOpCliktCommand(
+    name = "analyze",
+    help = "Commands related to static analysis",
+    epilog = "For more information, visit $helpLink"
+  ) {
+  init {
+    subcommands(AnalyzeImportsCommand(helpLink))
+  }
+
+  companion object {
+    class AnalyzeImportsCommand(helpLink: String) :
+      ModulesCommand(
+        name = "imports",
+        helpLink = helpLink,
+        help = "Prints the the graph of modules imported by the input module(s)."
+      ) {
+
+      private val outputPath: Path? by
+        option(
+            names = arrayOf("-o", "--output-path"),
+            metavar = "<path>",
+            help = "File path where the output file is placed."
+          )
+          .path()
+          .single()
+
+      override fun run() {
+        val options =
+          CliImportAnalyzerOptions(
+            base = baseOptions.baseOptions(modules, projectOptions),
+            outputFormat = baseOptions.format,
+            outputPath = outputPath
+          )
+        CliImportAnalyzer(options).run()
+      }
+    }
+  }
+}

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliImportAnalyzerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliImportAnalyzerTest.kt
@@ -41,7 +41,9 @@ class CliImportAnalyzerTest {
           imports {
             ["${otherFile.toUri()}"] {}
             ["${file.toUri()}"] {
-              "${otherFile.toUri()}"
+              new {
+                uri = "${otherFile.toUri()}"
+              }
             }
           }
           resolvedImports {
@@ -73,7 +75,9 @@ class CliImportAnalyzerTest {
             "imports": {
               "${otherFile.toUri()}": [],
               "${file.toUri()}": [
-                "${otherFile.toUri()}"
+                {
+                  "uri": "${otherFile.toUri()}"
+                }
               ]
             },
             "resolvedImports": {
@@ -101,7 +105,9 @@ class CliImportAnalyzerTest {
           imports {
             ["${otherFile.toUri()}"] {}
             ["${file.toUri()}"] {
-              "${otherFile.toUri()}"
+              new {
+                uri = "${otherFile.toUri()}"
+              }
             }
           }
           resolvedImports {

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliImportAnalyzerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliImportAnalyzerTest.kt
@@ -1,0 +1,136 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.cli
+
+import java.net.URI
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.pkl.commons.cli.CliBaseOptions
+import org.pkl.commons.writeString
+import org.pkl.core.OutputFormat
+import org.pkl.core.util.StringBuilderWriter
+
+class CliImportAnalyzerTest {
+  @Test
+  fun `write to console writer`(@TempDir tempDir: Path) {
+    val file = tempDir.resolve("test.pkl").writeString("import \"bar.pkl\"")
+    val otherFile = tempDir.resolve("bar.pkl").writeString("")
+    val baseOptions = CliBaseOptions(sourceModules = listOf(file.toUri()))
+    val sb = StringBuilder()
+    val analyzer = CliImportAnalyzer(CliImportAnalyzerOptions(baseOptions), StringBuilderWriter(sb))
+    analyzer.run()
+    assertThat(sb.toString())
+      .isEqualTo(
+        """
+      imports {
+        ["${otherFile.toUri()}"] {}
+        ["${file.toUri()}"] {
+          "${otherFile.toUri()}"
+        }
+      }
+      resolvedImports {
+        ["${otherFile.toUri()}"] = "${otherFile.toRealPath().toUri()}"
+        ["${file.toUri()}"] = "${file.toRealPath().toUri()}"
+      }
+      
+    """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `different output format`(@TempDir tempDir: Path) {
+    val file = tempDir.resolve("test.pkl").writeString("import \"bar.pkl\"")
+    val otherFile = tempDir.resolve("bar.pkl").writeString("")
+    val baseOptions = CliBaseOptions(sourceModules = listOf(file.toUri()))
+    val sb = StringBuilder()
+    val analyzer =
+      CliImportAnalyzer(
+        CliImportAnalyzerOptions(baseOptions, outputFormat = OutputFormat.JSON.toString()),
+        StringBuilderWriter(sb)
+      )
+    analyzer.run()
+    assertThat(sb.toString())
+      .isEqualTo(
+        """
+      {
+        "imports": {
+          "${otherFile.toUri()}": [],
+          "${file.toUri()}": [
+            "${otherFile.toUri()}"
+          ]
+        },
+        "resolvedImports": {
+          "${otherFile.toUri()}": "${otherFile.toRealPath().toUri()}",
+          "${file.toUri()}": "${file.toRealPath().toUri()}"
+        }
+      }
+      
+    """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `write to output file`(@TempDir tempDir: Path) {
+    val file = tempDir.resolve("test.pkl").writeString("import \"bar.pkl\"")
+    val otherFile = tempDir.resolve("bar.pkl").writeString("")
+    val outputPath = tempDir.resolve("imports.pcf")
+    val baseOptions = CliBaseOptions(sourceModules = listOf(file.toUri()))
+    val analyzer = CliImportAnalyzer(CliImportAnalyzerOptions(baseOptions, outputPath = outputPath))
+    analyzer.run()
+    assertThat(outputPath)
+      .hasContent(
+        """
+      imports {
+        ["${otherFile.toUri()}"] {}
+        ["${file.toUri()}"] {
+          "${otherFile.toUri()}"
+        }
+      }
+      resolvedImports {
+        ["${otherFile.toUri()}"] = "${otherFile.toRealPath().toUri()}"
+        ["${file.toUri()}"] = "${file.toRealPath().toUri()}"
+      }
+      
+    """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `invalid syntax in module`(@TempDir tempDir: Path) {
+    val file = tempDir.resolve("test.pkl").writeString("foo = bar(]")
+    assertThatCode {
+        CliImportAnalyzer(
+            CliImportAnalyzerOptions(
+              CliBaseOptions(sourceModules = listOf(file.toUri()), settings = URI("pkl:settings"))
+            )
+          )
+          .run()
+      }
+      .hasMessageContaining(
+        """
+        –– Pkl Error ––
+        Found a syntax error when parsing module `${file.toUri()}`.
+      """
+          .trimIndent()
+      )
+  }
+}

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliImportAnalyzerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliImportAnalyzerTest.kt
@@ -38,18 +38,18 @@ class CliImportAnalyzerTest {
     assertThat(sb.toString())
       .isEqualTo(
         """
-      imports {
-        ["${otherFile.toUri()}"] {}
-        ["${file.toUri()}"] {
-          "${otherFile.toUri()}"
-        }
-      }
-      resolvedImports {
-        ["${otherFile.toUri()}"] = "${otherFile.toRealPath().toUri()}"
-        ["${file.toUri()}"] = "${file.toRealPath().toUri()}"
-      }
-      
-    """
+          imports {
+            ["${otherFile.toUri()}"] {}
+            ["${file.toUri()}"] {
+              "${otherFile.toUri()}"
+            }
+          }
+          resolvedImports {
+            ["${otherFile.toUri()}"] = "${otherFile.toRealPath().toUri()}"
+            ["${file.toUri()}"] = "${file.toRealPath().toUri()}"
+          }
+
+        """
           .trimIndent()
       )
   }
@@ -69,20 +69,20 @@ class CliImportAnalyzerTest {
     assertThat(sb.toString())
       .isEqualTo(
         """
-      {
-        "imports": {
-          "${otherFile.toUri()}": [],
-          "${file.toUri()}": [
-            "${otherFile.toUri()}"
-          ]
-        },
-        "resolvedImports": {
-          "${otherFile.toUri()}": "${otherFile.toRealPath().toUri()}",
-          "${file.toUri()}": "${file.toRealPath().toUri()}"
-        }
-      }
-      
-    """
+          {
+            "imports": {
+              "${otherFile.toUri()}": [],
+              "${file.toUri()}": [
+                "${otherFile.toUri()}"
+              ]
+            },
+            "resolvedImports": {
+              "${otherFile.toUri()}": "${otherFile.toRealPath().toUri()}",
+              "${file.toUri()}": "${file.toRealPath().toUri()}"
+            }
+          }
+
+        """
           .trimIndent()
       )
   }
@@ -98,18 +98,18 @@ class CliImportAnalyzerTest {
     assertThat(outputPath)
       .hasContent(
         """
-      imports {
-        ["${otherFile.toUri()}"] {}
-        ["${file.toUri()}"] {
-          "${otherFile.toUri()}"
-        }
-      }
-      resolvedImports {
-        ["${otherFile.toUri()}"] = "${otherFile.toRealPath().toUri()}"
-        ["${file.toUri()}"] = "${file.toRealPath().toUri()}"
-      }
-      
-    """
+          imports {
+            ["${otherFile.toUri()}"] {}
+            ["${file.toUri()}"] {
+              "${otherFile.toUri()}"
+            }
+          }
+          resolvedImports {
+            ["${otherFile.toUri()}"] = "${otherFile.toRealPath().toUri()}"
+            ["${file.toUri()}"] = "${file.toRealPath().toUri()}"
+          }
+
+        """
           .trimIndent()
       )
   }
@@ -127,9 +127,9 @@ class CliImportAnalyzerTest {
       }
       .hasMessageContaining(
         """
-        –– Pkl Error ––
-        Found a syntax error when parsing module `${file.toUri()}`.
-      """
+          –– Pkl Error ––
+          Found a syntax error when parsing module `${file.toUri()}`.
+        """
           .trimIndent()
       )
   }

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliMainTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliMainTest.kt
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
+import org.pkl.cli.commands.AnalyzeCommand
 import org.pkl.cli.commands.EvalCommand
 import org.pkl.cli.commands.RootCommand
 import org.pkl.commons.writeString
@@ -34,7 +35,8 @@ import org.pkl.commons.writeString
 class CliMainTest {
 
   private val evalCmd = EvalCommand("")
-  private val cmd = RootCommand("pkl", "pkl version 1", "").subcommands(evalCmd)
+  private val analyzeCommand = AnalyzeCommand("")
+  private val cmd = RootCommand("pkl", "pkl version 1", "").subcommands(evalCmd, analyzeCommand)
 
   @Test
   fun `duplicate CLI option produces meaningful error message`(@TempDir tempDir: Path) {

--- a/pkl-core/src/main/java/org/pkl/core/Analyzer.java
+++ b/pkl-core/src/main/java/org/pkl/core/Analyzer.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.graalvm.polyglot.Context;
+import org.pkl.core.http.HttpClient;
+import org.pkl.core.http.HttpClientInitException;
+import org.pkl.core.module.ModuleKeyFactory;
+import org.pkl.core.module.ProjectDependenciesManager;
+import org.pkl.core.packages.PackageLoadError;
+import org.pkl.core.packages.PackageResolver;
+import org.pkl.core.project.DeclaredDependencies;
+import org.pkl.core.runtime.ModuleResolver;
+import org.pkl.core.runtime.ResourceManager;
+import org.pkl.core.runtime.VmContext;
+import org.pkl.core.runtime.VmException;
+import org.pkl.core.runtime.VmImportAnalyzer;
+import org.pkl.core.runtime.VmUtils;
+import org.pkl.core.util.Nullable;
+
+/** Utility library for static analysis of Pkl programs. */
+public class Analyzer {
+  private final StackFrameTransformer transformer;
+  private final SecurityManager securityManager;
+  private final @Nullable Path moduleCacheDir;
+  private final @Nullable DeclaredDependencies projectDependencies;
+  private final ModuleResolver moduleResolver;
+  private final HttpClient httpClient;
+
+  public Analyzer(
+      StackFrameTransformer transformer,
+      SecurityManager securityManager,
+      Collection<ModuleKeyFactory> moduleKeyFactories,
+      @Nullable Path moduleCacheDir,
+      @Nullable DeclaredDependencies projectDependencies,
+      HttpClient httpClient) {
+    this.transformer = transformer;
+    this.securityManager = securityManager;
+    this.moduleCacheDir = moduleCacheDir;
+    this.projectDependencies = projectDependencies;
+    this.moduleResolver = new ModuleResolver(moduleKeyFactories);
+    this.httpClient = httpClient;
+  }
+
+  /**
+   * Builds a graph of imports from the provided source modules.
+   *
+   * <p>For details, see {@link ImportGraph}.
+   */
+  public ImportGraph importGraph(URI... sources) {
+    var context = createContext();
+    try {
+      context.enter();
+      var vmContext = VmContext.get(null);
+      var results = VmImportAnalyzer.analyze(sources, vmContext);
+      return new ImportGraph(results.first, results.second);
+    } catch (SecurityManagerException
+        | IOException
+        | URISyntaxException
+        | PackageLoadError
+        | HttpClientInitException e) {
+      throw new PklException(e.getMessage(), e);
+    } catch (PklException err) {
+      throw err;
+    } catch (VmException err) {
+      throw err.toPklException(transformer);
+    } catch (Exception e) {
+      throw new PklBugException(e);
+    } finally {
+      context.leave();
+      context.close();
+    }
+  }
+
+  private Context createContext() {
+    var packageResolver =
+        PackageResolver.getInstance(
+            securityManager, HttpClient.builder().buildLazily(), moduleCacheDir);
+    return VmUtils.createContext(
+        () -> {
+          VmContext vmContext = VmContext.get(null);
+          vmContext.initialize(
+              new VmContext.Holder(
+                  transformer,
+                  securityManager,
+                  httpClient,
+                  moduleResolver,
+                  new ResourceManager(securityManager, List.of()),
+                  Loggers.noop(),
+                  Map.of(),
+                  Map.of(),
+                  moduleCacheDir,
+                  null,
+                  packageResolver,
+                  projectDependencies == null
+                      ? null
+                      : new ProjectDependenciesManager(
+                          projectDependencies, moduleResolver, securityManager)));
+        });
+  }
+}

--- a/pkl-core/src/main/java/org/pkl/core/Analyzer.java
+++ b/pkl-core/src/main/java/org/pkl/core/Analyzer.java
@@ -106,7 +106,7 @@ public class Analyzer {
                   httpClient,
                   moduleResolver,
                   new ResourceManager(securityManager, List.of()),
-                  Loggers.noop(),
+                  Loggers.stdErr(),
                   Map.of(),
                   Map.of(),
                   moduleCacheDir,

--- a/pkl-core/src/main/java/org/pkl/core/Analyzer.java
+++ b/pkl-core/src/main/java/org/pkl/core/Analyzer.java
@@ -72,8 +72,7 @@ public class Analyzer {
     try {
       context.enter();
       var vmContext = VmContext.get(null);
-      var results = VmImportAnalyzer.analyze(sources, vmContext);
-      return new ImportGraph(results.first, results.second);
+      return VmImportAnalyzer.analyze(sources, vmContext);
     } catch (SecurityManagerException
         | IOException
         | URISyntaxException

--- a/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
@@ -433,6 +433,10 @@ public final class EvaluatorBuilder {
     return this;
   }
 
+  public @Nullable DeclaredDependencies getProjectDependencies() {
+    return this.dependencies;
+  }
+
   /**
    * Given a project, sets its dependencies, and also applies any evaluator settings if set.
    *

--- a/pkl-core/src/main/java/org/pkl/core/ImportGraph.java
+++ b/pkl-core/src/main/java/org/pkl/core/ImportGraph.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Java representation of {@code pkl.analyze#ImportGraph}.
+ *
+ * @param imports The graph of imports declared within the program.
+ *     <p>Each key is a module inside the program, and each value is the module URIs decalred as
+ *     imports inside that module. The set of all modules initialized within the program is the set
+ *     of keys in this map.
+ * @param resolvedImports A mapping of a module's in-language URI, and the URI that it resolves to.
+ *     <p>For example, a local package dependency is represented with scheme {@code
+ *     projectpackage:}, and (typically) resolves to a {@code file:} scheme.
+ */
+public record ImportGraph(Map<URI, Set<URI>> imports, Map<URI, URI> resolvedImports) {}

--- a/pkl-core/src/main/java/org/pkl/core/ImportGraph.java
+++ b/pkl-core/src/main/java/org/pkl/core/ImportGraph.java
@@ -39,6 +39,13 @@ import org.pkl.core.util.json.Json.MappingException;
  *     projectpackage:}, and (typically) resolves to a {@code file:} scheme.
  */
 public record ImportGraph(Map<URI, Set<URI>> imports, Map<URI, URI> resolvedImports) {
+  /** Parses the provided JSON into an import graph. */
+  public static ImportGraph parseFromJson(String input) throws JsonParseException {
+    var parsed = Json.parseObject(input);
+    var imports = parseImports(parsed.getObject("imports"));
+    var resolvedImports = parseResolvedImports(parsed.getObject("resolvedImports"));
+    return new ImportGraph(imports, resolvedImports);
+  }
 
   private static Map<URI, Set<URI>> parseImports(Json.JsObject jsObject) throws JsonParseException {
     var ret = new TreeMap<URI, Set<URI>>();
@@ -81,13 +88,5 @@ public record ImportGraph(Map<URI, Set<URI>> imports, Map<URI, URI> resolvedImpo
       }
     }
     return ret;
-  }
-
-  /** Parses the provided JSON into an import graph. */
-  public static ImportGraph parseFromJson(String input) throws JsonParseException {
-    var parsed = Json.parseObject(input);
-    var imports = parseImports(parsed.getObject("imports"));
-    var resolvedImports = parseResolvedImports(parsed.getObject("resolvedImports"));
-    return new ImportGraph(imports, resolvedImports);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/module/ProjectDependenciesManager.java
+++ b/pkl-core/src/main/java/org/pkl/core/module/ProjectDependenciesManager.java
@@ -199,6 +199,10 @@ public final class ProjectDependenciesManager {
     }
   }
 
+  public DeclaredDependencies getDeclaredDependencies() {
+    return declaredDependencies;
+  }
+
   public Dependency getResolvedDependency(PackageUri packageUri) {
     var dep = getProjectDeps().get(CanonicalPackageUri.fromPackageUri(packageUri));
     if (dep == null) {

--- a/pkl-core/src/main/java/org/pkl/core/project/ProjectPackager.java
+++ b/pkl-core/src/main/java/org/pkl/core/project/ProjectPackager.java
@@ -15,7 +15,6 @@
  */
 package org.pkl.core.project;
 
-import com.oracle.truffle.api.source.SourceSection;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -64,7 +63,6 @@ import org.pkl.core.util.GlobResolver;
 import org.pkl.core.util.GlobResolver.InvalidGlobPatternException;
 import org.pkl.core.util.IoUtils;
 import org.pkl.core.util.Nullable;
-import org.pkl.core.util.Pair;
 
 /**
  * Given a list of project directories, prepares artifacts to be published as a package.
@@ -397,8 +395,8 @@ public final class ProjectPackager {
       return;
     }
     for (var importContext : imports) {
-      var importStr = importContext.first;
-      var sourceSection = importContext.second;
+      var importStr = importContext.stringValue();
+      var sourceSection = importContext.sourceSection();
       if (isAbsoluteImport(importStr)) {
         continue;
       }
@@ -440,7 +438,7 @@ public final class ProjectPackager {
     }
   }
 
-  private @Nullable List<Pair<String, SourceSection>> getImportsAndReads(Path pklModulePath) {
+  private @Nullable List<ImportsAndReadsParser.Entry> getImportsAndReads(Path pklModulePath) {
     try {
       var moduleKey = ModuleKeys.file(pklModulePath.toUri());
       var resolvedModuleKey = ResolvedModuleKeys.file(moduleKey, moduleKey.getUri(), pklModulePath);

--- a/pkl-core/src/main/java/org/pkl/core/runtime/AnalyzeModule.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/AnalyzeModule.java
@@ -33,8 +33,16 @@ public class AnalyzeModule extends StdLibModule {
     return AnalyzeModule.ImportGraphClass.instance;
   }
 
+  public static VmClass getImportClass() {
+    return AnalyzeModule.ImportClass.instance;
+  }
+
   private static final class ImportGraphClass {
     static final VmClass instance = loadClass("ImportGraph");
+  }
+
+  private static final class ImportClass {
+    static final VmClass instance = loadClass("Import");
   }
 
   @TruffleBoundary

--- a/pkl-core/src/main/java/org/pkl/core/runtime/AnalyzeModule.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/AnalyzeModule.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.runtime;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import java.net.URI;
+
+public class AnalyzeModule extends StdLibModule {
+  private static final VmTyped instance = VmUtils.createEmptyModule();
+
+  static {
+    loadModule(URI.create("pkl:analyze"), instance);
+  }
+
+  public static VmTyped getModule() {
+    return instance;
+  }
+
+  public static VmClass getImportGraphClass() {
+    return AnalyzeModule.ImportGraphClass.instance;
+  }
+
+  private static final class ImportGraphClass {
+    static final VmClass instance = loadClass("ImportGraph");
+  }
+
+  @TruffleBoundary
+  private static VmClass loadClass(String className) {
+    var theModule = getModule();
+    return (VmClass) VmUtils.readMember(theModule, Identifier.get(className));
+  }
+}

--- a/pkl-core/src/main/java/org/pkl/core/runtime/ModuleCache.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/ModuleCache.java
@@ -85,6 +85,8 @@ public final class ModuleCache {
       // some standard library modules are cached as static singletons
       // and hence aren't parsed/initialized anew for every evaluator
       switch (moduleName) {
+        case "analyze":
+          return AnalyzeModule.getModule();
         case "base":
           // always needed
           return BaseModule.getModule();

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmException.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmException.java
@@ -94,6 +94,7 @@ public abstract class VmException extends AbstractTruffleException {
   public enum Kind {
     EVAL_ERROR,
     UNDEFINED_VALUE,
+    WRAPPED,
     BUG
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmExceptionBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmExceptionBuilder.java
@@ -53,6 +53,7 @@ public final class VmExceptionBuilder {
 
   private @Nullable Object receiver;
   private @Nullable Map<CallTarget, StackFrame> insertedStackFrames;
+  private VmException wrappedException;
 
   public static class MultilineValue {
     private final Iterable<?> lines;
@@ -332,6 +333,12 @@ public final class VmExceptionBuilder {
     return this;
   }
 
+  public VmExceptionBuilder wrapping(VmException nestedException) {
+    this.wrappedException = nestedException;
+    this.kind = VmException.Kind.WRAPPED;
+    return this;
+  }
+
   public VmExceptionBuilder withInsertedStackFrames(
       Map<CallTarget, StackFrame> insertedStackFrames) {
     this.insertedStackFrames = insertedStackFrames;
@@ -383,6 +390,19 @@ public final class VmExceptionBuilder {
               memberName,
               hint,
               effectiveInsertedStackFrames);
+      case WRAPPED ->
+          new VmWrappedEvalException(
+              message,
+              cause,
+              isExternalMessage,
+              messageArguments,
+              programValues,
+              location,
+              sourceSection,
+              memberName,
+              hint,
+              effectiveInsertedStackFrames,
+              wrappedException);
     };
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmExceptionRenderer.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmExceptionRenderer.java
@@ -19,6 +19,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
 import org.pkl.core.Release;
 import org.pkl.core.util.ErrorMessages;
 import org.pkl.core.util.Nullable;
@@ -46,7 +47,7 @@ public final class VmExceptionRenderer {
     if (exception instanceof VmBugException bugException) {
       renderBugException(bugException, builder);
     } else {
-      renderException(exception, builder);
+      renderException(exception, builder, true);
     }
   }
 
@@ -66,13 +67,13 @@ public final class VmExceptionRenderer {
             .replaceAll("\\+", "%20"));
 
     builder.append("\n\n");
-    renderException(exception, builder);
+    renderException(exception, builder, true);
     builder.append('\n').append(Release.current().versionInfo()).append("\n\n");
 
     exceptionToReport.printStackTrace(new PrintWriter(new StringBuilderWriter(builder)));
   }
 
-  private void renderException(VmException exception, StringBuilder builder) {
+  private void renderException(VmException exception, StringBuilder builder, boolean withHeader) {
     var header = "–– Pkl Error ––";
 
     String message;
@@ -94,7 +95,16 @@ public final class VmExceptionRenderer {
       message = exception.getMessage();
     }
 
-    builder.append(header).append('\n').append(message).append('\n');
+    if (withHeader) {
+      builder.append(header).append('\n');
+    }
+    builder.append(message).append('\n');
+
+    if (exception instanceof VmWrappedEvalException vmWrappedEvalException) {
+      var sb = new StringBuilder();
+      renderException(vmWrappedEvalException.getWrappedException(), sb, false);
+      hint = sb.toString().lines().map((it) -> ">\t" + it).collect(Collectors.joining("\n"));
+    }
 
     // include cause's message unless it's the same as this exception's message
     if (exception.getCause() != null) {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmImportAnalyzer.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmImportAnalyzer.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.runtime;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.pkl.core.SecurityManager;
+import org.pkl.core.SecurityManagerException;
+import org.pkl.core.ast.builder.ImportsAndReadsParser;
+import org.pkl.core.ast.builder.ImportsAndReadsParser.Entry;
+import org.pkl.core.util.GlobResolver;
+import org.pkl.core.util.GlobResolver.InvalidGlobPatternException;
+import org.pkl.core.util.GlobResolver.ResolvedGlobElement;
+import org.pkl.core.util.IoUtils;
+import org.pkl.core.util.Pair;
+
+public class VmImportAnalyzer {
+  @TruffleBoundary
+  public static Pair<Map<URI, Set<URI>>, Map<URI, URI>> analyze(URI[] moduleUris, VmContext context)
+      throws IOException, URISyntaxException, SecurityManagerException {
+    var imports = new TreeMap<URI, Set<URI>>();
+    var resolvedImports = new TreeMap<URI, URI>();
+    for (var moduleUri : moduleUris) {
+      analyzeSingle(moduleUri, context, imports, resolvedImports);
+    }
+    return Pair.of(imports, resolvedImports);
+  }
+
+  @TruffleBoundary
+  private static void analyzeSingle(
+      URI moduleUri, VmContext context, Map<URI, Set<URI>> imports, Map<URI, URI> resolvedImports)
+      throws IOException, URISyntaxException, SecurityManagerException {
+    var moduleResolver = context.getModuleResolver();
+    var securityManager = context.getSecurityManager();
+    var importsInModule = collectImports(moduleUri, moduleResolver, securityManager);
+
+    imports.put(moduleUri, importsInModule);
+    resolvedImports.put(
+        moduleUri, moduleResolver.resolve(moduleUri).resolve(securityManager).getUri());
+    for (var importUri : importsInModule) {
+      if (imports.containsKey(importUri)) {
+        continue;
+      }
+      analyzeSingle(importUri, context, imports, resolvedImports);
+    }
+  }
+
+  private static Set<URI> collectImports(
+      URI moduleUri, ModuleResolver moduleResolver, SecurityManager securityManager)
+      throws IOException, URISyntaxException, SecurityManagerException {
+    var moduleKey = moduleResolver.resolve(moduleUri);
+    var resolvedModuleKey = moduleKey.resolve(securityManager);
+    List<Entry> importsAndReads;
+    try {
+      importsAndReads = ImportsAndReadsParser.parse(moduleKey, resolvedModuleKey);
+    } catch (VmException err) {
+      throw new VmExceptionBuilder()
+          .evalError("cannotAnalyzeBecauseSyntaxError", moduleKey.getUri())
+          .wrapping(err)
+          .build();
+    }
+    if (importsAndReads == null) {
+      return Set.of();
+    }
+    var result = new TreeSet<URI>();
+    for (var entry : importsAndReads) {
+      if (!entry.isModule()) {
+        continue;
+      }
+      if (entry.isGlob()) {
+        var theModuleKey =
+            moduleResolver.resolve(moduleKey.resolveUri(IoUtils.toUri(entry.stringValue())));
+        try {
+          var elements =
+              GlobResolver.resolveGlob(
+                  securityManager,
+                  theModuleKey,
+                  moduleKey,
+                  moduleKey.getUri(),
+                  entry.stringValue());
+          result.addAll(elements.values().stream().map(ResolvedGlobElement::getUri).toList());
+        } catch (InvalidGlobPatternException e) {
+          throw new VmExceptionBuilder()
+              .evalError("invalidGlobPattern", entry.stringValue())
+              .withSourceSection(entry.sourceSection())
+              .build();
+        }
+      } else {
+        var resolvedUri =
+            IoUtils.resolve(securityManager, moduleKey, IoUtils.toUri(entry.stringValue()));
+        result.add(resolvedUri);
+      }
+    }
+    return result;
+  }
+}

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmWrappedEvalException.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmWrappedEvalException.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.runtime;
+
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
+import java.util.List;
+import java.util.Map;
+import org.pkl.core.StackFrame;
+import org.pkl.core.util.Nullable;
+
+public class VmWrappedEvalException extends VmEvalException {
+
+  private final VmException wrappedException;
+
+  public VmWrappedEvalException(
+      String message,
+      @Nullable Throwable cause,
+      boolean isExternalMessage,
+      Object[] messageArguments,
+      List<ProgramValue> programValues,
+      @Nullable Node location,
+      @Nullable SourceSection sourceSection,
+      @Nullable String memberName,
+      @Nullable String hint,
+      Map<CallTarget, StackFrame> insertedStackFrames,
+      VmException wrappedException) {
+    super(
+        message,
+        cause,
+        isExternalMessage,
+        messageArguments,
+        programValues,
+        location,
+        sourceSection,
+        memberName,
+        hint,
+        insertedStackFrames);
+    this.wrappedException = wrappedException;
+  }
+
+  public VmException getWrappedException() {
+    return wrappedException;
+  }
+}

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/analyze/AnalyzeNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/analyze/AnalyzeNodes.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.stdlib.analyze;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.Specialization;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Set;
+import org.pkl.core.SecurityManagerException;
+import org.pkl.core.packages.PackageLoadError;
+import org.pkl.core.runtime.AnalyzeModule;
+import org.pkl.core.runtime.VmContext;
+import org.pkl.core.runtime.VmImportAnalyzer;
+import org.pkl.core.runtime.VmMap;
+import org.pkl.core.runtime.VmSet;
+import org.pkl.core.runtime.VmTyped;
+import org.pkl.core.stdlib.ExternalMethod1Node;
+import org.pkl.core.stdlib.VmObjectFactory;
+import org.pkl.core.util.Pair;
+
+public final class AnalyzeNodes {
+  private AnalyzeNodes() {}
+
+  private static VmObjectFactory<Pair<Map<URI, Set<URI>>, Map<URI, URI>>> importGraphFactory =
+      new VmObjectFactory<Pair<Map<URI, Set<URI>>, Map<URI, URI>>>(
+              AnalyzeModule::getImportGraphClass)
+          .addMapProperty(
+              "imports",
+              results -> {
+                var builder = VmMap.builder();
+                for (var entry : results.getFirst().entrySet()) {
+                  var vmSetBuilder = VmSet.EMPTY.builder();
+                  for (var importUri : entry.getValue()) {
+                    vmSetBuilder.add(importUri.toString());
+                  }
+                  builder.add(entry.getKey().toString(), vmSetBuilder.build());
+                }
+                return builder.build();
+              })
+          .addMapProperty(
+              "resolvedImports",
+              results -> {
+                var builder = VmMap.builder();
+                for (var entry : results.getSecond().entrySet()) {
+                  builder.add(entry.getKey().toString(), entry.getValue().toString());
+                }
+                return builder.build();
+              });
+
+  public abstract static class importGraph extends ExternalMethod1Node {
+    @Specialization
+    @TruffleBoundary
+    protected Object eval(@SuppressWarnings("unused") VmTyped self, VmSet moduleUris) {
+      var uris = new URI[moduleUris.getLength()];
+      var idx = 0;
+      for (var moduleUri : moduleUris) {
+        URI uri;
+        try {
+          uri = new URI((String) moduleUri);
+        } catch (URISyntaxException e) {
+          CompilerDirectives.transferToInterpreter();
+          throw exceptionBuilder()
+              .evalError("invalidModuleUri", moduleUri)
+              .withHint(e.getMessage())
+              .build();
+        }
+        if (!uri.isAbsolute()) {
+          CompilerDirectives.transferToInterpreter();
+          throw exceptionBuilder().evalError("cannotAnalyzeRelativeModuleUri", moduleUri).build();
+        }
+        uris[idx] = uri;
+        idx++;
+      }
+      var context = VmContext.get(this);
+      try {
+        var results = VmImportAnalyzer.analyze(uris, context);
+        return importGraphFactory.create(results);
+      } catch (IOException | URISyntaxException | SecurityManagerException | PackageLoadError e) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        throw exceptionBuilder().withCause(e).build();
+      }
+    }
+  }
+}

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/analyze/AnalyzeNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/analyze/AnalyzeNodes.java
@@ -75,14 +75,12 @@ public final class AnalyzeNodes {
         try {
           uri = new URI((String) moduleUri);
         } catch (URISyntaxException e) {
-          CompilerDirectives.transferToInterpreter();
           throw exceptionBuilder()
               .evalError("invalidModuleUri", moduleUri)
               .withHint(e.getMessage())
               .build();
         }
         if (!uri.isAbsolute()) {
-          CompilerDirectives.transferToInterpreter();
           throw exceptionBuilder().evalError("cannotAnalyzeRelativeModuleUri", moduleUri).build();
         }
         uris[idx] = uri;
@@ -93,7 +91,6 @@ public final class AnalyzeNodes {
         var results = VmImportAnalyzer.analyze(uris, context);
         return importGraphFactory.create(results);
       } catch (IOException | URISyntaxException | SecurityManagerException | PackageLoadError e) {
-        CompilerDirectives.transferToInterpreterAndInvalidate();
         throw exceptionBuilder().withCause(e).build();
       }
     }

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/analyze/package-info.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/analyze/package-info.java
@@ -1,6 +1,4 @@
 @NonnullByDefault
-@PklName("analyze")
 package org.pkl.core.stdlib.analyze;
 
-import org.pkl.core.stdlib.PklName;
 import org.pkl.core.util.NonnullByDefault;

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/analyze/package-info.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/analyze/package-info.java
@@ -1,0 +1,6 @@
+@NonnullByDefault
+@PklName("analyze")
+package org.pkl.core.stdlib.analyze;
+
+import org.pkl.core.stdlib.PklName;
+import org.pkl.core.util.NonnullByDefault;

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -632,6 +632,9 @@ Expected an exception, but none was thrown.
 cannotEvaluateRelativeModuleUri=\
 Cannot evaluate relative module URI `{0}`.
 
+cannotAnalyzeRelativeModuleUri=\
+Cannot analyze relative module URI `{0}`.
+
 invalidModuleUri=\
 Module URI `{0}` has invalid syntax.
 
@@ -1057,3 +1060,6 @@ To fix this problem, add dependendy `org.pkl:pkl-certs`.
 # suppress inspection "HttpUrlsUsage"
 malformedProxyAddress=\
 Malformed proxy URI (expecting `http://<host>[:<port>]`): `{0}`.
+
+cannotAnalyzeBecauseSyntaxError=\
+Found a syntax error when parsing module `{0}`.

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/analyze/a.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/analyze/a.pkl
@@ -1,0 +1,1 @@
+import "b.pkl"

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/analyze/cyclicalA.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/analyze/cyclicalA.pkl
@@ -1,0 +1,1 @@
+import "cyclicalB.pkl"

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/analyze/cyclicalB.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/analyze/cyclicalB.pkl
@@ -1,0 +1,1 @@
+import "cyclicalA.pkl"

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/analyze/globImport.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/analyze/globImport.pkl
@@ -1,0 +1,1 @@
+import* "[ab].pkl"

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/analyze1.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/analyze1.pkl
@@ -1,0 +1,33 @@
+amends "../snippetTest.pkl"
+
+import "pkl:analyze"
+import "pkl:reflect"
+
+import ".../input-helper/analyze/a.pkl"
+import ".../input-helper/analyze/cyclicalA.pkl"
+import ".../input-helper/analyze/globImport.pkl"
+
+examples {
+  ["basic"] {
+    analyze.importGraph(Set(reflect.Module(a).uri))
+  }
+  ["cycles"] {
+    analyze.importGraph(Set(reflect.Module(cyclicalA).uri))
+  }
+  ["globs"] {
+    analyze.importGraph(Set(reflect.Module(globImport).uri))
+  }
+  ["packages"] {
+    analyze.importGraph(Set("package://localhost:0/birds@0.5.0#/Bird.pkl"))
+  }
+}
+
+output {
+  renderer {
+    // mimick result of `pkl analyze imports` CLI command
+    converters {
+      [Map] = (it) -> it.toMapping()
+      [Set] = (it) -> it.toListing()
+    }
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/analyzeInvalidHttpModule.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/analyzeInvalidHttpModule.pkl
@@ -1,0 +1,3 @@
+import "pkl:analyze"
+
+result = analyze.importGraph(Set("http://localhost:0/foo.pkl"))

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/analyzeInvalidModuleUri.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/analyzeInvalidModuleUri.pkl
@@ -1,0 +1,3 @@
+import "pkl:analyze"
+
+result = analyze.importGraph(Set("foo <>"))

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/analyzeRelativeModuleUri.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/analyzeRelativeModuleUri.pkl
@@ -1,0 +1,3 @@
+import "pkl:analyze"
+
+result = analyze.importGraph(Set("foo.pkl"))

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/analyze1.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/analyze1.pcf
@@ -1,0 +1,65 @@
+examples {
+  ["basic"] {
+    new {
+      imports {
+        ["file:///$snippetsDir/input-helper/analyze/a.pkl"] {
+          "file:///$snippetsDir/input-helper/analyze/b.pkl"
+        }
+        ["file:///$snippetsDir/input-helper/analyze/b.pkl"] {}
+      }
+      resolvedImports {
+        ["file:///$snippetsDir/input-helper/analyze/a.pkl"] = "file:///$snippetsDir/input-helper/analyze/a.pkl"
+        ["file:///$snippetsDir/input-helper/analyze/b.pkl"] = "file:///$snippetsDir/input-helper/analyze/b.pkl"
+      }
+    }
+  }
+  ["cycles"] {
+    new {
+      imports {
+        ["file:///$snippetsDir/input-helper/analyze/cyclicalA.pkl"] {
+          "file:///$snippetsDir/input-helper/analyze/cyclicalB.pkl"
+        }
+        ["file:///$snippetsDir/input-helper/analyze/cyclicalB.pkl"] {
+          "file:///$snippetsDir/input-helper/analyze/cyclicalA.pkl"
+        }
+      }
+      resolvedImports {
+        ["file:///$snippetsDir/input-helper/analyze/cyclicalA.pkl"] = "file:///$snippetsDir/input-helper/analyze/cyclicalA.pkl"
+        ["file:///$snippetsDir/input-helper/analyze/cyclicalB.pkl"] = "file:///$snippetsDir/input-helper/analyze/cyclicalB.pkl"
+      }
+    }
+  }
+  ["globs"] {
+    new {
+      imports {
+        ["file:///$snippetsDir/input-helper/analyze/a.pkl"] {
+          "file:///$snippetsDir/input-helper/analyze/b.pkl"
+        }
+        ["file:///$snippetsDir/input-helper/analyze/b.pkl"] {}
+        ["file:///$snippetsDir/input-helper/analyze/globImport.pkl"] {
+          "file:///$snippetsDir/input-helper/analyze/a.pkl"
+          "file:///$snippetsDir/input-helper/analyze/b.pkl"
+        }
+      }
+      resolvedImports {
+        ["file:///$snippetsDir/input-helper/analyze/a.pkl"] = "file:///$snippetsDir/input-helper/analyze/a.pkl"
+        ["file:///$snippetsDir/input-helper/analyze/b.pkl"] = "file:///$snippetsDir/input-helper/analyze/b.pkl"
+        ["file:///$snippetsDir/input-helper/analyze/globImport.pkl"] = "file:///$snippetsDir/input-helper/analyze/globImport.pkl"
+      }
+    }
+  }
+  ["packages"] {
+    new {
+      imports {
+        ["package://localhost:0/birds@0.5.0#/Bird.pkl"] {
+          "package://localhost:0/fruit@1.0.5#/Fruit.pkl"
+        }
+        ["package://localhost:0/fruit@1.0.5#/Fruit.pkl"] {}
+      }
+      resolvedImports {
+        ["package://localhost:0/birds@0.5.0#/Bird.pkl"] = "package://localhost:0/birds@0.5.0#/Bird.pkl"
+        ["package://localhost:0/fruit@1.0.5#/Fruit.pkl"] = "package://localhost:0/fruit@1.0.5#/Fruit.pkl"
+      }
+    }
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/analyze1.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/analyze1.pcf
@@ -3,7 +3,9 @@ examples {
     new {
       imports {
         ["file:///$snippetsDir/input-helper/analyze/a.pkl"] {
-          "file:///$snippetsDir/input-helper/analyze/b.pkl"
+          new {
+            uri = "file:///$snippetsDir/input-helper/analyze/b.pkl"
+          }
         }
         ["file:///$snippetsDir/input-helper/analyze/b.pkl"] {}
       }
@@ -17,10 +19,14 @@ examples {
     new {
       imports {
         ["file:///$snippetsDir/input-helper/analyze/cyclicalA.pkl"] {
-          "file:///$snippetsDir/input-helper/analyze/cyclicalB.pkl"
+          new {
+            uri = "file:///$snippetsDir/input-helper/analyze/cyclicalB.pkl"
+          }
         }
         ["file:///$snippetsDir/input-helper/analyze/cyclicalB.pkl"] {
-          "file:///$snippetsDir/input-helper/analyze/cyclicalA.pkl"
+          new {
+            uri = "file:///$snippetsDir/input-helper/analyze/cyclicalA.pkl"
+          }
         }
       }
       resolvedImports {
@@ -33,12 +39,18 @@ examples {
     new {
       imports {
         ["file:///$snippetsDir/input-helper/analyze/a.pkl"] {
-          "file:///$snippetsDir/input-helper/analyze/b.pkl"
+          new {
+            uri = "file:///$snippetsDir/input-helper/analyze/b.pkl"
+          }
         }
         ["file:///$snippetsDir/input-helper/analyze/b.pkl"] {}
         ["file:///$snippetsDir/input-helper/analyze/globImport.pkl"] {
-          "file:///$snippetsDir/input-helper/analyze/a.pkl"
-          "file:///$snippetsDir/input-helper/analyze/b.pkl"
+          new {
+            uri = "file:///$snippetsDir/input-helper/analyze/a.pkl"
+          }
+          new {
+            uri = "file:///$snippetsDir/input-helper/analyze/b.pkl"
+          }
         }
       }
       resolvedImports {
@@ -52,7 +64,9 @@ examples {
     new {
       imports {
         ["package://localhost:0/birds@0.5.0#/Bird.pkl"] {
-          "package://localhost:0/fruit@1.0.5#/Fruit.pkl"
+          new {
+            uri = "package://localhost:0/fruit@1.0.5#/Fruit.pkl"
+          }
         }
         ["package://localhost:0/fruit@1.0.5#/Fruit.pkl"] {}
       }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeInvalidHttpModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeInvalidHttpModule.err
@@ -1,0 +1,10 @@
+–– Pkl Error ––
+HTTP/1.1 header parser received no bytes
+
+x | result = analyze.importGraph(Set("http://localhost:0/foo.pkl"))
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at analyzeInvalidHttpModule#result (file:///$snippetsDir/input/errors/analyzeInvalidHttpModule.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeInvalidModuleUri.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeInvalidModuleUri.err
@@ -1,0 +1,12 @@
+–– Pkl Error ––
+Module URI `foo <>` has invalid syntax.
+
+x | result = analyze.importGraph(Set("foo <>"))
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at analyzeInvalidModuleUri#result (file:///$snippetsDir/input/errors/analyzeInvalidModuleUri.pkl)
+
+Illegal character in path at index 3: foo <>
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeRelativeModuleUri.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeRelativeModuleUri.err
@@ -1,0 +1,10 @@
+–– Pkl Error ––
+Cannot analyze relative module URI `foo.pkl`.
+
+x | result = analyze.importGraph(Set("foo.pkl"))
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at analyzeRelativeModuleUri#result (file:///$snippetsDir/input/errors/analyzeRelativeModuleUri.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotFindStdLibModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotFindStdLibModule.err
@@ -6,6 +6,7 @@ x | import "pkl:nonExisting"
 at cannotFindStdLibModule#nonExisting (file:///$snippetsDir/input/errors/cannotFindStdLibModule.pkl)
 
 Available standard library modules:
+pkl:analyze
 pkl:base
 pkl:Benchmark
 pkl:DocPackageInfo

--- a/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
@@ -45,13 +45,13 @@ class AnalyzerTest {
         .resolve("test.pkl")
         .writeString(
           """
-      amends "pkl:base"
+            amends "pkl:base"
 
-      import "pkl:json"
+            import "pkl:json"
 
-      myProp = import("pkl:xml")
-    """
-            .trimIndent()
+            myProp = import("pkl:xml")
+          """
+            .trimIndent()```
         )
         .toUri()
     val result = simpleAnalyzer.importGraph(file)
@@ -66,9 +66,9 @@ class AnalyzerTest {
         .resolve("file1.pkl")
         .writeString(
           """
-      import* "*.pkl"
-    """
-            .trimIndent()
+            import* "*.pkl"
+          """
+            .trimIndent()```
         )
         .toUri()
     val file2 = tempDir.resolve("file2.pkl").writeString("foo = 1").toUri()
@@ -123,12 +123,12 @@ class AnalyzerTest {
       .resolve("PklProject")
       .writeString(
         """
-      amends "pkl:Project"
-      
-      dependencies {
-        ["birds"] { uri = "package://localhost:0/birds@0.5.0" }
-      }
-    """
+          amends "pkl:Project"
+
+          dependencies {
+            ["birds"] { uri = "package://localhost:0/birds@0.5.0" }
+          }
+        """
           .trimIndent()
       )
     val dollar = '$'
@@ -136,26 +136,26 @@ class AnalyzerTest {
       .resolve("PklProject.deps.json")
       .writeString(
         """
-      {
-        "schemaVersion": 1,
-        "resolvedDependencies": {
-          "package://localhost:0/birds@0": {
-            "type": "remote",
-            "uri": "projectpackage://localhost:0/birds@0.5.0",
-            "checksums": {
-              "sha256": "${dollar}skipChecksumVerification"
-            }
-          },
-          "package://localhost:0/fruit@1": {
-            "type": "remote",
-            "uri": "projectpackage://localhost:0/fruit@1.0.5",
-            "checksums": {
-              "sha256": "${dollar}skipChecksumVerification"
+          {
+            "schemaVersion": 1,
+            "resolvedDependencies": {
+              "package://localhost:0/birds@0": {
+                "type": "remote",
+                "uri": "projectpackage://localhost:0/birds@0.5.0",
+                "checksums": {
+                  "sha256": "${dollar}skipChecksumVerification"
+                }
+              },
+              "package://localhost:0/fruit@1": {
+                "type": "remote",
+                "uri": "projectpackage://localhost:0/fruit@1.0.5",
+                "checksums": {
+                  "sha256": "${dollar}skipChecksumVerification"
+                }
+              }
             }
           }
-        }
-      }
-    """
+        """
           .trimIndent()
       )
     val project = Project.loadFromPath(tempDir.resolve("PklProject"))
@@ -179,8 +179,8 @@ class AnalyzerTest {
         .resolve("file1.pkl")
         .writeString(
           """
-      import "@birds/Bird.pkl"
-    """
+            import "@birds/Bird.pkl"
+          """
             .trimIndent()
         )
         .toUri()
@@ -214,12 +214,12 @@ class AnalyzerTest {
         .createParentDirectories()
         .writeString(
           """
-      amends "pkl:Project"
-      
-      dependencies {
-        ["birds"] = import("../birds/PklProject")
-      }
-    """
+            amends "pkl:Project"
+
+            dependencies {
+              ["birds"] = import("../birds/PklProject")
+            }
+          """
             .trimIndent()
         )
 
@@ -228,15 +228,15 @@ class AnalyzerTest {
       .createParentDirectories()
       .writeString(
         """
-      amends "pkl:Project"
-      
-      package {
-        name = "birds"
-        version = "1.0.0"
-        packageZipUrl = "https://localhost:0/foo.zip"
-        baseUri = "package://localhost:0/birds"
-      }
-    """
+          amends "pkl:Project"
+
+          package {
+            name = "birds"
+            version = "1.0.0"
+            packageZipUrl = "https://localhost:0/foo.zip"
+            baseUri = "package://localhost:0/birds"
+          }
+        """
           .trimIndent()
       )
 
@@ -246,17 +246,18 @@ class AnalyzerTest {
       .resolve("PklProject.deps.json")
       .writeString(
         """
-      {
-        "schemaVersion": 1,
-        "resolvedDependencies": {
-          "package://localhost:0/birds@1": {
-            "type": "local",
-            "uri": "projectpackage://localhost:0/birds@1.0.0",
-            "path": "../birds"
+        """
+          {
+            "schemaVersion": 1,
+            "resolvedDependencies": {
+              "package://localhost:0/birds@1": {
+                "type": "local",
+                "uri": "projectpackage://localhost:0/birds@1.0.0",
+                "path": "../birds"
+              }
+            }
           }
-        }
-      }
-    """
+        """
           .trimIndent()
       )
     val mainPkl =
@@ -264,8 +265,8 @@ class AnalyzerTest {
         .resolve("main.pkl")
         .writeString(
           """
-        import "@birds/bird.pkl"
-      """
+            import "@birds/bird.pkl"
+          """
             .trimIndent()
         )
 

--- a/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
@@ -51,7 +51,7 @@ class AnalyzerTest {
 
             myProp = import("pkl:xml")
           """
-            .trimIndent()```
+            .trimIndent()
         )
         .toUri()
     val result = simpleAnalyzer.importGraph(file)
@@ -68,7 +68,7 @@ class AnalyzerTest {
           """
             import* "*.pkl"
           """
-            .trimIndent()```
+            .trimIndent()
         )
         .toUri()
     val file2 = tempDir.resolve("file2.pkl").writeString("foo = 1").toUri()
@@ -245,7 +245,6 @@ class AnalyzerTest {
     pklProject.parent
       .resolve("PklProject.deps.json")
       .writeString(
-        """
         """
           {
             "schemaVersion": 1,

--- a/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
@@ -146,7 +146,6 @@ class AnalyzerTest {
         """
           .trimIndent()
       )
-    val dollar = '$'
     tempDir
       .resolve("PklProject.deps.json")
       .writeString(
@@ -158,14 +157,14 @@ class AnalyzerTest {
                 "type": "remote",
                 "uri": "projectpackage://localhost:0/birds@0.5.0",
                 "checksums": {
-                  "sha256": "${dollar}skipChecksumVerification"
+                  "sha256": "${'$'}skipChecksumVerification"
                 }
               },
               "package://localhost:0/fruit@1": {
                 "type": "remote",
                 "uri": "projectpackage://localhost:0/fruit@1.0.5",
                 "checksums": {
-                  "sha256": "${dollar}skipChecksumVerification"
+                  "sha256": "${'$'}skipChecksumVerification"
                 }
               }
             }

--- a/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
@@ -1,0 +1,303 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core
+
+import java.net.URI
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.pkl.commons.createParentDirectories
+import org.pkl.commons.test.PackageServer
+import org.pkl.commons.writeString
+import org.pkl.core.http.HttpClient
+import org.pkl.core.module.ModuleKeyFactories
+import org.pkl.core.project.Project
+
+class AnalyzerTest {
+  private val simpleAnalyzer =
+    Analyzer(
+      StackFrameTransformers.defaultTransformer,
+      SecurityManagers.defaultManager,
+      listOf(ModuleKeyFactories.file, ModuleKeyFactories.standardLibrary, ModuleKeyFactories.pkg),
+      null,
+      null,
+      HttpClient.dummyClient()
+    )
+
+  @Test
+  fun `simple case`(@TempDir tempDir: Path) {
+    val file =
+      tempDir
+        .resolve("test.pkl")
+        .writeString(
+          """
+      amends "pkl:base"
+
+      import "pkl:json"
+
+      myProp = import("pkl:xml")
+    """
+            .trimIndent()
+        )
+        .toUri()
+    val result = simpleAnalyzer.importGraph(file)
+    assertThat(result.imports)
+      .containsEntry(file, setOf(URI("pkl:base"), URI("pkl:json"), URI("pkl:xml")))
+  }
+
+  @Test
+  fun `glob imports`(@TempDir tempDir: Path) {
+    val file1 =
+      tempDir
+        .resolve("file1.pkl")
+        .writeString(
+          """
+      import* "*.pkl"
+    """
+            .trimIndent()
+        )
+        .toUri()
+    val file2 = tempDir.resolve("file2.pkl").writeString("foo = 1").toUri()
+    val file3 = tempDir.resolve("file3.pkl").writeString("bar = 1").toUri()
+    val result = simpleAnalyzer.importGraph(file1)
+    assertThat(result.imports)
+      .isEqualTo(
+        mapOf(file1 to setOf(file1, file2, file3), file2 to emptySet(), file3 to emptySet()),
+      )
+  }
+
+  @Test
+  fun `cyclical imports`(@TempDir tempDir: Path) {
+    val file1 = tempDir.resolve("file1.pkl").writeString("import \"file2.pkl\"").toUri()
+    val file2 = tempDir.resolve("file2.pkl").writeString("import \"file1.pkl\"").toUri()
+    val result = simpleAnalyzer.importGraph(file1)
+    assertThat(result.imports).isEqualTo(mapOf(file1 to setOf(file2), file2 to setOf(file1)))
+  }
+
+  @Test
+  fun `package imports`(@TempDir tempDir: Path) {
+    val analyzer =
+      Analyzer(
+        StackFrameTransformers.defaultTransformer,
+        SecurityManagers.defaultManager,
+        listOf(ModuleKeyFactories.file, ModuleKeyFactories.standardLibrary, ModuleKeyFactories.pkg),
+        tempDir.resolve("packages"),
+        null,
+        HttpClient.dummyClient(),
+      )
+    PackageServer.populateCacheDir(tempDir.resolve("packages"))
+    val file1 =
+      tempDir
+        .resolve("file1.pkl")
+        .writeString("import \"package://localhost:0/birds@0.5.0#/Bird.pkl\"")
+        .toUri()
+    val result = analyzer.importGraph(file1)
+    assertThat(result.imports)
+      .isEqualTo(
+        mapOf(
+          file1 to setOf(URI("package://localhost:0/birds@0.5.0#/Bird.pkl")),
+          URI("package://localhost:0/birds@0.5.0#/Bird.pkl") to
+            setOf(URI("package://localhost:0/fruit@1.0.5#/Fruit.pkl")),
+          URI("package://localhost:0/fruit@1.0.5#/Fruit.pkl") to emptySet()
+        )
+      )
+  }
+
+  @Test
+  fun `project dependency imports`(@TempDir tempDir: Path) {
+    tempDir
+      .resolve("PklProject")
+      .writeString(
+        """
+      amends "pkl:Project"
+      
+      dependencies {
+        ["birds"] { uri = "package://localhost:0/birds@0.5.0" }
+      }
+    """
+          .trimIndent()
+      )
+    val dollar = '$'
+    tempDir
+      .resolve("PklProject.deps.json")
+      .writeString(
+        """
+      {
+        "schemaVersion": 1,
+        "resolvedDependencies": {
+          "package://localhost:0/birds@0": {
+            "type": "remote",
+            "uri": "projectpackage://localhost:0/birds@0.5.0",
+            "checksums": {
+              "sha256": "${dollar}skipChecksumVerification"
+            }
+          },
+          "package://localhost:0/fruit@1": {
+            "type": "remote",
+            "uri": "projectpackage://localhost:0/fruit@1.0.5",
+            "checksums": {
+              "sha256": "${dollar}skipChecksumVerification"
+            }
+          }
+        }
+      }
+    """
+          .trimIndent()
+      )
+    val project = Project.loadFromPath(tempDir.resolve("PklProject"))
+    PackageServer.populateCacheDir(tempDir.resolve("packages"))
+    val analyzer =
+      Analyzer(
+        StackFrameTransformers.defaultTransformer,
+        SecurityManagers.defaultManager,
+        listOf(
+          ModuleKeyFactories.file,
+          ModuleKeyFactories.standardLibrary,
+          ModuleKeyFactories.pkg,
+          ModuleKeyFactories.projectpackage
+        ),
+        tempDir.resolve("packages"),
+        project.dependencies,
+        HttpClient.dummyClient()
+      )
+    val file1 =
+      tempDir
+        .resolve("file1.pkl")
+        .writeString(
+          """
+      import "@birds/Bird.pkl"
+    """
+            .trimIndent()
+        )
+        .toUri()
+    val result = analyzer.importGraph(file1)
+    assertThat(result.imports)
+      .isEqualTo(
+        mapOf(
+          file1 to setOf(URI("projectpackage://localhost:0/birds@0.5.0#/Bird.pkl")),
+          URI("projectpackage://localhost:0/birds@0.5.0#/Bird.pkl") to
+            setOf(URI("projectpackage://localhost:0/fruit@1.0.5#/Fruit.pkl")),
+          URI("projectpackage://localhost:0/fruit@1.0.5#/Fruit.pkl") to emptySet()
+        )
+      )
+    assertThat(result.resolvedImports)
+      .isEqualTo(
+        mapOf(
+          file1 to file1.realPath(),
+          URI("projectpackage://localhost:0/birds@0.5.0#/Bird.pkl") to
+            URI("projectpackage://localhost:0/birds@0.5.0#/Bird.pkl"),
+          URI("projectpackage://localhost:0/fruit@1.0.5#/Fruit.pkl") to
+            URI("projectpackage://localhost:0/fruit@1.0.5#/Fruit.pkl")
+        )
+      )
+  }
+
+  @Test
+  fun `local project dependency import`(@TempDir tempDir: Path) {
+    val pklProject =
+      tempDir
+        .resolve("project1/PklProject")
+        .createParentDirectories()
+        .writeString(
+          """
+      amends "pkl:Project"
+      
+      dependencies {
+        ["birds"] = import("../birds/PklProject")
+      }
+    """
+            .trimIndent()
+        )
+
+    tempDir
+      .resolve("birds/PklProject")
+      .createParentDirectories()
+      .writeString(
+        """
+      amends "pkl:Project"
+      
+      package {
+        name = "birds"
+        version = "1.0.0"
+        packageZipUrl = "https://localhost:0/foo.zip"
+        baseUri = "package://localhost:0/birds"
+      }
+    """
+          .trimIndent()
+      )
+
+    val birdModule = tempDir.resolve("birds/bird.pkl").writeString("name = \"Warbler\"")
+
+    pklProject.parent
+      .resolve("PklProject.deps.json")
+      .writeString(
+        """
+      {
+        "schemaVersion": 1,
+        "resolvedDependencies": {
+          "package://localhost:0/birds@1": {
+            "type": "local",
+            "uri": "projectpackage://localhost:0/birds@1.0.0",
+            "path": "../birds"
+          }
+        }
+      }
+    """
+          .trimIndent()
+      )
+    val mainPkl =
+      pklProject.parent
+        .resolve("main.pkl")
+        .writeString(
+          """
+        import "@birds/bird.pkl"
+      """
+            .trimIndent()
+        )
+
+    val project = Project.loadFromPath(pklProject)
+    val analyzer =
+      Analyzer(
+        StackFrameTransformers.defaultTransformer,
+        SecurityManagers.defaultManager,
+        listOf(
+          ModuleKeyFactories.file,
+          ModuleKeyFactories.standardLibrary,
+          ModuleKeyFactories.pkg,
+          ModuleKeyFactories.projectpackage
+        ),
+        tempDir.resolve("packages"),
+        project.dependencies,
+        HttpClient.dummyClient()
+      )
+    val result = analyzer.importGraph(mainPkl.toUri())
+    val birdUri = URI("projectpackage://localhost:0/birds@1.0.0#/bird.pkl")
+    assertThat(result.imports)
+      .isEqualTo(
+        mapOf(mainPkl.toUri() to setOf(birdUri), birdUri to emptySet()),
+      )
+    assertThat(result.resolvedImports)
+      .isEqualTo(
+        mapOf(
+          mainPkl.toUri() to mainPkl.toRealPath().toUri(),
+          birdUri to birdModule.toRealPath().toUri()
+        )
+      )
+  }
+
+  private fun URI.realPath() = Path.of(this).toRealPath().toUri()
+}

--- a/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
@@ -56,7 +56,14 @@ class AnalyzerTest {
         .toUri()
     val result = simpleAnalyzer.importGraph(file)
     assertThat(result.imports)
-      .containsEntry(file, setOf(URI("pkl:base"), URI("pkl:json"), URI("pkl:xml")))
+      .containsEntry(
+        file,
+        setOf(
+          ImportGraph.Import(URI("pkl:base")),
+          ImportGraph.Import(URI("pkl:json")),
+          ImportGraph.Import(URI("pkl:xml"))
+        )
+      )
   }
 
   @Test
@@ -76,7 +83,12 @@ class AnalyzerTest {
     val result = simpleAnalyzer.importGraph(file1)
     assertThat(result.imports)
       .isEqualTo(
-        mapOf(file1 to setOf(file1, file2, file3), file2 to emptySet(), file3 to emptySet()),
+        mapOf(
+          file1 to
+            setOf(ImportGraph.Import(file1), ImportGraph.Import(file2), ImportGraph.Import(file3)),
+          file2 to emptySet(),
+          file3 to emptySet()
+        ),
       )
   }
 
@@ -85,7 +97,10 @@ class AnalyzerTest {
     val file1 = tempDir.resolve("file1.pkl").writeString("import \"file2.pkl\"").toUri()
     val file2 = tempDir.resolve("file2.pkl").writeString("import \"file1.pkl\"").toUri()
     val result = simpleAnalyzer.importGraph(file1)
-    assertThat(result.imports).isEqualTo(mapOf(file1 to setOf(file2), file2 to setOf(file1)))
+    assertThat(result.imports)
+      .isEqualTo(
+        mapOf(file1 to setOf(ImportGraph.Import(file2)), file2 to setOf(ImportGraph.Import(file1)))
+      )
   }
 
   @Test
@@ -109,9 +124,9 @@ class AnalyzerTest {
     assertThat(result.imports)
       .isEqualTo(
         mapOf(
-          file1 to setOf(URI("package://localhost:0/birds@0.5.0#/Bird.pkl")),
+          file1 to setOf(ImportGraph.Import(URI("package://localhost:0/birds@0.5.0#/Bird.pkl"))),
           URI("package://localhost:0/birds@0.5.0#/Bird.pkl") to
-            setOf(URI("package://localhost:0/fruit@1.0.5#/Fruit.pkl")),
+            setOf(ImportGraph.Import(URI("package://localhost:0/fruit@1.0.5#/Fruit.pkl"))),
           URI("package://localhost:0/fruit@1.0.5#/Fruit.pkl") to emptySet()
         )
       )
@@ -188,9 +203,10 @@ class AnalyzerTest {
     assertThat(result.imports)
       .isEqualTo(
         mapOf(
-          file1 to setOf(URI("projectpackage://localhost:0/birds@0.5.0#/Bird.pkl")),
+          file1 to
+            setOf(ImportGraph.Import(URI("projectpackage://localhost:0/birds@0.5.0#/Bird.pkl"))),
           URI("projectpackage://localhost:0/birds@0.5.0#/Bird.pkl") to
-            setOf(URI("projectpackage://localhost:0/fruit@1.0.5#/Fruit.pkl")),
+            setOf(ImportGraph.Import(URI("projectpackage://localhost:0/fruit@1.0.5#/Fruit.pkl"))),
           URI("projectpackage://localhost:0/fruit@1.0.5#/Fruit.pkl") to emptySet()
         )
       )
@@ -288,7 +304,7 @@ class AnalyzerTest {
     val birdUri = URI("projectpackage://localhost:0/birds@1.0.0#/bird.pkl")
     assertThat(result.imports)
       .isEqualTo(
-        mapOf(mainPkl.toUri() to setOf(birdUri), birdUri to emptySet()),
+        mapOf(mainPkl.toUri() to setOf(ImportGraph.Import(birdUri)), birdUri to emptySet()),
       )
     assertThat(result.resolvedImports)
       .isEqualTo(

--- a/pkl-core/src/test/kotlin/org/pkl/core/ast/builder/ImportsAndReadsParserTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/ast/builder/ImportsAndReadsParserTest.kt
@@ -70,8 +70,8 @@ class ImportsAndReadsParserTest {
   fun `invalid syntax`() {
     val moduleText =
       """
-      not valid Pkl syntax
-    """
+        not valid Pkl syntax
+      """
         .trimIndent()
     val moduleKey = ModuleKeys.synthetic(URI("repl:text"), moduleText)
     val err =
@@ -81,14 +81,14 @@ class ImportsAndReadsParserTest {
     assertThat(err.toPklException(StackFrameTransformers.defaultTransformer))
       .hasMessage(
         """
-      –– Pkl Error ––
-      Mismatched input: `<EOF>`. Expected one of: `{`, `=`, `:`
+          –– Pkl Error ––
+          Mismatched input: `<EOF>`. Expected one of: `{`, `=`, `:`
 
-      1 | not valid Pkl syntax
-                              ^
-      at text (repl:text)
+          1 | not valid Pkl syntax
+                                  ^
+          at text (repl:text)
 
-    """
+        """
           .trimIndent()
       )
   }

--- a/pkl-core/src/test/kotlin/org/pkl/core/ast/builder/ImportsAndReadsParserTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/ast/builder/ImportsAndReadsParserTest.kt
@@ -18,8 +18,11 @@ package org.pkl.core.ast.builder
 import java.net.URI
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.pkl.core.SecurityManagers
+import org.pkl.core.StackFrameTransformers
 import org.pkl.core.module.ModuleKeys
+import org.pkl.core.runtime.VmException
 
 class ImportsAndReadsParserTest {
   @Test
@@ -27,13 +30,13 @@ class ImportsAndReadsParserTest {
     val moduleText =
       """
       amends "foo.pkl"
-      
+
       import "bar.pkl"
       import "bazzy/buz.pkl"
-      
+
       res1 = import("qux.pkl")
       res2 = import*("qux/*.pkl")
-      
+
       class MyClass {
         res3 {
           res4 {
@@ -48,7 +51,7 @@ class ImportsAndReadsParserTest {
     val moduleKey = ModuleKeys.synthetic(URI("repl:text"), moduleText)
     val imports =
       ImportsAndReadsParser.parse(moduleKey, moduleKey.resolve(SecurityManagers.defaultManager))
-    assertThat(imports?.map { it.first })
+    assertThat(imports?.map { it.stringValue })
       .hasSameElementsAs(
         listOf(
           "foo.pkl",
@@ -60,6 +63,33 @@ class ImportsAndReadsParserTest {
           "/some/dir/chowner.txt",
           "/some/dir/*.txt"
         )
+      )
+  }
+
+  @Test
+  fun `invalid syntax`() {
+    val moduleText =
+      """
+      not valid Pkl syntax
+    """
+        .trimIndent()
+    val moduleKey = ModuleKeys.synthetic(URI("repl:text"), moduleText)
+    val err =
+      assertThrows<VmException> {
+        ImportsAndReadsParser.parse(moduleKey, moduleKey.resolve(SecurityManagers.defaultManager))
+      }
+    assertThat(err.toPklException(StackFrameTransformers.defaultTransformer))
+      .hasMessage(
+        """
+      –– Pkl Error ––
+      Mismatched input: `<EOF>`. Expected one of: `{`, `=`, `:`
+
+      1 | not valid Pkl syntax
+                              ^
+      at text (repl:text)
+
+    """
+          .trimIndent()
       )
   }
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklAnalyzeCommands.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklAnalyzeCommands.java
@@ -13,23 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pkl.gradle.spec;
+package org.pkl.gradle;
 
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Property;
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.pkl.gradle.spec.AnalyzeImportsSpec;
 
-public interface ModulesSpec extends BasePklSpec {
-  ListProperty<Object> getSourceModules();
+public interface PklAnalyzeCommands {
+  NamedDomainObjectContainer<AnalyzeImportsSpec> getImports();
 
-  /** As of Pkl 0.27, this setting is ignored. */
-  @Deprecated(since = "0.27.0", forRemoval = true)
-  ConfigurableFileCollection getTransitiveModules();
-
-  DirectoryProperty getProjectDir();
-
-  Property<Boolean> getOmitProjectSettings();
-
-  Property<Boolean> getNoProject();
+  default void imports(Action<? super NamedDomainObjectContainer<AnalyzeImportsSpec>> action) {
+    action.execute(getImports());
+  }
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklAnalyzerCommands.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklAnalyzerCommands.java
@@ -19,7 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.pkl.gradle.spec.AnalyzeImportsSpec;
 
-public interface PklAnalyzeCommands {
+public interface PklAnalyzerCommands {
   NamedDomainObjectContainer<AnalyzeImportsSpec> getImports();
 
   default void imports(Action<? super NamedDomainObjectContainer<AnalyzeImportsSpec>> action) {

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklExtension.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklExtension.java
@@ -39,6 +39,9 @@ public interface PklExtension {
   @Nested
   PklProjectCommands getProject();
 
+  @Nested
+  PklAnalyzeCommands getAnalyze();
+
   default void evaluators(Action<? super NamedDomainObjectContainer<EvalSpec>> action) {
     action.execute(getEvaluators());
   }
@@ -63,5 +66,9 @@ public interface PklExtension {
 
   default void project(Action<? super PklProjectCommands> action) {
     action.execute(getProject());
+  }
+
+  default void analyze(Action<? super PklAnalyzeCommands> action) {
+    action.execute(getAnalyze());
   }
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklExtension.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklExtension.java
@@ -40,7 +40,7 @@ public interface PklExtension {
   PklProjectCommands getProject();
 
   @Nested
-  PklAnalyzeCommands getAnalyze();
+  PklAnalyzerCommands getAnalyzers();
 
   default void evaluators(Action<? super NamedDomainObjectContainer<EvalSpec>> action) {
     action.execute(getEvaluators());
@@ -68,7 +68,7 @@ public interface PklExtension {
     action.execute(getProject());
   }
 
-  default void analyze(Action<? super PklAnalyzeCommands> action) {
-    action.execute(getAnalyze());
+  default void analyzers(Action<? super PklAnalyzerCommands> action) {
+    action.execute(getAnalyzers());
   }
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -93,7 +93,7 @@ public class PklPlugin implements Plugin<Project> {
     configureTestTasks(extension.getTests());
     configureProjectPackageTasks(extension.getProject().getPackagers());
     configureProjectResolveTasks(extension.getProject().getResolvers());
-    configureAnalyzeImportsTasks(extension.getAnalyze().getImports());
+    configureAnalyzeImportsTasks(extension.getAnalyzers().getImports());
   }
 
   private void configureProjectPackageTasks(NamedDomainObjectContainer<ProjectPackageSpec> specs) {

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -475,7 +475,9 @@ public class PklPlugin implements Plugin<Project> {
     task.getNoProject().set(spec.getNoProject());
     task.getProjectDir().set(spec.getProjectDir());
     task.getOmitProjectSettings().set(spec.getOmitProjectSettings());
-    if (analyzeImportsTask != null) {
+    if (!spec.getTransitiveModules().isEmpty()) {
+      task.getTransitiveModules().set(spec.getTransitiveModules());
+    } else if (analyzeImportsTask != null) {
       task.dependsOn(analyzeImportsTask);
       task.getTransitiveModules().set(analyzeImportsTask.map(this::getTransitiveModules));
     }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -17,6 +17,7 @@ package org.pkl.gradle;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -36,8 +37,12 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
 import org.gradle.util.GradleVersion;
 import org.pkl.cli.CliEvaluatorOptions;
+import org.pkl.core.ImportGraph;
+import org.pkl.core.OutputFormat;
 import org.pkl.core.util.IoUtils;
 import org.pkl.core.util.LateInit;
+import org.pkl.core.util.Nullable;
+import org.pkl.gradle.spec.AnalyzeImportsSpec;
 import org.pkl.gradle.spec.BasePklSpec;
 import org.pkl.gradle.spec.CodeGenSpec;
 import org.pkl.gradle.spec.EvalSpec;
@@ -48,6 +53,7 @@ import org.pkl.gradle.spec.PkldocSpec;
 import org.pkl.gradle.spec.ProjectPackageSpec;
 import org.pkl.gradle.spec.ProjectResolveSpec;
 import org.pkl.gradle.spec.TestSpec;
+import org.pkl.gradle.task.AnalyzeImportsTask;
 import org.pkl.gradle.task.BasePklTask;
 import org.pkl.gradle.task.CodeGenTask;
 import org.pkl.gradle.task.EvalTask;
@@ -87,6 +93,7 @@ public class PklPlugin implements Plugin<Project> {
     configureTestTasks(extension.getTests());
     configureProjectPackageTasks(extension.getProject().getPackagers());
     configureProjectResolveTasks(extension.getProject().getResolvers());
+    configureAnalyzeImportsTasks(extension.getAnalyze().getImports());
   }
 
   private void configureProjectPackageTasks(NamedDomainObjectContainer<ProjectPackageSpec> specs) {
@@ -128,6 +135,21 @@ public class PklPlugin implements Plugin<Project> {
         });
   }
 
+  private void configureAnalyzeImportsTasks(NamedDomainObjectContainer<AnalyzeImportsSpec> specs) {
+    specs.all(
+        spec -> {
+          configureBaseSpec(spec);
+          spec.getOutputFormat().convention(OutputFormat.PCF.toString());
+          var analyzeImportsTask = createTask(AnalyzeImportsTask.class, spec);
+          analyzeImportsTask.configure(
+              task -> {
+                task.getOutputFormat().set(spec.getOutputFormat());
+                task.getOutputFile().set(spec.getOutputFile());
+                configureModulesTask(task, spec, null);
+              });
+        });
+  }
+
   private void configureEvalTasks(NamedDomainObjectContainer<EvalSpec> specs) {
     specs.all(
         spec -> {
@@ -141,7 +163,7 @@ public class PklPlugin implements Plugin<Project> {
                       // and the working directory is set to the project directory,
                       // so this path works correctly.
                       .file("%{moduleDir}/%{moduleName}.%{outputFormat}"));
-          spec.getOutputFormat().convention("pcf");
+          spec.getOutputFormat().convention(OutputFormat.PCF.toString());
           spec.getModuleOutputSeparator()
               .convention(CliEvaluatorOptions.Companion.getDefaults().getModuleOutputSeparator());
           spec.getExpression()
@@ -431,20 +453,73 @@ public class PklPlugin implements Plugin<Project> {
     task.getHttpNoProxy().set(spec.getHttpNoProxy());
   }
 
-  private <T extends ModulesTask, S extends ModulesSpec> void configureModulesTask(T task, S spec) {
+  private List<File> getTransitiveModules(AnalyzeImportsTask analyzeTask) {
+    var outputFile = analyzeTask.getOutputFile().get().getAsFile().toPath();
+    try {
+      var contents = Files.readString(outputFile);
+      ImportGraph importGraph = ImportGraph.parseFromJson(contents);
+      var imports = importGraph.resolvedImports().values();
+      return imports.stream()
+          .filter((it) -> it.getScheme().equalsIgnoreCase("file"))
+          .map(File::new)
+          .toList();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private <T extends ModulesTask, S extends ModulesSpec> void configureModulesTask(
+      T task, S spec, @Nullable TaskProvider<AnalyzeImportsTask> analyzeImportsTask) {
     configureBaseTask(task, spec);
     task.getSourceModules().set(spec.getSourceModules());
-    task.getTransitiveModules().from(spec.getTransitiveModules());
     task.getNoProject().set(spec.getNoProject());
     task.getProjectDir().set(spec.getProjectDir());
     task.getOmitProjectSettings().set(spec.getOmitProjectSettings());
+    if (analyzeImportsTask != null) {
+      task.dependsOn(analyzeImportsTask);
+      task.getTransitiveModules().set(analyzeImportsTask.map(this::getTransitiveModules));
+    }
   }
 
-  private <T extends ModulesTask> TaskProvider<T> createModulesTask(
-      Class<T> taskClass, ModulesSpec spec) {
+  private TaskProvider<AnalyzeImportsTask> createAnalyzeImportsTask(ModulesSpec spec) {
+    var outputFile =
+        project
+            .getLayout()
+            .getBuildDirectory()
+            .file("pkl-gradle/imports/" + spec.getName() + ".json");
     return project
         .getTasks()
-        .register(spec.getName(), taskClass, task -> configureModulesTask(task, spec));
+        .register(
+            spec.getName() + "GatherImports",
+            AnalyzeImportsTask.class,
+            task -> {
+              configureModulesTask(task, spec, null);
+              task.setDescription("Compute the set of imports declared by input modules");
+              task.setGroup("build");
+              task.getOutputFormat().set(OutputFormat.JSON.toString());
+              task.getOutputFile().set(outputFile);
+            });
+  }
+
+  /**
+   * Implicitly also create a task of type {@link AnalyzeImportsTask}, postfixing the spec name
+   * with {@code "GatherImports"}.
+   *
+   * The resulting task depends on the analyze task, and configures its own input files based on
+   * the result of analysis.
+   *
+   * The end result is that the task automatically has correct up-to-date checks without users
+   * needing to manually provide transitive modules.
+   */
+  private <T extends ModulesTask> TaskProvider<T> createModulesTask(
+      Class<T> taskClass, ModulesSpec spec) {
+    var analyzeImportsTask = createAnalyzeImportsTask(spec);
+    return project
+        .getTasks()
+        .register(
+            spec.getName(),
+            taskClass,
+            task -> configureModulesTask(task, spec, analyzeImportsTask));
   }
 
   private <T extends BasePklTask> TaskProvider<T> createTask(Class<T> taskClass, BasePklSpec spec) {

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -502,13 +502,13 @@ public class PklPlugin implements Plugin<Project> {
   }
 
   /**
-   * Implicitly also create a task of type {@link AnalyzeImportsTask}, postfixing the spec name
-   * with {@code "GatherImports"}.
+   * Implicitly also create a task of type {@link AnalyzeImportsTask}, postfixing the spec name with
+   * {@code "GatherImports"}.
    *
-   * The resulting task depends on the analyze task, and configures its own input files based on
+   * <p>The resulting task depends on the analyze task, and configures its own input files based on
    * the result of analysis.
    *
-   * The end result is that the task automatically has correct up-to-date checks without users
+   * <p>The end result is that the task automatically has correct up-to-date checks without users
    * needing to manually provide transitive modules.
    */
   private <T extends ModulesTask> TaskProvider<T> createModulesTask(

--- a/pkl-gradle/src/main/java/org/pkl/gradle/spec/AnalyzeImportsSpec.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/spec/AnalyzeImportsSpec.java
@@ -15,21 +15,12 @@
  */
 package org.pkl.gradle.spec;
 
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.provider.ListProperty;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 
-public interface ModulesSpec extends BasePklSpec {
-  ListProperty<Object> getSourceModules();
+/** Configuration options for import analyzers. Documented in user manual. */
+public interface AnalyzeImportsSpec extends ModulesSpec {
+  RegularFileProperty getOutputFile();
 
-  /** As of Pkl 0.27, this setting is ignored. */
-  @Deprecated(since = "0.27.0", forRemoval = true)
-  ConfigurableFileCollection getTransitiveModules();
-
-  DirectoryProperty getProjectDir();
-
-  Property<Boolean> getOmitProjectSettings();
-
-  Property<Boolean> getNoProject();
+  Property<String> getOutputFormat();
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/spec/ModulesSpec.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/spec/ModulesSpec.java
@@ -23,8 +23,6 @@ import org.gradle.api.provider.Property;
 public interface ModulesSpec extends BasePklSpec {
   ListProperty<Object> getSourceModules();
 
-  /** As of Pkl 0.27, this setting is ignored. */
-  @Deprecated(since = "0.27.0", forRemoval = true)
   ConfigurableFileCollection getTransitiveModules();
 
   DirectoryProperty getProjectDir();

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/AnalyzeImportsTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/AnalyzeImportsTask.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.gradle.task;
+
+import java.io.File;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.pkl.cli.CliImportAnalyzer;
+import org.pkl.cli.CliImportAnalyzerOptions;
+
+public abstract class AnalyzeImportsTask extends ModulesTask {
+  @OutputFile
+  @Optional
+  public abstract RegularFileProperty getOutputFile();
+
+  @Input
+  public abstract Property<String> getOutputFormat();
+
+  private final Provider<CliImportAnalyzer> cliImportAnalyzerProvider =
+      getProviders()
+          .provider(
+              () ->
+                  new CliImportAnalyzer(
+                      new CliImportAnalyzerOptions(
+                          getCliBaseOptions(),
+                          mapAndGetOrNull(getOutputFile(), it -> it.getAsFile().toPath()),
+                          mapAndGetOrNull(getOutputFormat(), it -> it))));
+
+  @Override
+  protected void doRunTask() {
+    //noinspection ResultOfMethodCallIgnored
+    getOutputs().getPreviousOutputFiles().forEach(File::delete);
+    cliImportAnalyzerProvider.get().run();
+  }
+}

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ListProperty;
@@ -49,7 +48,7 @@ public abstract class ModulesTask extends BasePklTask {
   public abstract ListProperty<Object> getSourceModules();
 
   @InputFiles
-  public abstract ConfigurableFileCollection getTransitiveModules();
+  public abstract ListProperty<File> getTransitiveModules();
 
   private final Map<List<Object>, Pair<List<File>, List<URI>>> parsedSourceModulesCache =
       new HashMap<>();

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/AnalyzeImportsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/AnalyzeImportsTest.kt
@@ -1,0 +1,108 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.gradle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AnalyzeImportsTest : AbstractTest() {
+  @Test
+  fun `write to console`() {
+    writeFile("input.pkl", "")
+    writeFile(
+      "build.gradle",
+      """
+      plugins {
+        id "org.pkl-lang"
+      }
+
+      pkl {
+        analyze {
+          imports {
+            analyzeMyImports {
+              sourceModules = ["input.pkl"]
+            }
+          }
+        }
+      }
+    """
+        .trimIndent()
+    )
+    val result = runTask("analyzeMyImports")
+    assertThat(result.output).contains("imports {")
+  }
+
+  @Test
+  fun `output file`() {
+    writeFile("input.pkl", "")
+    writeFile(
+      "build.gradle",
+      """
+      plugins {
+        id "org.pkl-lang"
+      }
+
+      pkl {
+        analyze {
+          imports {
+            analyzeMyImports {
+              sourceModules = ["input.pkl"]
+              outputFile = file("myFile.pcf")
+            }
+          }
+        }
+      }
+    """
+        .trimIndent()
+    )
+    runTask("analyzeMyImports")
+    assertThat(testProjectDir.resolve("myFile.pcf")).exists()
+  }
+
+  @Test
+  fun `output format`() {
+    writeFile("input.pkl", "")
+    writeFile(
+      "build.gradle",
+      """
+      plugins {
+        id "org.pkl-lang"
+      }
+
+      pkl {
+        analyze {
+          imports {
+            analyzeMyImports {
+              sourceModules = ["input.pkl"]
+              outputFormat = "json"
+            }
+          }
+        }
+      }
+    """
+        .trimIndent()
+    )
+    val result = runTask("analyzeMyImports")
+    assertThat(result.output)
+      .contains(
+        """
+      {
+        "imports": {
+    """
+          .trimIndent()
+      )
+  }
+}

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/AnalyzeImportsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/AnalyzeImportsTest.kt
@@ -30,7 +30,7 @@ class AnalyzeImportsTest : AbstractTest() {
         }
 
         pkl {
-          analyze {
+          analyzers {
             imports {
               analyzeMyImports {
                 sourceModules = ["input.pkl"]
@@ -56,7 +56,7 @@ class AnalyzeImportsTest : AbstractTest() {
         }
 
         pkl {
-          analyze {
+          analyzers {
             imports {
               analyzeMyImports {
                 sourceModules = ["input.pkl"]
@@ -83,7 +83,7 @@ class AnalyzeImportsTest : AbstractTest() {
         }
 
         pkl {
-          analyze {
+          analyzers {
             imports {
               analyzeMyImports {
                 sourceModules = ["input.pkl"]

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/AnalyzeImportsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/AnalyzeImportsTest.kt
@@ -25,20 +25,20 @@ class AnalyzeImportsTest : AbstractTest() {
     writeFile(
       "build.gradle",
       """
-      plugins {
-        id "org.pkl-lang"
-      }
+        plugins {
+          id "org.pkl-lang"
+        }
 
-      pkl {
-        analyze {
-          imports {
-            analyzeMyImports {
-              sourceModules = ["input.pkl"]
+        pkl {
+          analyze {
+            imports {
+              analyzeMyImports {
+                sourceModules = ["input.pkl"]
+              }
             }
           }
         }
-      }
-    """
+      """
         .trimIndent()
     )
     val result = runTask("analyzeMyImports")
@@ -51,21 +51,21 @@ class AnalyzeImportsTest : AbstractTest() {
     writeFile(
       "build.gradle",
       """
-      plugins {
-        id "org.pkl-lang"
-      }
+        plugins {
+          id "org.pkl-lang"
+        }
 
-      pkl {
-        analyze {
-          imports {
-            analyzeMyImports {
-              sourceModules = ["input.pkl"]
-              outputFile = file("myFile.pcf")
+        pkl {
+          analyze {
+            imports {
+              analyzeMyImports {
+                sourceModules = ["input.pkl"]
+                outputFile = file("myFile.pcf")
+              }
             }
           }
         }
-      }
-    """
+      """
         .trimIndent()
     )
     runTask("analyzeMyImports")
@@ -78,30 +78,30 @@ class AnalyzeImportsTest : AbstractTest() {
     writeFile(
       "build.gradle",
       """
-      plugins {
-        id "org.pkl-lang"
-      }
+        plugins {
+          id "org.pkl-lang"
+        }
 
-      pkl {
-        analyze {
-          imports {
-            analyzeMyImports {
-              sourceModules = ["input.pkl"]
-              outputFormat = "json"
+        pkl {
+          analyze {
+            imports {
+              analyzeMyImports {
+                sourceModules = ["input.pkl"]
+                outputFormat = "json"
+              }
             }
           }
         }
-      }
-    """
+      """
         .trimIndent()
     )
     val result = runTask("analyzeMyImports")
     assertThat(result.output)
       .contains(
         """
-      {
-        "imports": {
-    """
+          {
+            "imports": {
+        """
           .trimIndent()
       )
   }

--- a/stdlib/analyze.pkl
+++ b/stdlib/analyze.pkl
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// A library for statically analyzing Pkl modules.
+///
+/// These tools differentiate from [pkl:reflect][reflect] in that they parse Pkl modules, but do not
+/// execute any code within these modules.
+@Since { version = "0.27.0" }
+@ModuleInfo { minPklVersion = "0.27.0" }
+module pkl.analyze
+
+// used by doc comments
+import "pkl:reflect"
+
+/// Given a set of Pkl module URIs, returns a graph of imports declared by these modules.
+///
+/// The resulting graph includes transitive imports.
+external function importGraph(moduleUris: Set<String>): ImportGraph
+
+class ImportGraph {
+  /// The imports declared within a Pkl program.
+  ///
+  /// Each entry is a module URI, mapped to the set of imports declared in that module.
+  ///
+  /// The set of all modules in the graph can be obtained via its keys.
+  imports: Map<Uri, Set<Uri>>
+
+  /// Mappings of modules from their in-language URI, to the URI that is used to fetch the module's
+  /// contents.
+  resolvedImports: Map<Uri, Uri>(keys == imports.keys)
+}

--- a/stdlib/analyze.pkl
+++ b/stdlib/analyze.pkl
@@ -28,17 +28,31 @@ import "pkl:reflect"
 /// Given a set of Pkl module URIs, returns a graph of imports declared by these modules.
 ///
 /// The resulting graph includes transitive imports.
-external function importGraph(moduleUris: Set<String>): ImportGraph
+external function importGraph(moduleUris: Set<Uri>): ImportGraph
 
+/// The graph of imports declared (directly and transitively) by the modules passed to
+/// [importGraph()].
 class ImportGraph {
   /// The imports declared within a Pkl program.
   ///
   /// Each entry is a module URI, mapped to the set of imports declared in that module.
   ///
-  /// The set of all modules in the graph can be obtained via its keys.
+  /// The set of all modules in the graph can be obtained via its [keys][Map.keys].
   imports: Map<Uri, Set<Uri>>
 
-  /// Mappings of modules from their in-language URI, to the URI that is used to fetch the module's
-  /// contents.
+  /// Mappings of modules from their in-language URI, to their resolved URI.
+  ///
+  /// A module's in-language URI is the form used within Pkl source code.
+  /// For example, modulepath-based modules have form `modulepath:/path/to/my/module.pkl`.
+  ///
+  /// A module's resolved URI is the form used to load the module's contents.
+  /// The same modulepath module might have form
+  /// `jar:file:///path/to/file.zip!/path/to/my/module.pkl` if Pkl run with
+  /// `--module-path /path/to/file.zip`.
+  ///
+  /// Dependency-notation imports, such as `"@myPackage/myModule.pkl"`, are represented as
+  /// in-language URIs with scheme `projectpackage:`.
+  /// In the case of local project dependenecies, they will be local URIs resolved from the project
+  /// file URI (in normal cases, `file:` URIs).
   resolvedImports: Map<Uri, Uri>(keys == imports.keys)
 }

--- a/stdlib/analyze.pkl
+++ b/stdlib/analyze.pkl
@@ -35,7 +35,7 @@ external function importGraph(moduleUris: Set<Uri>): ImportGraph
 class ImportGraph {
   /// The imports declared within a Pkl program.
   ///
-  /// Each entry is a module URI, mapped to the set of imports declared in that module.
+  /// Each entry maps a module URI to the set of imports declared in that module.
   ///
   /// The set of all modules in the graph can be obtained via its [keys][Map.keys].
   imports: Map<Uri, Set<Uri>>

--- a/stdlib/analyze.pkl
+++ b/stdlib/analyze.pkl
@@ -30,6 +30,14 @@ import "pkl:reflect"
 /// The resulting graph includes transitive imports.
 external function importGraph(moduleUris: Set<Uri>): ImportGraph
 
+class Import {
+  /// The absolute (in-language) URI of the import.
+  ///
+  /// Dependency notation URIs (such as `import "@foo/bar"`) are resolved to package URIs with
+  /// scheme `projectpackage:`.
+  uri: Uri
+}
+
 /// The graph of imports declared (directly and transitively) by the modules passed to
 /// [importGraph()].
 class ImportGraph {
@@ -38,7 +46,7 @@ class ImportGraph {
   /// Each entry maps a module URI to the set of imports declared in that module.
   ///
   /// The set of all modules in the graph can be obtained via its [keys][Map.keys].
-  imports: Map<Uri, Set<Uri>>
+  imports: Map<Uri, Set<Import>>
 
   /// Mappings of modules from their in-language URI, to their resolved URI.
   ///

--- a/stdlib/analyze.pkl
+++ b/stdlib/analyze.pkl
@@ -30,14 +30,6 @@ import "pkl:reflect"
 /// The resulting graph includes transitive imports.
 external function importGraph(moduleUris: Set<Uri>): ImportGraph
 
-class Import {
-  /// The absolute (in-language) URI of the import.
-  ///
-  /// Dependency notation URIs (such as `import "@foo/bar"`) are resolved to package URIs with
-  /// scheme `projectpackage:`.
-  uri: Uri
-}
-
 /// The graph of imports declared (directly and transitively) by the modules passed to
 /// [importGraph()].
 class ImportGraph {
@@ -63,4 +55,13 @@ class ImportGraph {
   /// In the case of local project dependenecies, they will be local URIs resolved from the project
   /// file URI (in normal cases, `file:` URIs).
   resolvedImports: Map<Uri, Uri>(keys == imports.keys)
+}
+
+/// An import as declared inside a module.
+class Import {
+  /// The absolute (in-language) URI of the import.
+  ///
+  /// Dependency notation URIs (such as `import "@foo/bar"`) are resolved to package URIs with
+  /// scheme `projectpackage:`.
+  uri: Uri
 }


### PR DESCRIPTION
This adds a new feature to build a dependency graph of Pkl programs, following the SPICE outlined in https://github.com/apple/pkl-evolution/pull/2.

It adds:
* CLI command `pkl analyze imports`
* Java API `org.pkl.core.Analyzer`
* Pkl stdlib module `pkl:analyze`
* pkl-gradle extension `analyze`

In addition, it also deprecates `transitiveModules` from pkl-gradle. It instead derives transitive modules by building an import graph of those tasks' source modules.
