### PR TITLE
Fix build performance issues of spotless tasks

### DIFF
--- a/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts
@@ -129,7 +129,6 @@ private val licenseHeaderFile by lazy {
 
 private fun KotlinGradleExtension.configureFormatter() {
   ktfmt(libs.versions.ktfmt.get()).googleStyle()
-  targetExclude("**/generated/**", "**/build/**")
   licenseHeaderFile(licenseHeaderFile, "([a-zA-Z]|@file|//)")
 }
 
@@ -140,15 +139,17 @@ spotless {
   if (project === rootProject) {
     kotlinGradle {
       configureFormatter()
-      target("*.kts", "buildSrc/**/*.kts")
+      target("*.kts", "buildSrc/*.kts", "buildSrc/src/*/kotlin/**/*.kts")
     }
     kotlin {
       ktfmt(libs.versions.ktfmt.get()).googleStyle()
-      targetExclude("**/generated/**", "**/build/**")
-      target("buildSrc/**/*.kt")
+      target("buildSrc/src/*/kotlin/**/*.kt")
       licenseHeaderFile(licenseHeaderFile)
     }
   } else {
-    kotlinGradle { configureFormatter() }
+    kotlinGradle {
+      configureFormatter()
+      target("*.kts")
+    }
   }
 }

--- a/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
@@ -42,12 +42,12 @@ artifacts {
 spotless {
   java {
     googleJavaFormat(libs.versions.googleJavaFormat.get())
-    targetExclude("**/generated/**", "**/build/**")
+    target("src/*/java/**/*.java")
     licenseHeaderFile(rootProject.file("buildSrc/src/main/resources/license-header.star-block.txt"))
   }
   kotlin {
     ktfmt(libs.versions.ktfmt.get()).googleStyle()
-    targetExclude("**/generated/**", "**/build/**")
+    target("src/*/kotlin/**/*.kt")
     licenseHeaderFile(rootProject.file("buildSrc/src/main/resources/license-header.star-block.txt"))
   }
 }


### PR DESCRIPTION
Motivation:
Spotless tasks take minutes instead of seconds to complete. This greatly slows down `gw spotlessApply`, `gw check`, and `gw build`.

Changes:
- Use more efficient glob expressions for inclusion filters (`target()`).
- Avoid the need for exclusion filters (`targetExclude()`).

Result:
Spotless tasks complete in seconds instead of minutes. As a concrete example, repeated invocation of `gw spotlessApply` completes in 2 instead of 122 seconds on my laptop.