### PR TITLE
codegen-java: Change condition for generating equals/hashCode/toString/with/Serializable

### DIFF
--- a/pkl-codegen-java/src/test/resources/org/pkl/codegen/java/Inheritance.jva
+++ b/pkl-codegen-java/src/test/resources/org/pkl/codegen/java/Inheritance.jva
@@ -32,13 +32,23 @@ public final class Mod {
     public long getOne() {
       return one;
     }
+  }
+
+  public static class None extends Foo {
+    public None(@Named("one") long one) {
+      super(one);
+    }
+
+    public None withOne(long one) {
+      return new None(one);
+    }
 
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
       if (obj == null) return false;
       if (this.getClass() != obj.getClass()) return false;
-      Foo other = (Foo) obj;
+      None other = (None) obj;
       if (!Objects.equals(this.one, other.one)) return false;
       return true;
     }
@@ -53,20 +63,10 @@ public final class Mod {
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder(100);
-      builder.append(Foo.class.getSimpleName()).append(" {");
+      builder.append(None.class.getSimpleName()).append(" {");
       appendProperty(builder, "one", this.one);
       builder.append("\n}");
       return builder.toString();
-    }
-  }
-
-  public static class None extends Foo {
-    public None(@Named("one") long one) {
-      super(one);
-    }
-
-    public None withOne(long one) {
-      return new None(one);
     }
   }
 


### PR DESCRIPTION
Motivation:
* Currently, the condition for generating `equals/hashCode/toString` methods is "generated class declares properties". As a result, classes that don't declare properties inherit these methods from their generated superclasses. However, generated `equals` and `toString` methods aren't designed to be inherited and will either fail or produce wrong results when called for a subclass.
* Currently, the condition for generating `with` methods is "class is not abstract". However, it isn't useful to generate `with` methods for non-instantiable non-abstract classes.
* Currently, the condition for making classes serializable is "class is not a module class". However, it isn't useful to make non-instantiable non-module classes serializable, and it is useful to make instantiable module classes serializable.

Changes:
Change the condition for generating `equals/hashCode/toString/with/Serializable` to "class is instantiable". This is a breaking change.
(A generated class is instantiable, i.e., declares a public constructor, if it is neither abstract nor stateless. This behavior remains unchanged.)

Result:
* Fixes all motivating issues.
* Fixes #706.