### PR TITLE
Update Gradle to 8.11

### DIFF
--- a/bench/bench.gradle.kts
+++ b/bench/bench.gradle.kts
@@ -16,7 +16,6 @@
 plugins {
   pklAllProjects
   pklJavaLibrary
-  pklGraalVm
   id("me.champeau.jmh")
 }
 

--- a/buildSrc/src/main/kotlin/BuildInfo.kt
+++ b/buildSrc/src/main/kotlin/BuildInfo.kt
@@ -50,6 +50,11 @@ open class BuildInfo(project: Project) {
       "https://download.oracle.com/graalvm/$jdkMajor/archive/$baseName.$extension"
     }
 
+    val downloadFile: File by lazy {
+      val extension = if (os.isWindows) "zip" else "tar.gz"
+      File(homeDir, "${baseName}.$extension")
+    }
+
     val installDir: File by lazy { File(homeDir, baseName) }
 
     val baseDir: String by lazy {

--- a/buildSrc/src/main/kotlin/InstallGraalVm.kt
+++ b/buildSrc/src/main/kotlin/InstallGraalVm.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.util.*
+import javax.inject.Inject
+import kotlin.io.path.createDirectories
+import org.gradle.api.DefaultTask
+import org.gradle.api.internal.file.FileOperations
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+
+abstract class InstallGraalVm
+@Inject
+constructor(
+  private val fileOperations: FileOperations,
+  private val execOperations: ExecOperations
+) : DefaultTask() {
+  @get:Input abstract val graalVm: Property<BuildInfo.GraalVm>
+
+  init {
+    @Suppress("LeakingThis") onlyIf("GraalVM not installed") { !graalVm.get().installDir.exists() }
+  }
+
+  @TaskAction
+  @Suppress("unused")
+  fun run() {
+    // minimize chance of corruption by extract-to-random-dir-and-flip-symlink
+    val distroDir = Paths.get(graalVm.get().homeDir, UUID.randomUUID().toString())
+    try {
+      distroDir.createDirectories()
+      println("Extracting ${graalVm.get().downloadFile} into $distroDir")
+      // faster and more reliable than Gradle's `copy { from tarTree() }`
+      execOperations.exec {
+        workingDir = distroDir.toFile()
+        executable = "tar"
+        args("--strip-components=1", "-xzf", graalVm.get().downloadFile)
+      }
+
+      val os = org.gradle.internal.os.OperatingSystem.current()
+      val distroBinDir =
+        if (os.isMacOsX) distroDir.resolve("Contents/Home/bin") else distroDir.resolve("bin")
+
+      println("Installing native-image into $distroDir")
+      execOperations.exec {
+        val executableName = if (os.isWindows) "gu.cmd" else "gu"
+        executable = distroBinDir.resolve(executableName).toString()
+        args("install", "--no-progress", "native-image")
+      }
+
+      println("Creating symlink ${graalVm.get().installDir} for $distroDir")
+      val tempLink = Paths.get(graalVm.get().homeDir, UUID.randomUUID().toString())
+      Files.createSymbolicLink(tempLink, distroDir)
+      try {
+        Files.move(tempLink, graalVm.get().installDir.toPath(), StandardCopyOption.ATOMIC_MOVE)
+      } catch (e: Exception) {
+        try {
+          fileOperations.delete(tempLink.toFile())
+        } catch (ignored: Exception) {}
+        throw e
+      }
+    } catch (e: Exception) {
+      try {
+        fileOperations.delete(distroDir)
+      } catch (ignored: Exception) {}
+      throw e
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/pklGraalVm.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklGraalVm.gradle.kts
@@ -15,19 +15,10 @@
  */
 import de.undercouch.gradle.tasks.download.Download
 import de.undercouch.gradle.tasks.download.Verify
-import java.nio.file.*
-import java.util.UUID
-import kotlin.io.path.createDirectories
 
 plugins { id("de.undercouch.download") }
 
 val buildInfo = project.extensions.getByType<BuildInfo>()
-
-val BuildInfo.GraalVm.downloadFile
-  get(): File {
-    val extension = if (buildInfo.os.isWindows) "zip" else "tar.gz"
-    return file(homeDir).resolve("${baseName}.$extension")
-  }
 
 // tries to minimize chance of corruption by download-to-temp-file-and-move
 val downloadGraalVmAarch64 by
@@ -68,63 +59,16 @@ fun Verify.configureVerifyGraalVm(graalvm: BuildInfo.GraalVm) {
   algorithm("SHA-256")
 }
 
-// minimize chance of corruption by extract-to-random-dir-and-flip-symlink
+@Suppress("unused")
 val installGraalVmAarch64 by
-  tasks.registering {
+  tasks.registering(InstallGraalVm::class) {
     dependsOn(verifyGraalVmAarch64)
-    configureInstallGraalVm(buildInfo.graalVmAarch64)
+    graalVm = buildInfo.graalVmAarch64
   }
 
-// minimize chance of corruption by extract-to-random-dir-and-flip-symlink
+@Suppress("unused")
 val installGraalVmAmd64 by
-  tasks.registering {
+  tasks.registering(InstallGraalVm::class) {
     dependsOn(verifyGraalVmAmd64)
-    configureInstallGraalVm(buildInfo.graalVmAmd64)
+    graalVm = buildInfo.graalVmAmd64
   }
-
-fun Task.configureInstallGraalVm(graalVm: BuildInfo.GraalVm) {
-  onlyIf { !graalVm.installDir.exists() }
-
-  doLast {
-    val distroDir = Paths.get(graalVm.homeDir, UUID.randomUUID().toString())
-
-    try {
-      distroDir.createDirectories()
-      println("Extracting ${graalVm.downloadFile} into $distroDir")
-      // faster and more reliable than Gradle's `copy { from tarTree() }`
-      exec {
-        workingDir = file(distroDir)
-        executable = "tar"
-        args("--strip-components=1", "-xzf", graalVm.downloadFile)
-      }
-
-      val distroBinDir =
-        if (buildInfo.os.isMacOsX) distroDir.resolve("Contents/Home/bin")
-        else distroDir.resolve("bin")
-
-      println("Installing native-image into $distroDir")
-      exec {
-        val executableName = if (buildInfo.os.isWindows) "gu.cmd" else "gu"
-        executable = distroBinDir.resolve(executableName).toString()
-        args("install", "--no-progress", "native-image")
-      }
-
-      println("Creating symlink ${graalVm.installDir} for $distroDir")
-      val tempLink = Paths.get(graalVm.homeDir, UUID.randomUUID().toString())
-      Files.createSymbolicLink(tempLink, distroDir)
-      try {
-        Files.move(tempLink, graalVm.installDir.toPath(), StandardCopyOption.ATOMIC_MOVE)
-      } catch (e: Exception) {
-        try {
-          delete(tempLink.toFile())
-        } catch (ignored: Exception) {}
-        throw e
-      }
-    } catch (e: Exception) {
-      try {
-        delete(distroDir)
-      } catch (ignored: Exception) {}
-      throw e
-    }
-  }
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionSha256Sum=57dafb5c2622c6cc08b993c85b7c06956a2f53536432a30ead46166dbca0f1e9
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Changes:
- Update wrapper by running the following command: ./gradlew wrapper --gradle-version 8.11 --gradle-distribution-sha256-sum 57dafb5c2622c6cc08b993c85b7c06956a2f53536432a30ead46166dbca0f1e9
- Verify wrapper JAR integrity according to: https://docs.gradle.org/current/userguide/gradle_wrapper.html# manually_verifying_the_gradle_wrapper_jar
- Replace usages of deprecated method `Project.exec` with `ExecOperations.exec`
- Convert extension function `Task.configureInstallGraalVm` to task class `InstallGraalVm`
  - a task class is the cleanest way to get hold of `ExecOperations`
- Move extension property `BuildInfo.GraalVm.downloadFile` into class `GraalVm`
- Don't apply plugin `pklGraalVm` in project `bench` (unnecessary, now causes error)