### PR TITLE
Switch from com.squareup.javapoet to com.palantir.javapoet

### DIFF
--- a/buildSrc/src/main/kotlin/pklFatJar.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklFatJar.gradle.kts
@@ -65,7 +65,7 @@ val relocations =
     "io.leangen.geantyref." to "org.pkl.thirdparty.geantyref.",
 
     // pkl-codegen-java dependencies
-    "com.squareup.javapoet." to "org.pkl.thirdparty.javapoet.",
+    "com.palantir.javapoet." to "org.pkl.thirdparty.javapoet.",
 
     // pkl-codegen-kotlin dependencies
     "com.squareup.kotlinpoet." to "org.pkl.thirdparty.kotlinpoet.",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ graalVmSha256-linux-x64 = "b6f3dace24cf1960ec790216f4c86f00d4f43df64e4e8b548f638
 graalVmSha256-linux-aarch64 = "bd991d486b92deb74337b881e0f13a764c9c1e90fc358819080f7321fa5175e8"
 graalVmSha256-windows-x64 = "8b978e56dddc0edc60db99794b56975740d9c52293b31549cfc3f7516fc18b43"
 ideaExtPlugin = "1.1.9"
-javaPoet = "1.+"
+javaPoet = "0.+"
 javaxInject = "1"
 jansi = "2.+"
 jimfs = "1.+"
