### PR TITLE
codegen-kotlin: Support Java serialization of module classes

### DIFF
--- a/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
+++ b/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
@@ -1761,6 +1761,45 @@ class KotlinCodeGeneratorTest {
   }
 
   @Test
+  fun `generates serializable module classes`() {
+    val kotlinCode =
+      generateKotlinCode(
+        """
+        module Person
+        
+        address: Address
+        
+        class Address {
+          street: String
+        }
+      """,
+        implementSerializable = true
+      )
+
+    assertThat(kotlinCode)
+      .contains(
+        """
+      |data class Person(
+      |  val address: Address
+      |) : Serializable {
+      |  data class Address(
+      |    val street: String
+      |  ) : Serializable {
+      |    companion object {
+      |      private const val serialVersionUID: Long = 0L
+      |    }
+      |  }
+      |
+      |  companion object {
+      |    private const val serialVersionUID: Long = 0L
+      |  }
+      |}
+    """
+          .trimMargin()
+      )
+  }
+
+  @Test
   fun `encoded file paths`() {
     val kotlinCode =
       generateFiles(


### PR DESCRIPTION
Motivation:
- Java serialization makes as much sense for module classes as it does for regular classes.
- Offer same Java serialization support as codegen-java.

Changes:
- Move generation of `appendProperty` method and serialization code
  into new method `generateCompanionRelatedCode`.
- Improve/fix generation of serialization code.

Result:
Java serialization is also supported for module classes.