### PR TITLE
Eagerly check function arguments when called from inside iterable

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
@@ -1986,6 +1986,7 @@ public final class AstBuilder extends AbstractAstBuilder<Object> {
               visitArgumentList(argCtx),
               MemberLookupMode.EXPLICIT_RECEIVER,
               needsConst,
+              symbolTable.getCurrentScope().isVisitingIterable(),
               PropagateNullReceiverNodeGen.create(unavailableSourceSection(), receiver),
               GetClassNodeGen.create(null)));
     }
@@ -1998,6 +1999,7 @@ public final class AstBuilder extends AbstractAstBuilder<Object> {
         visitArgumentList(argCtx),
         MemberLookupMode.EXPLICIT_RECEIVER,
         needsConst,
+        symbolTable.getCurrentScope().isVisitingIterable(),
         receiver,
         GetClassNodeGen.create(null));
   }
@@ -2072,7 +2074,11 @@ public final class AstBuilder extends AbstractAstBuilder<Object> {
       }
 
       return InvokeSuperMethodNodeGen.create(
-          sourceSection, memberName, visitArgumentList(argCtx), needsConst);
+          sourceSection,
+          memberName,
+          symbolTable.getCurrentScope().isVisitingIterable(),
+          visitArgumentList(argCtx),
+          needsConst);
     }
 
     // superproperty call