@@ -64,7 +64,7 @@ geantyref = { group = "io.leangen.geantyref", name = "geantyref", version.ref = 
 graalCompiler = { group = "org.graalvm.compiler", name = "compiler", version.ref = "graalVm" }
 graalSdk = { group = "org.graalvm.sdk", name = "graal-sdk", version.ref = "graalVm" }
 graalJs = { group = "org.graalvm.js", name = "js", version.ref = "graalVm" }
-javaPoet = { group = "com.squareup", name = "javapoet", version.ref = "javaPoet" }
+javaPoet = { group = "com.palantir.javapoet", name = "javapoet", version.ref = "javaPoet" }
 javaxInject = { group = "javax.inject", name = "javax.inject", version.ref = "javaxInject" }
 jansi = { group = "org.fusesource.jansi", name = "jansi", version.ref = "jansi" }
 jimfs = { group = "com.google.jimfs", name = "jimfs", version.ref = "jimfs" }

--- a/pkl-codegen-java/gradle.lockfile
+++ b/pkl-codegen-java/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 com.github.ajalt.clikt:clikt-jvm:3.5.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.ajalt.clikt:clikt:3.5.4=apiDependenciesMetadata,compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
-com.squareup:javapoet:1.13.0=compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
+com.palantir.javapoet:javapoet:0.5.0=compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 com.tunnelvisionlabs:antlr4-runtime:4.9.0=runtimeClasspath,testRuntimeClasspath
 io.leangen.geantyref:geantyref:1.3.16=testRuntimeClasspath
 net.bytebuddy:byte-buddy:1.14.18=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -15,7 +15,7 @@
  */
 package org.pkl.codegen.java
 
-import com.squareup.javapoet.*
+import com.palantir.javapoet.*
 import java.io.StringWriter
 import java.lang.Deprecated
 import java.net.URI
@@ -91,6 +91,7 @@ class JavaCodeGenerator(
 ) {
 
   companion object {
+    private val OBJECT = ClassName.get(Object::class.java)
     private val STRING = ClassName.get(String::class.java)
     private val DURATION = ClassName.get(Duration::class.java)
     private val DURATION_UNIT = ClassName.get(DurationUnit::class.java)
@@ -721,15 +722,15 @@ class JavaCodeGenerator(
 
   private fun PType.toJavaPoetName(nullable: Boolean = false, boxed: Boolean = false): TypeName =
     when (this) {
-      PType.UNKNOWN -> TypeName.OBJECT.nullableIf(nullable)
+      PType.UNKNOWN -> OBJECT.nullableIf(nullable)
       PType.NOTHING -> TypeName.VOID
       is PType.StringLiteral -> STRING.nullableIf(nullable)
       is PType.Class -> {
         // if in doubt, spell it out
         when (val classInfo = pClass.info) {
-          PClassInfo.Any -> TypeName.OBJECT
+          PClassInfo.Any -> OBJECT
           PClassInfo.Typed,
-          PClassInfo.Dynamic -> TypeName.OBJECT.nullableIf(nullable)
+          PClassInfo.Dynamic -> OBJECT.nullableIf(nullable)
           PClassInfo.Boolean -> TypeName.BOOLEAN.boxIf(boxed).nullableIf(nullable)
           PClassInfo.String -> STRING.nullableIf(nullable)
           // seems more useful to generate `double` than `java.lang.Number`
@@ -742,12 +743,12 @@ class JavaCodeGenerator(
             ParameterizedTypeName.get(
                 PAIR,
                 if (typeArguments.isEmpty()) {
-                  TypeName.OBJECT
+                  OBJECT
                 } else {
                   typeArguments[0].toJavaPoetTypeArgumentName()
                 },
                 if (typeArguments.isEmpty()) {
-                  TypeName.OBJECT
+                  OBJECT
                 } else {
                   typeArguments[1].toJavaPoetTypeArgumentName()
                 }
@@ -757,7 +758,7 @@ class JavaCodeGenerator(
             ParameterizedTypeName.get(
                 COLLECTION,
                 if (typeArguments.isEmpty()) {
-                  TypeName.OBJECT
+                  OBJECT
                 } else {
                   typeArguments[0].toJavaPoetTypeArgumentName()
                 }
@@ -768,7 +769,7 @@ class JavaCodeGenerator(
             ParameterizedTypeName.get(
                 LIST,
                 if (typeArguments.isEmpty()) {
-                  TypeName.OBJECT
+                  OBJECT
                 } else {
                   typeArguments[0].toJavaPoetTypeArgumentName()
                 }
@@ -779,7 +780,7 @@ class JavaCodeGenerator(
             ParameterizedTypeName.get(
                 SET,
                 if (typeArguments.isEmpty()) {
-                  TypeName.OBJECT
+                  OBJECT
                 } else {
                   typeArguments[0].toJavaPoetTypeArgumentName()
                 }
@@ -790,12 +791,12 @@ class JavaCodeGenerator(
             ParameterizedTypeName.get(
                 MAP,
                 if (typeArguments.isEmpty()) {
-                  TypeName.OBJECT
+                  OBJECT
                 } else {
                   typeArguments[0].toJavaPoetTypeArgumentName()
                 },
                 if (typeArguments.isEmpty()) {
-                  TypeName.OBJECT
+                  OBJECT
                 } else {
                   typeArguments[1].toJavaPoetTypeArgumentName()
                 }
@@ -820,7 +821,7 @@ class JavaCodeGenerator(
       is PType.Constrained -> baseType.toJavaPoetName(nullable = nullable, boxed = boxed)
       is PType.Alias ->
         when (typeAlias.qualifiedName) {
-          "pkl.base#NonNull" -> TypeName.OBJECT.nullableIf(nullable)
+          "pkl.base#NonNull" -> OBJECT.nullableIf(nullable)
           "pkl.base#Int8" -> TypeName.BYTE.boxIf(boxed).nullableIf(nullable)
           "pkl.base#Int16",
           "pkl.base#UInt8" -> TypeName.SHORT.boxIf(boxed).nullableIf(nullable)

--- a/pkl-config-java/gradle.lockfile
+++ b/pkl-config-java/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 com.github.ajalt.clikt:clikt-jvm:3.5.4=pklCodegenJava
 com.github.ajalt.clikt:clikt:3.5.4=pklCodegenJava
-com.squareup:javapoet:1.13.0=pklCodegenJava
+com.palantir.javapoet:javapoet:0.5.0=pklCodegenJava
 com.tunnelvisionlabs:antlr4-runtime:4.9.0=pklCodegenJava,runtimeClasspath,testRuntimeClasspath
 io.leangen.geantyref:geantyref:1.3.16=compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 javax.inject:javax.inject:1=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath

--- a/pkl-core/gradle.lockfile
+++ b/pkl-core/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2=compileClasspath,compileOnlyDependenciesMetadata
-com.squareup:javapoet:1.13.0=generatorCompileClasspath,generatorImplementationDependenciesMetadata,generatorRuntimeClasspath
+com.palantir.javapoet:javapoet:0.5.0=generatorCompileClasspath,generatorImplementationDependenciesMetadata,generatorRuntimeClasspath
 com.tunnelvisionlabs:antlr4-annotations:4.9.0=antlr
 com.tunnelvisionlabs:antlr4-runtime:4.9.0=antlr,compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 com.tunnelvisionlabs:antlr4:4.9.0=antlr

--- a/pkl-core/src/generator/kotlin/org/pkl/core/generator/MemberRegistryGenerator.kt
+++ b/pkl-core/src/generator/kotlin/org/pkl/core/generator/MemberRegistryGenerator.kt
@@ -16,10 +16,10 @@
 package org.pkl.core.generator
 
 import com.oracle.truffle.api.dsl.GeneratedBy
-import com.squareup.javapoet.ClassName
-import com.squareup.javapoet.JavaFile
-import com.squareup.javapoet.MethodSpec
-import com.squareup.javapoet.TypeSpec
+import com.palantir.javapoet.ClassName
+import com.palantir.javapoet.JavaFile
+import com.palantir.javapoet.MethodSpec
+import com.palantir.javapoet.TypeSpec
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion

--- a/pkl-tools/gradle.lockfile
+++ b/pkl-tools/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 com.github.ajalt.clikt:clikt-jvm:3.5.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.ajalt.clikt:clikt:3.5.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.squareup:javapoet:1.13.0=runtimeClasspath,testRuntimeClasspath
+com.palantir.javapoet:javapoet:0.5.0=runtimeClasspath,testRuntimeClasspath
 com.squareup:kotlinpoet:1.6.0=runtimeClasspath,testRuntimeClasspath
 com.tunnelvisionlabs:antlr4-runtime:4.9.0=runtimeClasspath,testRuntimeClasspath
 io.leangen.geantyref:geantyref:1.3.16=runtimeClasspath,testRuntimeClasspath


### PR DESCRIPTION
Motivation:
`com.squareup.javapoet` is EOL. `com.palantir.javapoet` is an actively maintained fork that supports generating record classes.