### PR TITLE
Fix typecheck error on Listing/Mapping

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmUtils.java
@@ -298,6 +298,9 @@ public final class VmUtils {
           }
         }
       } else if (receiver instanceof VmListingOrMapping<?> vmListingOrMapping) {
+        if (owner != receiver && owner instanceof VmListingOrMapping<?> vmListingOrMappingOwner) {
+          ret = vmListingOrMappingOwner.typecastObjectMember(member, ret, callNode);
+        }
         ret = vmListingOrMapping.typecastObjectMember(member, ret, callNode);
       }
       receiver.setCachedValue(memberKey, ret, member);

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/listingTypeCheckError6.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/listingTypeCheckError6.pkl
@@ -1,0 +1,5 @@
+local listing1: Listing<Int> = new { 1 }
+local listing2: Listing<String> = listing1
+local listing3 = (listing2) { "2" }
+
+first = listing3[0]

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/listingTypeCheckError7.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/listingTypeCheckError7.pkl
@@ -1,0 +1,2 @@
+foo: Listing = new { 1; 2; 3 }
+bar: Listing<String> = (foo) { "bar" }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/mappingTypeCheckError10.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/mappingTypeCheckError10.pkl
@@ -1,0 +1,2 @@
+foo: Mapping = new { ["foo"] = 1; ["bar"] = 2 }
+bar: Mapping<String, String> = (foo) { ["baz"] = "three" }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/mappingTypeCheckError9.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/mappingTypeCheckError9.pkl
@@ -1,0 +1,5 @@
+local mapping1: Mapping<String, Int> = new { ["foo"] = 1 }
+local mapping2: Mapping<String, String> = mapping1
+local mapping3 = (mapping2) { ["bar"] =  "2" }
+
+first = mapping3["foo"]

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError6.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError6.err
@@ -1,0 +1,19 @@
+–– Pkl Error ––
+Expected value of type `String`, but got type `Int`.
+Value: 1
+
+x | local listing2: Listing<String> = listing1
+                            ^^^^^^
+at listingTypeCheckError6#listing2 (file:///$snippetsDir/input/errors/listingTypeCheckError6.pkl)
+
+x | local listing1: Listing<Int> = new { 1 }
+                                         ^
+at listingTypeCheckError6#listing1[#1] (file:///$snippetsDir/input/errors/listingTypeCheckError6.pkl)
+
+x | first = listing3[0]
+            ^^^^^^^^^^^
+at listingTypeCheckError6#first (file:///$snippetsDir/input/errors/listingTypeCheckError6.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError7.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError7.err
@@ -1,0 +1,15 @@
+–– Pkl Error ––
+Expected value of type `String`, but got type `Int`.
+Value: 1
+
+x | bar: Listing<String> = (foo) { "bar" }
+                 ^^^^^^
+at listingTypeCheckError7#bar (file:///$snippetsDir/input/errors/listingTypeCheckError7.pkl)
+
+x | foo: Listing = new { 1; 2; 3 }
+                         ^
+at listingTypeCheckError7#foo[#1] (file:///$snippetsDir/input/errors/listingTypeCheckError7.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError10.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError10.err
@@ -1,0 +1,15 @@
+–– Pkl Error ––
+Expected value of type `String`, but got type `Int`.
+Value: 1
+
+x | bar: Mapping<String, String> = (foo) { ["baz"] = "three" }
+                         ^^^^^^
+at mappingTypeCheckError10#bar (file:///$snippetsDir/input/errors/mappingTypeCheckError10.pkl)
+
+x | foo: Mapping = new { ["foo"] = 1; ["bar"] = 2 }
+                                   ^
+at mappingTypeCheckError10#foo["foo"] (file:///$snippetsDir/input/errors/mappingTypeCheckError10.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError9.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError9.err
@@ -1,0 +1,19 @@
+–– Pkl Error ––
+Expected value of type `String`, but got type `Int`.
+Value: 1
+
+x | local mapping2: Mapping<String, String> = mapping1
+                                    ^^^^^^
+at mappingTypeCheckError9#mapping2 (file:///$snippetsDir/input/errors/mappingTypeCheckError9.pkl)
+
+x | local mapping1: Mapping<String, Int> = new { ["foo"] = 1 }
+                                                           ^
+at mappingTypeCheckError9#mapping1["foo"] (file:///$snippetsDir/input/errors/mappingTypeCheckError9.pkl)
+
+x | first = mapping3["foo"]
+            ^^^^^^^^^^^^^^^
+at mappingTypeCheckError9#first (file:///$snippetsDir/input/errors/mappingTypeCheckError9.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)


### PR DESCRIPTION
The addresses the following case:

```
local l1: Listing<String> = new { 1 }
l2: Listing<Int> = (l1) { 2 }
```

The member in `l1` should be checked against its owner; to check against `Listing<String>`.