### PR TITLE
Delay instantiation of `cachedValues` to save memory

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmDynamic.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmDynamic.java
@@ -75,8 +75,7 @@ public final class VmDynamic extends VmObject {
   @Override
   @TruffleBoundary
   public PObject export() {
-    var properties =
-        CollectionUtils.<String, Object>newLinkedHashMap(EconomicMaps.size(cachedValues));
+    var properties = CollectionUtils.<String, Object>newLinkedHashMap(getCacheSize());
 
     iterateMemberValues(
         (key, member, value) -> {
@@ -107,7 +106,9 @@ public final class VmDynamic extends VmObject {
     force(false);
     other.force(false);
     if (getRegularMemberCount() != other.getRegularMemberCount()) return false;
+    if (getCacheSize() == 0) return true;
 
+    assert cachedValues != null;
     var cursor = cachedValues.getEntries();
     while (cursor.advance()) {
       Object key = cursor.getKey();
@@ -129,6 +130,10 @@ public final class VmDynamic extends VmObject {
 
     force(false);
     var result = 0;
+    if (getCacheSize() == 0) {
+      return 0;
+    }
+    assert cachedValues != null;
     var cursor = cachedValues.getEntries();
 
     while (cursor.advance()) {
@@ -149,8 +154,11 @@ public final class VmDynamic extends VmObject {
     if (cachedRegularMemberCount != -1) return cachedRegularMemberCount;
 
     var result = 0;
-    for (var key : cachedValues.getKeys()) {
-      if (!isHiddenOrLocalProperty(key)) result += 1;
+    if (getCacheSize() != 0) {
+      assert cachedValues != null;
+      for (var key : cachedValues.getKeys()) {
+        if (!isHiddenOrLocalProperty(key)) result += 1;
+      }
     }
     cachedRegularMemberCount = result;
     return result;

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmFunction.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmFunction.java
@@ -107,6 +107,11 @@ public final class VmFunction extends VmObjectLike {
   }
 
   @Override
+  public int getCacheSize() {
+    return 0;
+  }
+
+  @Override
   public @Nullable Object getCachedValue(Object key) {
     return null;
   }

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmListing.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmListing.java
@@ -94,7 +94,7 @@ public final class VmListing extends VmListingOrMapping<VmListing> {
   @Override
   @TruffleBoundary
   public List<Object> export() {
-    var properties = new ArrayList<>(EconomicMaps.size(cachedValues));
+    var properties = new ArrayList<>(getCacheSize());
 
     iterateMemberValues(
         (key, prop, value) -> {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmListingOrMapping.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmListingOrMapping.java
@@ -103,6 +103,9 @@ public abstract class VmListingOrMapping<SELF extends VmListingOrMapping<SELF>> 
     var objectMember = findMember(key);
     var ret = typecastObjectMember(objectMember, memberValue, IndirectCallNode.getUncached());
     if (ret != memberValue) {
+      if (cachedValues == null) {
+        cachedValues = EconomicMaps.create();
+      }
       EconomicMaps.put(cachedValues, key, ret);
     } else {
       // optimization: don't add to own cached values if typecast results in the same value

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmMapping.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmMapping.java
@@ -104,7 +104,7 @@ public final class VmMapping extends VmListingOrMapping<VmMapping> {
   @Override
   @TruffleBoundary
   public Map<Object, Object> export() {
-    var properties = CollectionUtils.newLinkedHashMap(EconomicMaps.size(cachedValues));
+    var properties = CollectionUtils.newLinkedHashMap(getCacheSize());
 
     iterateMemberValues(
         (key, prop, value) -> {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmObjectLike.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmObjectLike.java
@@ -83,6 +83,12 @@ public abstract class VmObjectLike extends VmValue {
   public abstract UnmodifiableEconomicMap<Object, ObjectMember> getMembers();
 
   /**
+   * @return The (current) size of the properties cache for this object.
+   */
+  @TruffleBoundary
+  public abstract @Nullable int getCacheSize();
+
+  /**
    * Reads from the properties cache for this object. The cache contains the values of all members
    * defined in this object or an ancestor thereof which have been requested with this object as the
    * receiver.


### PR DESCRIPTION
I'm putting this up as a discussion piece, more than anything. Wins are minimal, at best.

The thinking was that every `VmObject` gets its `cachedValues` initialised by default, but only the ones that are forced get those values filled. However, `cachedValues.entries` is `null` by default. There appears to be a bigger possible win to address the fact that a lot of `EconomicMap`s have `entries` be an oversized array (`Object[8]` by default).