### PR TITLE
 Correct EmbeddedExecutor to throw ExecutorException instead of PklException when project evaluation fails

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
@@ -122,7 +122,7 @@ public final class ExecutorSpiImpl implements ExecutorSpi {
         var project =
             Project.loadFromPath(
                 options.getProjectDir().resolve(PKL_PROJECT_FILENAME),
-                SecurityManagers.defaultManager,
+                securityManager,
                 null,
                 transformer,
                 System.getenv());

--- a/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
@@ -125,7 +125,7 @@ public final class ExecutorSpiImpl implements ExecutorSpi {
                 securityManager,
                 null,
                 transformer,
-                System.getenv());
+                options.getEnvironmentVariables());
         builder.setProjectDependencies(project.getDependencies());
       }
 

--- a/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/service/ExecutorSpiImpl.java
@@ -116,13 +116,22 @@ public final class ExecutorSpiImpl implements ExecutorSpi {
             .setTimeout(options.getTimeout())
             .setOutputFormat(options.getOutputFormat())
             .setModuleCacheDir(options.getModuleCacheDir());
-    if (options.getProjectDir() != null) {
-      var project = Project.loadFromPath(options.getProjectDir().resolve(PKL_PROJECT_FILENAME));
-      builder.setProjectDependencies(project.getDependencies());
-    }
 
-    try (var evaluator = builder.build()) {
-      return evaluator.evaluateOutputText(ModuleSource.path(modulePath));
+    try {
+      if (options.getProjectDir() != null) {
+        var project =
+            Project.loadFromPath(
+                options.getProjectDir().resolve(PKL_PROJECT_FILENAME),
+                SecurityManagers.defaultManager,
+                null,
+                transformer,
+                System.getenv());
+        builder.setProjectDependencies(project.getDependencies());
+      }
+
+      try (var evaluator = builder.build()) {
+        return evaluator.evaluateOutputText(ModuleSource.path(modulePath));
+      }
     } catch (PklException e) {
       throw new ExecutorSpiException(e.getMessage(), e.getCause());
     } finally {

--- a/pkl-executor/src/main/java/org/pkl/executor/EmbeddedExecutor.java
+++ b/pkl-executor/src/main/java/org/pkl/executor/EmbeddedExecutor.java
@@ -227,6 +227,13 @@ final class EmbeddedExecutor implements Executor {
         return executorSpi.evaluatePath(modulePath, options.toSpiOptions());
       } catch (ExecutorSpiException e) {
         throw new ExecutorException(e.getMessage(), e.getCause(), executorSpi.getPklVersion());
+      } catch (RuntimeException e) {
+        // This branch would ideally never be hit, but older Pkl releases (<0.27) may trigger this
+        // by bubbling PklException up to this point in cases where project evaluation fails.
+        // This catch-all ensures the API contract of Executor is upheld.
+        // Unfortunately the PklException thrown by the ExecutorSpi is from a different class loader
+        // so the host program cannot directly catch PklException specifically
+        throw new ExecutorException(e.getMessage(), e.getCause());
       } finally {
         currentThread.setContextClassLoader(prevContextClassLoader);
       }

--- a/pkl-executor/src/test/kotlin/org/pkl/executor/EmbeddedExecutorTest.kt
+++ b/pkl-executor/src/test/kotlin/org/pkl/executor/EmbeddedExecutorTest.kt
@@ -70,11 +70,6 @@ class EmbeddedExecutorTest {
       )
     }
 
-    @JvmStatic
-    private val allTestExecutorsWithoutDistribution1: List<TestExecutor> by lazy {
-      allTestExecutors.filter { !it.toString().contains("Distribution1") }
-    }
-
     private val currentExecutor: TestExecutor by lazy {
       TestExecutor(executor2_2.value, -1, "currentExecutor")
     }


### PR DESCRIPTION
There are two fixes here:
* pkl-core's `ExecutorSpiImpl` now properly handles project evaluation errors
* pkl-executor's `EmbeddedExecutor` now catches all `RuntimeException`s and transforms them to `ExecutorException` so the `Executor` API contract is upheld.