### PR TITLE
Rename JavaCodegenOptions to JavaCodeGeneratorOptions

### DIFF
--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGenerator.kt
@@ -33,7 +33,7 @@ class CliJavaCodeGenerator(private val options: CliJavaCodeGeneratorOptions) :
       builder.build().use { evaluator ->
         for (moduleUri in options.base.normalizedSourceModules) {
           val schema = evaluator.evaluateSchema(ModuleSource.uri(moduleUri))
-          val codeGenerator = JavaCodeGenerator(schema, options.toJavaCodegenOptions())
+          val codeGenerator = JavaCodeGenerator(schema, options.toJavaCodeGeneratorOptions())
           try {
             for ((fileName, fileContents) in codeGenerator.output) {
               val outputFile = options.outputDir.resolve(fileName)

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
@@ -66,7 +66,7 @@ data class CliJavaCodeGeneratorOptions(
   val renames: Map<String, String> = emptyMap()
 ) {
   fun toJavaCodegenOptions() =
-    JavaCodegenOptions(
+    JavaCodeGeneratorOptions(
       indent,
       generateGetters,
       generateJavadoc,

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
@@ -65,7 +65,11 @@ data class CliJavaCodeGeneratorOptions(
    */
   val renames: Map<String, String> = emptyMap()
 ) {
-  fun toJavaCodegenOptions() =
+  @Suppress("DeprecatedCallableAddReplaceWith")
+  @Deprecated("deprecated without replacement")
+  fun toJavaCodegenOptions() = toJavaCodeGeneratorOptions()
+
+  internal fun toJavaCodeGeneratorOptions() =
     JavaCodeGeneratorOptions(
       indent,
       generateGetters,

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -41,7 +41,10 @@ import org.pkl.core.util.IoUtils
 
 class JavaCodeGeneratorException(message: String) : RuntimeException(message)
 
-data class JavaCodegenOptions(
+@kotlin.Deprecated("renamed to JavaCodeGeneratorOptions", ReplaceWith("JavaCodeGeneratorOptions"))
+typealias JavaCodegenOptions = JavaCodeGeneratorOptions
+
+data class JavaCodeGeneratorOptions(
   /** The characters to use for indenting generated Java code. */
   val indent: String = "  ",
 
@@ -84,7 +87,7 @@ data class JavaCodegenOptions(
 /** Entrypoint for the Java code generator API. */
 class JavaCodeGenerator(
   private val schema: ModuleSchema,
-  private val codegenOptions: JavaCodegenOptions
+  private val codegenOptions: JavaCodeGeneratorOptions
 ) {
 
   companion object {

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
@@ -115,7 +115,7 @@ class JavaCodeGeneratorTest {
       val generator =
         JavaCodeGenerator(
           module,
-          JavaCodegenOptions(
+          JavaCodeGeneratorOptions(
             generateGetters = generateGetters,
             generateJavadoc = generateJavadoc,
             generateSpringBootConfig = generateSpringBootConfig,
@@ -1987,7 +1987,7 @@ class JavaCodeGeneratorTest {
   @Test
   fun `override names in a standalone module`() {
     val files =
-      JavaCodegenOptions(
+      JavaCodeGeneratorOptions(
           renames = mapOf("a.b.c." to "x.y.z.", "d.e.f.AnotherModule" to "u.v.w.RenamedModule")
         )
         .generateFiles(
@@ -2023,7 +2023,7 @@ class JavaCodeGeneratorTest {
   @Test
   fun `override names based on the longest prefix`() {
     val files =
-      JavaCodegenOptions(
+      JavaCodeGeneratorOptions(
           renames = mapOf("com.foo.bar." to "x.", "com.foo." to "y.", "com." to "z.", "" to "w.")
         )
         .generateFiles(
@@ -2068,7 +2068,7 @@ class JavaCodeGeneratorTest {
   @Test
   fun `override names in multiple modules using each other`() {
     val files =
-      JavaCodegenOptions(
+      JavaCodeGeneratorOptions(
           renames =
             mapOf(
               "org.foo." to "com.foo.x.",
@@ -2150,7 +2150,7 @@ class JavaCodeGeneratorTest {
   @Test
   fun `do not capitalize names of renamed classes`() {
     val files =
-      JavaCodegenOptions(
+      JavaCodeGeneratorOptions(
           renames = mapOf("a.b.c.MyModule" to "x.y.z.renamed_module", "d.e.f." to "u.v.w.")
         )
         .generateFiles(
@@ -2238,7 +2238,9 @@ class JavaCodeGeneratorTest {
     assertThat(files).isEmpty()
   }
 
-  private fun JavaCodegenOptions.generateFiles(vararg pklModules: PklModule): Map<String, String> {
+  private fun JavaCodeGeneratorOptions.generateFiles(
+    vararg pklModules: PklModule
+  ): Map<String, String> {
     val pklFiles = pklModules.map { it.writeToDisk(tempDir.resolve("pkl/${it.name}.pkl")) }
     val evaluator = Evaluator.preconfigured()
     return pklFiles.fold(mapOf()) { acc, pklFile ->
@@ -2248,13 +2250,13 @@ class JavaCodeGeneratorTest {
     }
   }
 
-  private fun JavaCodegenOptions.generateFiles(
+  private fun JavaCodeGeneratorOptions.generateFiles(
     vararg pklModules: kotlin.Pair<String, String>
   ): Map<String, String> =
     generateFiles(*pklModules.map { (name, text) -> PklModule(name, text) }.toTypedArray())
 
   private fun generateFiles(vararg pklModules: PklModule): Map<String, JavaSourceCode> =
-    JavaCodegenOptions().generateFiles(*pklModules).mapValues { JavaSourceCode(it.value) }
+    JavaCodeGeneratorOptions().generateFiles(*pklModules).mapValues { JavaSourceCode(it.value) }
 
   private fun instantiateOtherAndPropertyTypes(): kotlin.Pair<Any, Any> {
     val otherCtor = propertyTypesClasses.getValue("my.Mod\$Other").constructors.first()


### PR DESCRIPTION
The new name is consistent with existing names `JavaCodeGenerator` and `CliJavaCodeGeneratorOptions`.
Backward compatibility is ensured by turning `JavaCodegenOptions` into a (deprecated) type alias.

Second commit: Deprecate `CliJavaCodeGeneratorOptions.toJavaCodegenOptions()`
I suspect this method was a public API by accident.