### PR TITLE
codegen-java/kotlin: Support Spring Boot 3.x instead of 2.x

### DIFF
--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -493,10 +493,6 @@ class JavaCodeGenerator(
     }
 
     fun generateSpringBootAnnotations(builder: TypeSpec.Builder) {
-      builder.addAnnotation(
-        ClassName.get("org.springframework.boot.context.properties", "ConstructorBinding")
-      )
-
       if (isModuleClass) {
         builder.addAnnotation(
           ClassName.get("org.springframework.boot.context.properties", "ConfigurationProperties")

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
@@ -1407,7 +1407,6 @@ class JavaCodeGeneratorTest {
     assertThat(javaCode)
       .contains(
         """
-        |@ConstructorBinding
         |@ConfigurationProperties
         |public final class Mod {
       """
@@ -1421,7 +1420,6 @@ class JavaCodeGeneratorTest {
       )
       .contains(
         """
-        |  @ConstructorBinding
         |  @ConfigurationProperties("server")
         |  public static final class Server {
       """
@@ -1435,13 +1433,12 @@ class JavaCodeGeneratorTest {
       """
           .trimMargin()
       )
+      .doesNotContain("@ConstructorBinding")
 
     // not worthwhile to add spring & spring boot dependency just so that this test can compile
     // their annotations
     val javaCodeWithoutSpringAnnotations =
-      javaCode.deleteLines {
-        it.contains("ConstructorBinding") || it.contains("ConfigurationProperties")
-      }
+      javaCode.deleteLines { it.contains("ConfigurationProperties") }
     assertThat(javaCodeWithoutSpringAnnotations).compilesSuccessfully()
   }
 

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
@@ -413,10 +413,6 @@ class KotlinCodeGenerator(
     }
 
     fun generateSpringBootAnnotations(builder: TypeSpec.Builder) {
-      builder.addAnnotation(
-        ClassName("org.springframework.boot.context.properties", "ConstructorBinding")
-      )
-
       if (isModuleClass) {
         builder.addAnnotation(
           ClassName("org.springframework.boot.context.properties", "ConfigurationProperties")

--- a/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
+++ b/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
@@ -1427,7 +1427,6 @@ class KotlinCodeGeneratorTest {
     assertThat(kotlinCode)
       .contains(
         """
-        |@ConstructorBinding
         |@ConfigurationProperties
         |data class Mod(
         |  val server: Server
@@ -1436,7 +1435,6 @@ class KotlinCodeGeneratorTest {
       )
       .contains(
         """
-        |  @ConstructorBinding
         |  @ConfigurationProperties("server")
         |  data class Server(
         |    val port: Long,
@@ -1444,13 +1442,12 @@ class KotlinCodeGeneratorTest {
       """
           .trimMargin()
       )
+      .doesNotContain("@ConstructorBinding")
 
     // not worthwhile to add spring & spring boot dependency just so that this test can compile
     // their annotations
     val kotlinCodeWithoutSpringAnnotations =
-      kotlinCode.deleteLines {
-        it.contains("ConstructorBinding") || it.contains("ConfigurationProperties")
-      }
+      kotlinCode.deleteLines { it.contains("ConfigurationProperties") }
     assertThat(kotlinCodeWithoutSpringAnnotations).compilesSuccessfully()
   }
 


### PR DESCRIPTION
Motivation:
In Spring Boot 3.0, the annotation type `org.springframework.boot.context.properties.ConstructorBinding` was deprecated in favor of `org.springframework.boot.context.properties.bind.ConstructorBinding`. In 3.2, the old annotation type was removed.
As of 3.0, a `@ConstructorBinding` annotation is no longer required/recommended for configuration classes with a single public constructor.

Changes:
Remove generation of `@ConstructorBinding` annotations in codegen-java and codegen-kotlin.

Result:
- Generated code is compatible with Spring Boot 3.x. (Verified with locally updated pkl-spring.)
- Generated code is no longer compatible with Spring Boot 2.x. To use Pkl 0.27 and later with Spring Boot 2.x, use Pkl 0.26's code generator.
- Fixes #139.