### PR TITLE
Polish external reader API/implementation

### DIFF
--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -21,7 +21,7 @@ import java.util.regex.Pattern
 import kotlin.io.path.isRegularFile
 import org.pkl.core.*
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings
-import org.pkl.core.externalreader.ExternalReaderProcessImpl
+import org.pkl.core.externalreader.ExternalReaderProcess
 import org.pkl.core.http.HttpClient
 import org.pkl.core.module.ModuleKeyFactories
 import org.pkl.core.module.ModuleKeyFactory
@@ -185,12 +185,11 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
   }
 
   private val externalProcesses by lazy {
-    // share ExternalProcessImpl instances between configured external resource/module readers with
-    // the same spec
-    // this avoids spawning multiple subprocesses if the same reader implements both reader types
-    // and/or multiple schemes
+    // Share ExternalReaderProcess instances between configured external resource/module readers
+    // with the same spec. This avoids spawning multiple subprocesses if the same reader implements
+    // both reader types and/or multiple schemes.
     (externalModuleReaders + externalResourceReaders).values.toSet().associateWith {
-      ExternalReaderProcessImpl(it)
+      ExternalReaderProcess.of(it)
     }
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
@@ -22,7 +22,6 @@ import java.util.regex.Pattern;
 import org.pkl.core.SecurityManagers.StandardBuilder;
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings.ExternalReader;
 import org.pkl.core.externalreader.ExternalReaderProcess;
-import org.pkl.core.externalreader.ExternalReaderProcessImpl;
 import org.pkl.core.http.HttpClient;
 import org.pkl.core.module.ModuleKeyFactories;
 import org.pkl.core.module.ModuleKeyFactory;
@@ -482,14 +481,14 @@ public final class EvaluatorBuilder {
       setModuleCacheDir(settings.moduleCacheDir());
     }
 
-    // this isn't ideal as project and non-project ExternalProcessImpl instances can be dupes
+    // this isn't ideal as project and non-project ExternalReaderProcess instances can be dupes
     var procs = new HashMap<ExternalReader, ExternalReaderProcess>();
     if (settings.externalModuleReaders() != null) {
       for (var entry : settings.externalModuleReaders().entrySet()) {
         addModuleKeyFactory(
             ModuleKeyFactories.externalProcess(
                 entry.getKey(),
-                procs.computeIfAbsent(entry.getValue(), ExternalReaderProcessImpl::new)));
+                procs.computeIfAbsent(entry.getValue(), ExternalReaderProcess::of)));
       }
     }
     if (settings.externalResourceReaders() != null) {
@@ -497,7 +496,7 @@ public final class EvaluatorBuilder {
         addResourceReader(
             ResourceReaders.externalProcess(
                 entry.getKey(),
-                procs.computeIfAbsent(entry.getValue(), ExternalReaderProcessImpl::new)));
+                procs.computeIfAbsent(entry.getValue(), ExternalReaderProcess::of)));
       }
     }
     return this;

--- a/pkl-core/src/main/java/org/pkl/core/externalreader/ExternalReaderMessagePackDecoder.java
+++ b/pkl-core/src/main/java/org/pkl/core/externalreader/ExternalReaderMessagePackDecoder.java
@@ -28,7 +28,7 @@ import org.pkl.core.messaging.Message;
 import org.pkl.core.messaging.Message.Type;
 import org.pkl.core.util.Nullable;
 
