### PR TITLE
codegen-kotlin: Deprecate method `toKotlinCodegenOptions` without replacement

### DIFF
--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGenerator.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGenerator.kt
@@ -34,7 +34,7 @@ class CliKotlinCodeGenerator(private val options: CliKotlinCodeGeneratorOptions)
       builder.build().use { evaluator ->
         for (moduleUri in options.base.normalizedSourceModules) {
           val schema = evaluator.evaluateSchema(ModuleSource.uri(moduleUri))
-          val codeGenerator = KotlinCodeGenerator(schema, options.toKotlinCodegenOptions())
+          val codeGenerator = KotlinCodeGenerator(schema, options.toKotlinCodeGeneratorOptions())
           try {
             for ((fileName, fileContents) in codeGenerator.output) {
               val outputFile = options.outputDir.resolve(fileName)

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorOptions.kt
@@ -47,7 +47,11 @@ data class CliKotlinCodeGeneratorOptions(
    */
   val renames: Map<String, String> = emptyMap()
 ) {
-  fun toKotlinCodegenOptions(): KotlinCodeGeneratorOptions =
+  @Suppress("DeprecatedCallableAddReplaceWith")
+  @Deprecated("deprecated without replacement")
+  fun toKotlinCodegenOptions(): KotlinCodeGeneratorOptions = toKotlinCodeGeneratorOptions()
+
+  internal fun toKotlinCodeGeneratorOptions(): KotlinCodeGeneratorOptions =
     KotlinCodeGeneratorOptions(
       indent,
       generateKdoc,


### PR DESCRIPTION
Motivation:
`CliKotlinCodeGeneratorOptions.toKotlinCodegenOptions` is an internal method that isn't useful to clients.