### PR TITLE
Fix broken link to documentation site in release notes

### DIFF
--- a/docs/modules/release-notes/pages/0.27.adoc
+++ b/docs/modules/release-notes/pages/0.27.adoc
@@ -377,7 +377,7 @@ These are:
 
 The `String` to `Number` converter methods, for example,  {uri-stdlib-StringToInt}[`String.toInt()`], can now handle underscore separators (https://github.com/apple/pkl/pull/578[#578], https://github.com/apple/pkl/pull/580[#580]).
 
-This better aligns with the source code representation of file:///Users/danielchao/code/apple/pkl-lang.org/build/local/main/current/language-reference/index.html#integers[number literals].
+This better aligns with the source code representation of xref:language-reference:index.adoc#integers[number literals].
 
 [source,pkl]
 ----


### PR DESCRIPTION
The "number literals" link on the [0.27 release notes](https://pkl-lang.org/main/current/release-notes/0.27.html) is a broken link pointing to a local `file://` URL. I think this should fix it to point to the live docs site (similar to how other doc links are setup).