-public class ExternalReaderMessagePackDecoder extends BaseMessagePackDecoder {
+final class ExternalReaderMessagePackDecoder extends BaseMessagePackDecoder {
 
   public ExternalReaderMessagePackDecoder(MessageUnpacker unpacker) {
     super(unpacker);

--- a/pkl-core/src/main/java/org/pkl/core/externalreader/ExternalReaderMessagePackEncoder.java
+++ b/pkl-core/src/main/java/org/pkl/core/externalreader/ExternalReaderMessagePackEncoder.java
@@ -25,7 +25,7 @@ import org.pkl.core.messaging.Message;
 import org.pkl.core.messaging.ProtocolException;
 import org.pkl.core.util.Nullable;
 
-public class ExternalReaderMessagePackEncoder extends BaseMessagePackEncoder {
+final class ExternalReaderMessagePackEncoder extends BaseMessagePackEncoder {
 
   public ExternalReaderMessagePackEncoder(MessagePacker packer) {
     super(packer);

--- a/pkl-core/src/main/java/org/pkl/core/externalreader/ExternalReaderMessages.java
+++ b/pkl-core/src/main/java/org/pkl/core/externalreader/ExternalReaderMessages.java
@@ -20,7 +20,8 @@ import org.pkl.core.messaging.Messages.ModuleReaderSpec;
 import org.pkl.core.messaging.Messages.ResourceReaderSpec;
 import org.pkl.core.util.Nullable;
 
-public class ExternalReaderMessages {
+final class ExternalReaderMessages {
+  private ExternalReaderMessages() {}
 
   public record InitializeModuleReaderRequest(long requestId, String scheme)
       implements Server.Request {

--- a/pkl-core/src/main/java/org/pkl/core/messaging/MessageTransports.java
+++ b/pkl-core/src/main/java/org/pkl/core/messaging/MessageTransports.java
@@ -27,7 +27,8 @@ import org.pkl.core.util.ErrorMessages;
 import org.pkl.core.util.Pair;
 
 /** Factory methods for creating [MessageTransport]s. */
-public class MessageTransports {
+public final class MessageTransports {
+  private MessageTransports() {}
 
   public interface Logger {
     void log(String msg);

--- a/pkl-core/src/main/java/org/pkl/core/messaging/Messages.java
+++ b/pkl-core/src/main/java/org/pkl/core/messaging/Messages.java
@@ -23,7 +23,8 @@ import org.pkl.core.messaging.Message.*;
 import org.pkl.core.module.PathElement;
 import org.pkl.core.util.Nullable;
 
-public class Messages {
+public final class Messages {
+  private Messages() {}
 
   public record ModuleReaderSpec(
       String scheme, boolean hasHierarchicalUris, boolean isLocal, boolean isGlobbable) {}
@@ -77,12 +78,6 @@ public class Messages {
   public record ReadResourceResponse(
       long requestId, long evaluatorId, byte @Nullable [] contents, @Nullable String error)
       implements Client.Response {
-
-    // workaround for kotlin bridging issue where `byte @Nullable [] contents` isn't detected as
-    // nullable
-    //    public ReadResourceResponse(long requestId, long evaluatorId, @Nullable String error) {
-    //      this(requestId, evaluatorId, null, error);
-    //    }
 
     public Type type() {
       return Type.READ_RESOURCE_RESPONSE;

--- a/pkl-core/src/main/java/org/pkl/core/module/ModuleKeys.java
+++ b/pkl-core/src/main/java/org/pkl/core/module/ModuleKeys.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import org.pkl.core.SecurityManager;
 import org.pkl.core.SecurityManagerException;
 import org.pkl.core.externalreader.ExternalReaderProcessException;
-import org.pkl.core.messaging.Messages.*;
+import org.pkl.core.messaging.Messages.ModuleReaderSpec;
 import org.pkl.core.packages.Dependency;
 import org.pkl.core.packages.Dependency.LocalDependency;
 import org.pkl.core.packages.PackageAssetUri;
@@ -131,7 +131,7 @@ public final class ModuleKeys {
 
   /** Creates a module key for an externally read module. */
   public static ModuleKey externalResolver(
-      URI uri, ModuleReaderSpec spec, ExternalModuleResolver resolver) throws URISyntaxException {
+      URI uri, ModuleReaderSpec spec, ExternalModuleResolver resolver) {
     return new ExternalResolver(uri, spec, resolver);
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/resource/ExternalResourceResolver.java
+++ b/pkl-core/src/main/java/org/pkl/core/resource/ExternalResourceResolver.java
@@ -49,7 +49,7 @@ public class ExternalResourceResolver {
     return Optional.of(new Resource(uri, result));
   }
 
-  public boolean hasElement(org.pkl.core.SecurityManager securityManager, URI elementUri)
+  public boolean hasElement(SecurityManager securityManager, URI elementUri)
       throws SecurityManagerException {
     securityManager.checkResolveResource(elementUri);
     try {

--- a/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaders.java
+++ b/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaders.java
@@ -31,7 +31,7 @@ import org.pkl.core.SecurityManager;
 import org.pkl.core.SecurityManagerException;
 import org.pkl.core.externalreader.ExternalReaderProcess;
 import org.pkl.core.externalreader.ExternalReaderProcessException;
-import org.pkl.core.messaging.Messages.*;
+import org.pkl.core.messaging.Messages.ResourceReaderSpec;
 import org.pkl.core.module.FileResolver;
 import org.pkl.core.module.ModulePathResolver;
 import org.pkl.core.module.PathElement;

--- a/pkl-core/src/main/java/org/pkl/core/util/Readers.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/Readers.java
@@ -15,7 +15,9 @@
  */
 package org.pkl.core.util;
 
-public class Readers {
+public final class Readers {
+  private Readers() {}
+
   /** Closes the given readers, ignoring any exceptions. */
   public static void closeQuietly(Iterable<? extends AutoCloseable> readers) {
     for (var reader : readers) {

--- a/pkl-server/src/main/kotlin/org/pkl/server/Server.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/Server.kt
@@ -25,7 +25,6 @@ import kotlin.random.Random
 import org.pkl.core.*
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings.ExternalReader
 import org.pkl.core.externalreader.ExternalReaderProcess
-import org.pkl.core.externalreader.ExternalReaderProcessImpl
 import org.pkl.core.http.HttpClient
 import org.pkl.core.messaging.MessageTransport
 import org.pkl.core.messaging.MessageTransports
@@ -286,5 +285,5 @@ class Server(private val transport: MessageTransport) : AutoCloseable {
   private fun getExternalProcess(evaluatorId: Long, spec: ExternalReader): ExternalReaderProcess =
     externalReaderProcesses
       .computeIfAbsent(evaluatorId) { ConcurrentHashMap() }
-      .computeIfAbsent(spec) { ExternalReaderProcessImpl(it) }
+      .computeIfAbsent(spec) { ExternalReaderProcess.of(it) }
 }


### PR DESCRIPTION
Things I noticed but didn't address in this PR:
* many APIs are missing Javadoc
* libraries shouldn't log directly to std out/err (see `ExternalReaderProcessImpl`)
* some `ExternalReaderProcessException` messages are externalized, others aren't
* `ExternalReaderProcessException` is a checked exception
  - it's not clear to me what Pkl's policy on unchecked vs. checked exceptions is
* `new Random().nextLong()` is expensive and has poor randomness (Random should be reused or replaced with counter)
* deprecation of `ModuleKeyFactories.closeQuietly` in favor of `org.pkl.core.util.Readers.closeQuietly` turns package `org.pkl.core.util` into a public API
  - private packages keep leaking into public APIs
* `org.pkl.core.module.ResourceReaders` API is (too) tightly coupled to reader protocol via `ModuleReaderSpec`
* `ExternalReaderProcess` is a leaky abstraction
  - only partially implements the reader protocol
  - exposes its `MessageTransport`
  - interface name implies that all implementations spawn a process (unnecessary requirement?)
* msgpack is now a hard dependency of pkl-core, pkl-config-java, etc.
  - might be safer to make it an optional dependency
  
IMHO the external reader API/implementation needs more work.

Changes:
- keep implementation classes internal to their packages
- make classes final if possible
- make namespace classes non-instantiable
- throw IllegalStateException instead of ExternalReaderProcessException for use after close
  - common convention already used by HttpClient etc.
  - programming errors should be signaled with unchecked exceptions
- use private instead of public lock object
- polish Javadoc
- delete commented out code
- don't use star import for importing a single class