### PR TITLE
codegen-java: Make stateless classes instantiable

### DIFF
--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -541,8 +541,9 @@ class JavaCodeGenerator(
       val builder =
         TypeSpec.classBuilder(javaPoetClassName.simpleName()).addModifiers(Modifier.PUBLIC)
 
-      // stateless classes aren't instantiable by choice, i.e., no public ctor is generated
-      val isInstantiable = !pClass.isAbstract && allProperties.isNotEmpty()
+      // stateless final module classes are non-instantiable by choice
+      val isInstantiable =
+        !(pClass.isAbstract || (isModuleClass && !pClass.isOpen && allProperties.isEmpty()))
 
       if (codegenOptions.implementSerializable && isInstantiable) {
         builder.addSuperinterface(java.io.Serializable::class.java)


### PR DESCRIPTION
Last codegen PR for now. :-)

Motivation:
Currently, the condition for making a generated Java class instantiable is "class is neither abstract nor stateless".
(An instantiable class receives a public constructor and equals/hashCode/toString/with methods.)
This is inconsistent with Pkl and codegen-kotlin, both of which support instantiation of stateless classes.

Changes:
Widen condition for making a class instantiable to "class is neither abstract nor a stateless final module class".
This is consistent with codegen-kotlin, which generates object declarations (only) for stateless final module classes.

Result:
Stateless classes are instantiable in Pkl, codegen-java, and codegen-kotlin.