### PR TITLE
Fix: check computed members against listing/mapping owner

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmUtils.java
@@ -315,6 +315,9 @@ public final class VmUtils {
       ret = callNode.call(callTarget, receiver, owner, memberKey, VmUtils.SKIP_TYPECHECK_MARKER);
     }
     if (receiver instanceof VmListingOrMapping<?> vmListingOrMapping) {
+      if (owner != receiver && owner instanceof VmListingOrMapping<?> vmListingOrMappingOwner) {
+        ret = vmListingOrMappingOwner.typecastObjectMember(member, ret, callNode);
+      }
       ret = vmListingOrMapping.typecastObjectMember(member, ret, callNode);
     }
     receiver.setCachedValue(memberKey, ret, member);

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/listingTypeCheckError8.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/listingTypeCheckError8.pkl
@@ -1,0 +1,6 @@
+local a = new Listing { new Listing { 0 } }
+local b = a as Listing<Listing<String>>
+local c = (b) { new Listing { 1 } }
+local d = c as Listing<Listing<Int>>
+
+result = d

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError8.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError8.err
@@ -1,0 +1,15 @@
+–– Pkl Error ––
+Expected value of type `String`, but got type `Int`.
+Value: 0
+
+x | local b = a as Listing<Listing<String>>
+                                   ^^^^^^
+at listingTypeCheckError8#b (file:///$snippetsDir/input/errors/listingTypeCheckError8.pkl)
+
+x | local a = new Listing { new Listing { 0 } }
+                                          ^
+at listingTypeCheckError8#a[#1][#1] (file:///$snippetsDir/input/errors/listingTypeCheckError8.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)


### PR DESCRIPTION
This addresses a regression where a value can possibly not be type-casted correctly.

Closes https://github.com/apple/pkl/issues/785