### PR TITLE
Add version of resolved Pkl distribution to `ExecutorException`

### DIFF
--- a/pkl-executor/src/main/java/org/pkl/executor/EmbeddedExecutor.java
+++ b/pkl-executor/src/main/java/org/pkl/executor/EmbeddedExecutor.java
@@ -226,7 +226,7 @@ final class EmbeddedExecutor implements Executor {
       try {
         return executorSpi.evaluatePath(modulePath, options.toSpiOptions());
       } catch (ExecutorSpiException e) {
-        throw new ExecutorException(e.getMessage(), executorSpi.getPklVersion(), e.getCause());
+        throw new ExecutorException(e.getMessage(), e.getCause(), executorSpi.getPklVersion());
       } finally {
         currentThread.setContextClassLoader(prevContextClassLoader);
       }

--- a/pkl-executor/src/main/java/org/pkl/executor/EmbeddedExecutor.java
+++ b/pkl-executor/src/main/java/org/pkl/executor/EmbeddedExecutor.java
@@ -226,7 +226,7 @@ final class EmbeddedExecutor implements Executor {
       try {
         return executorSpi.evaluatePath(modulePath, options.toSpiOptions());
       } catch (ExecutorSpiException e) {
-        throw new ExecutorException(e.getMessage(), e.getCause());
+        throw new ExecutorException(e.getMessage(), executorSpi.getPklVersion(), e.getCause());
       } finally {
         currentThread.setContextClassLoader(prevContextClassLoader);
       }

--- a/pkl-executor/src/main/java/org/pkl/executor/ExecutorException.java
+++ b/pkl-executor/src/main/java/org/pkl/executor/ExecutorException.java
@@ -19,11 +19,22 @@ package org.pkl.executor;
  * Indicates an {@link Executor} error. {@link #getMessage()} returns a user-facing error message.
  */
 public final class ExecutorException extends RuntimeException {
+  String pklVersion = "unresolved";
+
   public ExecutorException(String message) {
     super(message);
   }
 
   public ExecutorException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  public ExecutorException(String message, String version, Throwable cause) {
+    super(message, cause);
+    pklVersion = version;
+  }
+
+  public String getPklVersion() {
+    return pklVersion;
   }
 }

--- a/pkl-executor/src/main/java/org/pkl/executor/ExecutorException.java
+++ b/pkl-executor/src/main/java/org/pkl/executor/ExecutorException.java
@@ -15,26 +15,44 @@
  */
 package org.pkl.executor;
 
+import java.util.Objects;
+
 /**
  * Indicates an {@link Executor} error. {@link #getMessage()} returns a user-facing error message.
  */
 public final class ExecutorException extends RuntimeException {
-  String pklVersion = "unresolved";
+  private final String pklVersion;
 
   public ExecutorException(String message) {
     super(message);
+    pklVersion = null;
   }
 
   public ExecutorException(String message, Throwable cause) {
     super(message, cause);
+    pklVersion = null;
   }
 
-  public ExecutorException(String message, String version, Throwable cause) {
+  public ExecutorException(String message, Throwable cause, String version) {
     super(message, cause);
-    pklVersion = version;
+    pklVersion = Objects.requireNonNull(version);
   }
 
+  /**
+   * The selected Pkl version used to evaluate the module.
+   *
+   * <p>Returns {@code null} if this exception does not originate from an underlying Pkl evaluator.
+   */
   public String getPklVersion() {
     return pklVersion;
+  }
+
+  @Override
+  public String getMessage() {
+    var message = super.getMessage();
+    if (pklVersion == null) {
+      return message;
+    }
+    return message + "\nPkl version: " + pklVersion;
   }
 }


### PR DESCRIPTION
Only when catching an exception from evaluation can we decorate the `ExecutorException` with Pkl version information (all other occurrences are pre-resolution failures or failure-to-resolve). That's why this PR adds an extra constructor.