### PR TITLE
codegen-java/kotlin: Fix generation of hashCode methods

### DIFF
--- a/pkl-codegen-java/src/test/resources/org/pkl/codegen/java/PropertyTypes.jva
+++ b/pkl-codegen-java/src/test/resources/org/pkl/codegen/java/PropertyTypes.jva
@@ -306,7 +306,7 @@ public final class Mod {
       result = 31 * result + Objects.hashCode(this.container);
       result = 31 * result + Objects.hashCode(this.container2);
       result = 31 * result + Objects.hashCode(this.other);
-      result = 31 * result + Objects.hashCode(this.regex);
+      result = 31 * result + Objects.hashCode(this.regex.pattern());
       result = 31 * result + Objects.hashCode(this.any);
       result = 31 * result + Objects.hashCode(this.nonNull);
       result = 31 * result + Objects.hashCode(this._enum);

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/KotlinCodeGenerator.kt
@@ -267,8 +267,6 @@ class KotlinCodeGenerator(
     fun PClass.Property.isRegex(): Boolean =
       (this.type as? PType.Class)?.pClass?.info == PClassInfo.Regex
 
-    val containRegexProperty = properties.values.any { it.isRegex() }
-
     fun generateConstructor(): FunSpec {
       val builder = FunSpec.constructorBuilder()
       for ((name, property) in allProperties) {
@@ -370,11 +368,12 @@ class KotlinCodeGenerator(
           .returns(INT)
           .addStatement("var result = 1")
 
-      for (propertyName in allProperties.keys) {
+      for ((propertyName, property) in allProperties) {
+        val accessor = if (property.isRegex()) "this.%N.pattern" else "this.%N"
         // use Objects.hashCode() because Kotlin's Any?.hashCode()
         // doesn't work for platform types (will get NPE if null)
         builder.addStatement(
-          "result = 31 * result + %T.hashCode(this.%N)",
+          "result = 31 * result + %T.hashCode($accessor)",
           Objects::class,
           propertyName
         )
@@ -544,15 +543,17 @@ class KotlinCodeGenerator(
         builder.addKdoc(renderAsKdoc(docComment))
       }
 
+      var hasRegex = false
       for ((name, property) in properties) {
+        hasRegex = hasRegex || property.isRegex()
         builder.addProperty(generateProperty(name, property))
       }
 
-      // Regex requires special approach when compared to another Regex
-      // So we need to override `.equals` method even for kotlin's `data class`es if
-      // any of the properties is of Regex type
-      if (containRegexProperty) {
-        builder.addFunction(generateEqualsMethod())
+      // kotlin.text.Regex (and java.util.regex.Pattern) defines equality as identity.
+      // To match Pkl semantics and compare regexes by their String pattern,
+      // override equals and hashCode if the data class has a property of type Regex.
+      if (hasRegex) {
+        builder.addFunction(generateEqualsMethod()).addFunction(generateHashCodeMethod())
       }
 
       return builder

--- a/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
+++ b/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
@@ -575,6 +575,26 @@ class KotlinCodeGeneratorTest {
   }
 
   @Test
+  fun `data class with Regex property has custom equals and hashCode methods`() {
+    val kotlinCode =
+      generateKotlinCode(
+        """
+      module my.mod
+
+      class Person {
+        age: Int
+        name: Regex
+      }
+    """
+          .trimIndent()
+      )
+
+    assertThat(kotlinCode)
+      .contains("if (this.name.pattern != other.name.pattern) return false")
+      .contains("result = 31 * result + Objects.hashCode(this.name.pattern)")
+  }
+
+  @Test
   fun `recursive types`() {
     val kotlinCode =
       generateKotlinCode(

--- a/pkl-codegen-kotlin/src/test/resources/org/pkl/codegen/kotlin/PropertyTypes.kotlin
+++ b/pkl-codegen-kotlin/src/test/resources/org/pkl/codegen/kotlin/PropertyTypes.kotlin
@@ -153,7 +153,7 @@ object Mod {
       result = 31 * result + Objects.hashCode(this.container)
       result = 31 * result + Objects.hashCode(this.container2)
       result = 31 * result + Objects.hashCode(this.other)
-      result = 31 * result + Objects.hashCode(this.regex)
+      result = 31 * result + Objects.hashCode(this.regex.pattern)
       result = 31 * result + Objects.hashCode(this.any)
       result = 31 * result + Objects.hashCode(this.nonNull)
       result = 31 * result + Objects.hashCode(this.enum)


### PR DESCRIPTION
codegen-java:
- use `pattern.pattern()` instead of `pattern` in hashCode method
  (consistent with equals method)

codegen-kotlin:
- use `regex.pattern` instead of `regex` in hashCode method
  (consistent with equals method)
- if a data class has a Regex property, generate not only
  an equals method but also a hashCode method