### PR TITLE
Exclude thrown ascii filename error from native tests

### DIFF
--- a/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt
@@ -199,6 +199,8 @@ abstract class AbstractNativeLanguageSnippetTestsEngine : AbstractLanguageSnippe
       // executable)
       // on the other hand, don't exclude /native/
       Regex(".*/import1b\\.pkl"),
+      // URIs get rendered slightly differently (percent-encoded vs raw)
+      Regex(".*日本語_error\\.pkl")
     )
 
   /** Avoid running tests for native binaries when those native binaries have not been built. */


### PR DESCRIPTION
The URI encoding is not predictable here (different from JVM on macOS/Linux)