### PR TITLE
Fix exception handling of PklRootNode's

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/MemberNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/MemberNode.java
@@ -16,7 +16,6 @@
 package org.pkl.core.ast;
 
 import com.oracle.truffle.api.frame.FrameDescriptor;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 import java.util.function.Function;
 import org.pkl.core.ast.member.DefaultPropertyBodyNode;
@@ -46,10 +45,6 @@ public abstract class MemberNode extends PklRootNode {
 
   public final void replaceBody(Function<ExpressionNode, ExpressionNode> replacer) {
     bodyNode = insert(replacer.apply(bodyNode));
-  }
-
-  protected final Object executeBody(VirtualFrame frame) {
-    return executeBody(frame, bodyNode);
   }
 
   protected final VmExceptionBuilder exceptionBuilder() {

--- a/pkl-core/src/main/java/org/pkl/core/ast/SimpleRootNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/SimpleRootNode.java
@@ -49,7 +49,7 @@ public final class SimpleRootNode extends PklRootNode {
   }
 
   @Override
-  public Object execute(VirtualFrame frame) {
-    return executeBody(frame, bodyNode);
+  protected Object executeImpl(VirtualFrame frame) {
+    return bodyNode.executeGeneric(frame);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/ListingOrMappingTypeCastNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/ListingOrMappingTypeCastNode.java
@@ -15,13 +15,11 @@
  */
 package org.pkl.core.ast.member;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 import org.pkl.core.ast.PklRootNode;
 import org.pkl.core.ast.type.TypeNode;
-import org.pkl.core.ast.type.VmTypeMismatchException;
 import org.pkl.core.runtime.VmLanguage;
 import org.pkl.core.util.Nullable;
 
@@ -53,12 +51,7 @@ public class ListingOrMappingTypeCastNode extends PklRootNode {
   }
 
   @Override
-  public Object execute(VirtualFrame frame) {
-    try {
-      return typeNode.execute(frame, frame.getArguments()[2]);
-    } catch (VmTypeMismatchException e) {
-      CompilerDirectives.transferToInterpreter();
-      throw e.toVmException();
-    }
+  protected Object executeImpl(VirtualFrame frame) {
+    return typeNode.execute(frame, frame.getArguments()[2]);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/ModuleNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/ModuleNode.java
@@ -52,8 +52,8 @@ public final class ModuleNode extends PklRootNode {
   }
 
   @Override
-  public Object execute(VirtualFrame frame) {
-    var module = executeBody(frame, moduleNode);
+  protected Object executeImpl(VirtualFrame frame) {
+    var module = moduleNode.executeGeneric(frame);
     if (module instanceof VmClass vmClass) {
       return vmClass.getPrototype();
     }

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/ObjectMethodNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/ObjectMethodNode.java
@@ -59,7 +59,7 @@ public final class ObjectMethodNode extends RegularMemberNode {
   }
 
   @Override
-  public CallTarget execute(VirtualFrame frame) {
+  protected CallTarget executeImpl(VirtualFrame frame) {
     if (functionNode == null) {
       CompilerDirectives.transferToInterpreter();
 

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/SharedMemberNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/SharedMemberNode.java
@@ -58,7 +58,7 @@ public class SharedMemberNode extends MemberNode {
   }
 
   @Override
-  public Object execute(VirtualFrame frame) {
-    return executeBody(frame);
+  protected Object executeImpl(VirtualFrame frame) {
+    return bodyNode.executeGeneric(frame);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/TypeCheckedPropertyNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/TypeCheckedPropertyNode.java
@@ -51,7 +51,7 @@ public abstract class TypeCheckedPropertyNode extends RegularMemberNode {
       @Cached("getProperty(cachedOwnerClass)") ClassProperty property,
       @Cached("createTypeCheckCallNode(property)") @Nullable DirectCallNode callNode) {
 
-    var result = executeBody(frame);
+    var result = bodyNode.executeGeneric(frame);
 
     // TODO: propagate SUPER_CALL_MARKER to disable constraint (but not type) check
     if (callNode != null && VmUtils.shouldRunTypeCheck(frame)) {
@@ -66,7 +66,7 @@ public abstract class TypeCheckedPropertyNode extends RegularMemberNode {
   protected Object eval(
       VirtualFrame frame, VmObjectLike owner, @Cached("create()") IndirectCallNode callNode) {
 
-    var result = executeBody(frame);
+    var result = bodyNode.executeGeneric(frame);
 
     if (VmUtils.shouldRunTypeCheck(frame)) {
       var property = getProperty(owner.getVmClass());
@@ -86,7 +86,7 @@ public abstract class TypeCheckedPropertyNode extends RegularMemberNode {
 
   @Specialization
   protected Object eval(VirtualFrame frame, @SuppressWarnings("unused") VmDynamic owner) {
-    return executeBody(frame);
+    return bodyNode.executeGeneric(frame);
   }
 
   protected ClassProperty getProperty(VmClass ownerClass) {

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/TypedPropertyNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/TypedPropertyNode.java
@@ -43,8 +43,8 @@ public final class TypedPropertyNode extends RegularMemberNode {
   }
 
   @Override
-  public Object execute(VirtualFrame frame) {
-    var propertyValue = executeBody(frame);
+  protected Object executeImpl(VirtualFrame frame) {
+    var propertyValue = bodyNode.executeGeneric(frame);
     if (VmUtils.shouldRunTypeCheck(frame)) {
       return typeCheckCallNode.call(
           VmUtils.getReceiver(frame),

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/UntypedObjectMemberNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/UntypedObjectMemberNode.java
@@ -32,7 +32,7 @@ public final class UntypedObjectMemberNode extends RegularMemberNode {
   }
 
   @Override
-  public Object execute(VirtualFrame frame) {
-    return executeBody(frame);
+  protected Object executeImpl(VirtualFrame frame) {
+    return bodyNode.executeGeneric(frame);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/repl/ResolveClassMemberNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/repl/ResolveClassMemberNode.java
@@ -49,7 +49,7 @@ public final class ResolveClassMemberNode extends PklRootNode {
   }
 
   @Override
-  public Object execute(VirtualFrame frame) {
+  protected Object executeImpl(VirtualFrame frame) {
     return unresolvedNode.execute(frame, clazz);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/IdentityMixinNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/IdentityMixinNode.java
@@ -20,7 +20,6 @@ import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 import org.pkl.core.ast.PklRootNode;
-import org.pkl.core.runtime.VmException;
 import org.pkl.core.runtime.VmLanguage;
 import org.pkl.core.util.Nullable;
 
@@ -53,7 +52,7 @@ public final class IdentityMixinNode extends PklRootNode {
   }
 
   @Override
-  public Object execute(VirtualFrame frame) {
+  protected Object executeImpl(VirtualFrame frame) {
     var arguments = frame.getArguments();
     if (arguments.length != 4) {
       CompilerDirectives.transferToInterpreter();
@@ -62,23 +61,10 @@ public final class IdentityMixinNode extends PklRootNode {
           .withSourceSection(sourceSection)
           .build();
     }
-
-    try {
-      var argument = arguments[3];
-      if (argumentTypeNode != null) {
-        return argumentTypeNode.execute(frame, argument);
-      }
-      return argument;
-    } catch (VmTypeMismatchException e) {
-      CompilerDirectives.transferToInterpreter();
-      throw e.toVmException();
-    } catch (Exception e) {
-      CompilerDirectives.transferToInterpreter();
-      if (e instanceof VmException) {
-        throw e;
-      } else {
-        throw exceptionBuilder().bug(e.getMessage()).withCause(e).build();
-      }
+    var argument = arguments[3];
+    if (argumentTypeNode != null) {
+      return argumentTypeNode.execute(frame, argument);
     }
+    return argument;
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/benchmark/MicrobenchmarkNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/benchmark/MicrobenchmarkNodes.java
@@ -17,7 +17,6 @@ package org.pkl.core.stdlib.benchmark;
 
 import static org.pkl.core.stdlib.benchmark.BenchmarkUtils.runBenchmark;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameDescriptor;
@@ -29,7 +28,6 @@ import org.pkl.core.ast.PklRootNode;
 import org.pkl.core.ast.internal.BlackholeNode;
 import org.pkl.core.ast.internal.BlackholeNodeGen;
 import org.pkl.core.runtime.Identifier;
-import org.pkl.core.runtime.VmException;
 import org.pkl.core.runtime.VmLanguage;
 import org.pkl.core.runtime.VmTyped;
 import org.pkl.core.runtime.VmUtils;
@@ -83,23 +81,14 @@ public final class MicrobenchmarkNodes {
     }
 
     @Override
-    public @Nullable Object execute(VirtualFrame frame) {
-      try {
-        var repetitions = (long) frame.getArguments()[2];
-        for (long i = 0; i < repetitions; i++) {
-          blackholeNode.executeGeneric(frame);
-        }
-        LoopNode.reportLoopCount(
-            this, repetitions > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) repetitions);
-        return null;
-      } catch (Exception e) {
-        CompilerDirectives.transferToInterpreter();
-        if (e instanceof VmException) {
-          throw e;
-        } else {
-          throw exceptionBuilder().bug(e.getMessage()).withCause(e).build();
-        }
+    protected @Nullable Object executeImpl(VirtualFrame frame) {
+      var repetitions = (long) frame.getArguments()[2];
+      for (long i = 0; i < repetitions; i++) {
+        blackholeNode.executeGeneric(frame);
       }
+      LoopNode.reportLoopCount(
+          this, repetitions > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) repetitions);
+      return null;
     }
   }
 }


### PR DESCRIPTION
Motivation:
- Perform same exception handling for every implementation of PklRootNode.execute().
- Avoid code duplication.

Changes:
- Change PklRootNode.execute() to be a final method that performs exception handling and calls abstract method executeImpl(), which is implemented by subclasses.
- Remove executeBody() methods, which served a similar purpose but were more limited.
- Remove duplicate exception handling code.

Result:
- More reliable exception handling. This should fix known problems such as misclassifying stack overflows as internal errors and displaying errors without a stack trace.
- Less code duplication.