@@ -2130,7 +2136,8 @@ public final class AstBuilder extends AbstractAstBuilder<Object> {
         isBaseModule,
         scope.isCustomThisScope(),
         scope.getConstLevel(),
-        scope.getConstDepth());
+        scope.getConstDepth(),
+        scope.isVisitingIterable());
   }
 
   @Override

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/binary/LetExprNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/binary/LetExprNode.java
@@ -71,6 +71,6 @@ public final class LetExprNode extends ExpressionNode {
 
     var value = valueNode.executeGeneric(frame);
 
-    return callNode.call(function.getThisValue(), function, value);
+    return callNode.call(function.getThisValue(), function, false, value);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/literal/AmendFunctionNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/literal/AmendFunctionNode.java
@@ -184,7 +184,8 @@ public final class AmendFunctionNode extends PklNode {
       var arguments = new Object[frameArguments.length];
       arguments[0] = functionToAmend.getThisValue();
       arguments[1] = functionToAmend;
-      System.arraycopy(frameArguments, 2, arguments, 2, frameArguments.length - 2);
+      arguments[2] = false;
+      System.arraycopy(frameArguments, 3, arguments, 3, frameArguments.length - 3);
 
       var valueToAmend = callNode.call(functionToAmend.getCallTarget(), arguments);
       if (!(valueToAmend instanceof VmFunction newFunctionToAmend)) {

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/member/InvokeMethodDirectNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/member/InvokeMethodDirectNode.java
@@ -28,6 +28,7 @@ public final class InvokeMethodDirectNode extends ExpressionNode {
   private final VmObjectLike owner;
   @Child private ExpressionNode receiverNode;
   @Children private final ExpressionNode[] argumentNodes;
+  private final boolean isInIterable;
 
   @Child private DirectCallNode callNode;
 
@@ -35,12 +36,14 @@ public final class InvokeMethodDirectNode extends ExpressionNode {
       SourceSection sourceSection,
       ClassMethod method,
       ExpressionNode receiverNode,
-      ExpressionNode[] argumentNodes) {
+      ExpressionNode[] argumentNodes,
+      boolean isInIterable) {
 
     super(sourceSection);
     this.owner = method.getOwner();
     this.receiverNode = receiverNode;
     this.argumentNodes = argumentNodes;
+    this.isInIterable = isInIterable;
 
     callNode = DirectCallNode.create(method.getCallTarget(sourceSection));
   }
@@ -48,11 +51,12 @@ public final class InvokeMethodDirectNode extends ExpressionNode {
   @Override
   @ExplodeLoop
   public Object executeGeneric(VirtualFrame frame) {
-    var args = new Object[2 + argumentNodes.length];
+    var args = new Object[3 + argumentNodes.length];
     args[0] = receiverNode.executeGeneric(frame);
     args[1] = owner;
+    args[2] = isInIterable;
     for (var i = 0; i < argumentNodes.length; i++) {
-      args[2 + i] = argumentNodes[i].executeGeneric(frame);
+      args[3 + i] = argumentNodes[i].executeGeneric(frame);
     }
 
     return callNode.call(args);

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/member/InvokeMethodLexicalNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/member/InvokeMethodLexicalNode.java
@@ -33,29 +33,33 @@ public final class InvokeMethodLexicalNode extends ExpressionNode {
   private final int levelsUp;
 
   @Child private DirectCallNode callNode;
+  private final boolean isInIterable;
 
   InvokeMethodLexicalNode(
       SourceSection sourceSection,
       CallTarget callTarget,
       int levelsUp,
-      ExpressionNode[] argumentNodes) {
+      ExpressionNode[] argumentNodes,
+      boolean isInIterable) {
 
     super(sourceSection);
     this.levelsUp = levelsUp;
     this.argumentNodes = argumentNodes;
 
     callNode = DirectCallNode.create(callTarget);
+    this.isInIterable = isInIterable;
   }
 
   @Override
   @ExplodeLoop
   public Object executeGeneric(VirtualFrame frame) {
-    var args = new Object[2 + argumentNodes.length];
+    var args = new Object[3 + argumentNodes.length];
     var enclosingFrame = getEnclosingFrame(frame);
     args[0] = VmUtils.getReceiver(enclosingFrame);
     args[1] = VmUtils.getOwner(enclosingFrame);
+    args[2] = isInIterable;
     for (var i = 0; i < argumentNodes.length; i++) {
-      args[2 + i] = argumentNodes[i].executeGeneric(frame);
+      args[3 + i] = argumentNodes[i].executeGeneric(frame);
     }
 
     return callNode.call(args);

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/member/InvokeSuperMethodNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/member/InvokeSuperMethodNode.java
@@ -30,15 +30,18 @@ import org.pkl.core.runtime.VmUtils;
 public abstract class InvokeSuperMethodNode extends ExpressionNode {
   private final Identifier methodName;
   @Children private final ExpressionNode[] argumentNodes;
+  private final boolean isInIterable;
   private final boolean needsConst;
 
   protected InvokeSuperMethodNode(
       SourceSection sourceSection,
       Identifier methodName,
+      boolean isInIterable,
       ExpressionNode[] argumentNodes,
       boolean needsConst) {
 
     super(sourceSection);
+    this.isInIterable = isInIterable;
     this.needsConst = needsConst;
 
     assert !methodName.isLocalMethod();
@@ -54,11 +57,12 @@ public abstract class InvokeSuperMethodNode extends ExpressionNode {
       @Cached(value = "findSupermethod(frame)", neverDefault = true) ClassMethod supermethod,
       @Cached("create(supermethod.getCallTarget(sourceSection))") DirectCallNode callNode) {
 
-    var args = new Object[2 + argumentNodes.length];
+    var args = new Object[3 + argumentNodes.length];
     args[0] = VmUtils.getReceiverOrNull(frame);
     args[1] = supermethod.getOwner();
+    args[2] = isInIterable;
     for (int i = 0; i < argumentNodes.length; i++) {
-      args[2 + i] = argumentNodes[i].executeGeneric(frame);
+      args[3 + i] = argumentNodes[i].executeGeneric(frame);
     }
 
     return callNode.call(args);

--- a/pkl-core/src/main/java/org/pkl/core/ast/internal/ToStringNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/internal/ToStringNode.java
@@ -80,6 +80,7 @@ public abstract class ToStringNode extends UnaryExpressionNode {
         Identifier.TO_STRING,
         new ExpressionNode[] {},
         MemberLookupMode.EXPLICIT_RECEIVER,
+        false,
         null,
         null);
   }

--- a/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction0Node.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction0Node.java
@@ -33,12 +33,12 @@ public abstract class ApplyVmFunction0Node extends PklNode {
           RootCallTarget cachedCallTarget,
       @Cached("create(cachedCallTarget)") DirectCallNode callNode) {
 
-    return callNode.call(function.getThisValue(), function);
+    return callNode.call(function.getThisValue(), function, false);
   }
 
   @Specialization(replaces = "evalDirect")
   protected Object eval(VmFunction function, @Cached("create()") IndirectCallNode callNode) {
 
-    return callNode.call(function.getCallTarget(), function.getThisValue(), function);
+    return callNode.call(function.getCallTarget(), function.getThisValue(), function, false);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction1Node.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction1Node.java
@@ -77,13 +77,13 @@ public abstract class ApplyVmFunction1Node extends ExpressionNode {
           RootCallTarget cachedCallTarget,
       @Cached("create(cachedCallTarget)") DirectCallNode callNode) {
 
-    return callNode.call(function.getThisValue(), function, arg1);
+    return callNode.call(function.getThisValue(), function, false, arg1);
   }
 
   @Specialization(replaces = "evalDirect")
   protected Object eval(
       VmFunction function, Object arg1, @Cached("create()") IndirectCallNode callNode) {
 
-    return callNode.call(function.getCallTarget(), function.getThisValue(), function, arg1);
+    return callNode.call(function.getCallTarget(), function.getThisValue(), function, false, arg1);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction2Node.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction2Node.java
@@ -76,7 +76,7 @@ public abstract class ApplyVmFunction2Node extends PklNode {
           RootCallTarget cachedCallTarget,
       @Cached("create(cachedCallTarget)") DirectCallNode callNode) {
 
-    return callNode.call(function.getThisValue(), function, arg1, arg2);
+    return callNode.call(function.getThisValue(), function, false, arg1, arg2);
   }
 
   @Specialization(replaces = "evalDirect")
@@ -86,6 +86,7 @@ public abstract class ApplyVmFunction2Node extends PklNode {
       Object arg2,
       @Cached("create()") IndirectCallNode callNode) {
 
-    return callNode.call(function.getCallTarget(), function.getThisValue(), function, arg1, arg2);
+    return callNode.call(
+        function.getCallTarget(), function.getThisValue(), function, false, arg1, arg2);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction3Node.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction3Node.java
@@ -36,7 +36,7 @@ public abstract class ApplyVmFunction3Node extends PklNode {
           RootCallTarget cachedCallTarget,
       @Cached("create(cachedCallTarget)") DirectCallNode callNode) {
 
-    return callNode.call(function.getThisValue(), function, arg1, arg2, arg3);
+    return callNode.call(function.getThisValue(), function, false, arg1, arg2, arg3);
   }
 
   @Specialization(replaces = "evalDirect")
@@ -48,6 +48,6 @@ public abstract class ApplyVmFunction3Node extends PklNode {
       @Cached("create()") IndirectCallNode callNode) {
 
     return callNode.call(
-        function.getCallTarget(), function.getThisValue(), function, arg1, arg2, arg3);
+        function.getCallTarget(), function.getThisValue(), function, false, arg1, arg2, arg3);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction4Node.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction4Node.java
@@ -38,7 +38,7 @@ public abstract class ApplyVmFunction4Node extends PklNode {
           RootCallTarget cachedCallTarget,
       @Cached("create(cachedCallTarget)") DirectCallNode callNode) {
 
-    return callNode.call(function.getThisValue(), function, arg1, arg2, arg3, arg4);
+    return callNode.call(function.getThisValue(), function, false, arg1, arg2, arg3, arg4);
   }
 
   @Specialization(replaces = "evalDirect")
@@ -51,6 +51,6 @@ public abstract class ApplyVmFunction4Node extends PklNode {
       @Cached("create()") IndirectCallNode callNode) {
 
     return callNode.call(
-        function.getCallTarget(), function.getThisValue(), function, arg1, arg2, arg3, arg4);
+        function.getCallTarget(), function.getThisValue(), function, false, arg1, arg2, arg3, arg4);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction5Node.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/lambda/ApplyVmFunction5Node.java
@@ -39,7 +39,7 @@ public abstract class ApplyVmFunction5Node extends PklNode {
           RootCallTarget cachedCallTarget,
       @Cached("create(cachedCallTarget)") DirectCallNode callNode) {
 
-    return callNode.call(function.getThisValue(), function, arg1, arg2, arg3, arg4, arg5);
+    return callNode.call(function.getThisValue(), function, false, arg1, arg2, arg3, arg4, arg5);
   }
 
   @Specialization(replaces = "evalDirect")
@@ -53,6 +53,14 @@ public abstract class ApplyVmFunction5Node extends PklNode {
       @Cached("create()") IndirectCallNode callNode) {
 
     return callNode.call(
-        function.getCallTarget(), function.getThisValue(), function, arg1, arg2, arg3, arg4, arg5);
+        function.getCallTarget(),
+        function.getThisValue(),
+        function,
+        false,
+        arg1,
+        arg2,
+        arg3,
+        arg4,
+        arg5);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/FunctionNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/FunctionNode.java
@@ -44,7 +44,7 @@ public final class FunctionNode extends RegularMemberNode {
   // For VmObject receivers, the owner is the same as or an ancestor of the receiver.
   // For other receivers, the owner is the prototype of the receiver's class.
   // The chain of enclosing owners forms a function/property's lexical scope.
-  private static final int IMPLICIT_PARAM_COUNT = 2;
+  private static final int IMPLICIT_PARAM_COUNT = 3;
 
   private final int paramCount;
   private final int totalParamCount;
@@ -109,10 +109,15 @@ public final class FunctionNode extends RegularMemberNode {
       throw wrongArgumentCount(totalArgCount - IMPLICIT_PARAM_COUNT);
     }
 
+    var isInIterable = (boolean) frame.getArguments()[2];
     try {
       for (var i = 0; i < parameterTypeNodes.length; i++) {
         var argument = frame.getArguments()[IMPLICIT_PARAM_COUNT + i];
-        parameterTypeNodes[i].executeAndSet(frame, argument);
+        if (isInIterable) {
+          parameterTypeNodes[i].executeEagerlyAndSet(frame, argument);
+        } else {
+          parameterTypeNodes[i].executeAndSet(frame, argument);
+        }
       }
 
       var result = bodyNode.executeGeneric(frame);

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/FunctionNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/FunctionNode.java
@@ -44,6 +44,10 @@ public final class FunctionNode extends RegularMemberNode {
   // For VmObject receivers, the owner is the same as or an ancestor of the receiver.
   // For other receivers, the owner is the prototype of the receiver's class.
   // The chain of enclosing owners forms a function/property's lexical scope.
+  //
+  // For function calls only, a third implicit argument is passed; whether the call came from within
+  // an iterable node or not.
+  // This is a mitigation for an existing bug (https://github.com/apple/pkl/issues/741).
   private static final int IMPLICIT_PARAM_COUNT = 3;
 
   private final int paramCount;

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/IdentityMixinNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/IdentityMixinNode.java
@@ -55,16 +55,16 @@ public final class IdentityMixinNode extends PklRootNode {
   @Override
   public Object execute(VirtualFrame frame) {
     var arguments = frame.getArguments();
-    if (arguments.length != 3) {
+    if (arguments.length != 4) {
       CompilerDirectives.transferToInterpreter();
       throw exceptionBuilder()
-          .evalError("wrongFunctionArgumentCount", 1, arguments.length - 2)
+          .evalError("wrongFunctionArgumentCount", 1, arguments.length - 3)
           .withSourceSection(sourceSection)
           .build();
     }
 
     try {
-      var argument = arguments[2];
+      var argument = arguments[3];
       if (argumentTypeNode != null) {
         return argumentTypeNode.execute(frame, argument);
       }

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmFunction.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmFunction.java
@@ -55,7 +55,7 @@ public final class VmFunction extends VmObjectLike {
   // if call site is a node, use ApplyVmFunction1Node.execute() or DirectCallNode.call() instead of
   // this method
   public Object apply(Object arg1) {
-    return getCallTarget().call(thisValue, this, arg1);
+    return getCallTarget().call(thisValue, this, false, arg1);
   }
 
   public String applyString(Object arg1) {
@@ -69,7 +69,7 @@ public final class VmFunction extends VmObjectLike {
   // if call site is a node, use ApplyVmFunction2Node.execute() or DirectCallNode.call() instead of
   // this method
   public Object apply(Object arg1, Object arg2) {
-    return getCallTarget().call(thisValue, this, arg1, arg2);
+    return getCallTarget().call(thisValue, this, false, arg1, arg2);
   }
 
   public VmFunction copy(

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/FunctionNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/FunctionNodes.java
@@ -31,11 +31,12 @@ public final class FunctionNodes {
     protected Object eval(VmFunction self, VmList argList) {
       var argCount = argList.getLength();
 
-      var args = new Object[2 + argCount];
+      var args = new Object[3 + argCount];
       args[0] = self.getThisValue();
       args[1] = self;
+      args[2] = false;
 
-      var i = 2;
+      var i = 3;
       for (var arg : argList) {
         args[i++] = arg;
       }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/generators/forGeneratorNestedReference.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/generators/forGeneratorNestedReference.pkl
@@ -31,3 +31,27 @@ res2 {
     }.birds
   }
 }
+
+res3 {
+  for (key, _ in Map("hello-there", 5)) {
+    ...myself(new Listing {
+      new Listing {
+        key
+      }
+    })
+  }
+}
+
+res4 {
+  for (key, _ in Map("hello-there", 5)) {
+    ...myself2.apply(new Listing {
+      new Listing {
+        key
+      }
+    })
+  }
+}
+
+function myself(l: Listing<Listing<String>>) = l
+
+local myself2 = (l: Listing<Listing<String>>) -> l

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/generators/forGeneratorNestedReference.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/generators/forGeneratorNestedReference.pcf
@@ -8,3 +8,13 @@ res2 {
     age = 1
   }
 }
+res3 {
+  new {
+    "hello-there"
+  }
+}
+res4 {
+  new {
+    "hello-there"
+  }
+}


### PR DESCRIPTION
This mitigates an issue where lazy mappings and listings widen an existing bug.

This is a follow-up to https://github.com/apple/pkl/pull/752.

Ideally, when we fix the scoping bug, we also revert this commit.