### PR TITLE
Replace code tick with italic

### DIFF
--- a/docs/modules/pkl-doc/pages/index.adoc
+++ b/docs/modules/pkl-doc/pages/index.adoc
@@ -162,7 +162,7 @@ We recommend to provision it with a Maven compatible build tool as shown in <<in
 The Pkldoc tool is offered as Gradle plugin, Java library, and CLI.
 It can generate documentation either for modules directly, or generate documentation for _package uris_.
 
-The tool requires an argument of a module named `_docsite-info.pkl`, that amends link:{uri-DocsiteInfo}[pkl.DocsiteInfo].
+The tool requires an argument of a module named _docsite-info.pkl_, that amends link:{uri-DocsiteInfo}[pkl.DocsiteInfo].
 
 [discrete]
 ==== Generating documentation for modules directly


### PR DESCRIPTION
Right now it looks like that (red underline):
![Screenshot 2024-10-30 at 10 39 57 AM](https://github.com/user-attachments/assets/8daa713a-0e79-4067-9a1f-af9f2fb2c43c)

I removed the code ticks and replaced them with an underscore to better match the style (see the blue circle 🙃).
