### PR TITLE
Replace some usages of java.lang.String.replaceAll with String.replace

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
@@ -1516,7 +1516,7 @@ public final class AstBuilder extends AbstractAstBuilder<Object> {
       text = "-" + text;
     }
 
-    text = text.replaceAll("_", "");
+    text = text.replace("_", "");
     try {
       var num = Long.parseLong(text, radix);
       return new IntLiteralNode(section, num);
@@ -1550,7 +1550,7 @@ public final class AstBuilder extends AbstractAstBuilder<Object> {
           source.createSection(ctx.getStart().getStartIndex() + exponentIdx + 1, 1));
     }
 
-    text = text.replaceAll("_", "");
+    text = text.replace("_", "");
     try {
       var num = Double.parseDouble(text);
       return new FloatLiteralNode(section, num);

--- a/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
+++ b/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
@@ -492,7 +492,7 @@ final class PackageResolvers {
       Files.createDirectories(tmpDir);
       var tmpPath =
           Files.createTempFile(
-              tmpDir, IoUtils.encodePath(packageUri.toString().replaceAll("/", "-")), ".json");
+              tmpDir, IoUtils.encodePath(packageUri.toString().replace("/", "-")), ".json");
       try {
         downloadMetadata(packageUri, requestUri, tmpPath, checksums);
         Files.createDirectories(cachePath.getParent());
@@ -544,7 +544,7 @@ final class PackageResolvers {
       Files.createDirectories(tmpDir);
       var tmpPath =
           Files.createTempFile(
-              tmpDir, IoUtils.encodePath(packageUri.toString().replaceAll("/", "-")), ".zip");
+              tmpDir, IoUtils.encodePath(packageUri.toString().replace("/", "-")), ".zip");
       try {
         var checksumBytes =
             downloadUriToPathAndComputeChecksum(dependencyMetadata.getPackageZipUrl(), tmpPath);


### PR DESCRIPTION
Both methods replace all occurrences.
The difference is that String.replaceAll interprets its first argument as a regex.