### PR TITLE
Fix test failures on main

### DIFF
--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/TestsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/TestsTest.kt
@@ -112,6 +112,8 @@ class TestsTest : AbstractTest() {
     assertThat(output.trimStart())
       .startsWith(
         """
+      > Task :evalTestGatherImports
+
       > Task :evalTest FAILED
       pkl: TRACE: 8 = 8 (file:///file, line x)
       module test
@@ -181,6 +183,8 @@ class TestsTest : AbstractTest() {
     assertThat(output.trimStart())
       .startsWith(
         """
+      > Task :evalTestGatherImports
+
       > Task :evalTest FAILED
       module test
         facts


### PR DESCRIPTION
Just rebased some PRs on main and they're all failing in the pkl-gradle tests. This PR fixes the expectations, which changed with what I think is #695 