### PR TITLE
Fix lazy type checking of UInt types

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
@@ -2153,7 +2153,7 @@ public abstract class TypeNode extends PklNode {
 
     @Override
     public boolean isEquivalentTo(TypeNode other) {
-      return other instanceof UIntTypeAliasTypeNode;
+      return other instanceof UIntTypeAliasTypeNode aliasTypeNode && mask == aliasTypeNode.mask;
     }
 
     @Override

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/basic/as2.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/basic/as2.pkl
@@ -22,11 +22,35 @@ examples {
     new Listing { 1; 2; 3 } as Listing<Int>
     module.catch(() -> (new Listing { 1; 2; 3 } as Listing<String>)[0])
   }
+  
+  ["cast Listing<UInt32> to other integer types"] {
+    local l = new Listing<UInt32> { 9999999 }
+    (l as Listing<Int>)[0]
+    (l as Listing<UInt>)[0]
+    (l as Listing<Int32>)[0]
+    (l as Listing<UInt32>)[0]
+    module.catch(() -> (l as Listing<Int16>)[0])
+    module.catch(() -> (l as Listing<UInt16>)[0])
+    module.catch(() -> (l as Listing<Int8>)[0])
+    module.catch(() -> (l as Listing<UInt8>)[0])
+  }
 
   ["mapping"] {
     module.catch(() -> new Listing { 1; 2; 3 } as Mapping<Int, String>)
     new Mapping { ["Pigeon"] = 42; ["Barn Owl"] = 21 } as Mapping<String, Int>
     module.catch(() -> new Mapping { ["Pigeon"] = 42; ["Barn Owl"] = 21 } as Mapping<Int, String>)
+  }
+  
+  ["cast Mapping<, UInt> to other integer types"] {
+    local m = new Mapping<String, UInt> { ["x"] = 9999 }
+    (m as Mapping<String, Int>)["x"]
+    (m as Mapping<String, UInt>)["x"]
+    (m as Mapping<String, Int32>)["x"]
+    (m as Mapping<String, UInt32>)["x"]
+    (m as Mapping<String, Int16>)["x"]
+    (m as Mapping<String, UInt16>)["x"]
+    module.catch(() -> (m as Mapping<String, Int8>)["x"])
+    module.catch(() -> (m as Mapping<String, UInt8>)["x"])
   }
   
   ["union type"] {

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/basic/as2.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/basic/as2.pcf
@@ -21,6 +21,16 @@ examples {
     }
     "Expected value of type `String`, but got type `Int`. Value: 1"
   }
+  ["cast Listing<UInt32> to other integer types"] {
+    9999999
+    9999999
+    9999999
+    9999999
+    "Type constraint `isBetween(-32768, 32767)` violated. Value: 9999999"
+    "Type constraint `isBetween(0, 65535)` violated. Value: 9999999"
+    "Type constraint `isBetween(-128, 127)` violated. Value: 9999999"
+    "Type constraint `isBetween(0, 255)` violated. Value: 9999999"
+  }
   ["mapping"] {
     "Expected value of type `Mapping`, but got type `Listing`. Value: new Listing { ?; ?; ? }"
     new {
@@ -28,6 +38,16 @@ examples {
       ["Barn Owl"] = 21
     }
     "Expected value of type `Int`, but got type `String`. Value: \"Pigeon\""
+  }
+  ["cast Mapping<, UInt> to other integer types"] {
+    9999
+    9999
+    9999
+    9999
+    9999
+    9999
+    "Type constraint `isBetween(-128, 127)` violated. Value: 9999"
+    "Type constraint `isBetween(0, 255)` violated. Value: 9999"
   }
   ["union type"] {
     42


### PR DESCRIPTION
For example, `Listing<UInt16>` is equivalent to `Listing<UInt16>`, but not to `Listing<UInt32>`.