### PR TITLE
Download JDK for windows build

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -21,9 +21,7 @@ import "jobs/GradleCheckJob.pkl"
 import "jobs/DeployJob.pkl"
 import "jobs/SimpleGradleJob.pkl"
 
-local prbJobs: Listing<String> = (gradleCheckJobs.keys.toListing()) {
-  "pkl-cli-windows-amd64-snapshot"
-}
+local prbJobs: Listing<String> = new { "pkl-cli-windows-amd64-snapshot"; "gradle-check-jdk17-windows" }
 
 local buildAndTestJobs = (prbJobs) {
   "bench"
@@ -110,10 +108,12 @@ local gradleCheckJobs: Mapping<String, GradleCheckJob> = new {
   ["gradle-check-jdk17"] {
     javaVersion = "17.0"
     isRelease = false
+    os = "linux"
   }
   ["gradle-check-jdk21"] {
     javaVersion = "21.0"
     isRelease = false
+    os = "linux"
   }
   ["gradle-check-jdk17-windows"] {
     javaVersion = "17.0"

--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -21,7 +21,7 @@ import "jobs/GradleCheckJob.pkl"
 import "jobs/DeployJob.pkl"
 import "jobs/SimpleGradleJob.pkl"
 
-local prbJobs: Listing<String> = new { "pkl-cli-windows-amd64-snapshot"; "gradle-check-jdk17-windows" }
+local prbJobs: Listing<String> = gradleCheckJobs.keys.toListing()
 
 local buildAndTestJobs = (prbJobs) {
   "bench"

--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -21,7 +21,9 @@ import "jobs/GradleCheckJob.pkl"
 import "jobs/DeployJob.pkl"
 import "jobs/SimpleGradleJob.pkl"
 
-local prbJobs: Listing<String> = gradleCheckJobs.keys.toListing()
+local prbJobs: Listing<String> = (gradleCheckJobs.keys.toListing()) {
+  "pkl-cli-windows-amd64-snapshot"
+}
 
 local buildAndTestJobs = (prbJobs) {
   "bench"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -742,7 +742,10 @@ workflows:
         type: approval
     - pr-approval/authenticate:
         context: pkl-pr-approval
-    - pkl-cli-windows-amd64-snapshot:
+    - gradle-check-jdk17:
+        requires:
+        - hold
+    - gradle-check-jdk21:
         requires:
         - hold
     - gradle-check-jdk17-windows:
@@ -754,7 +757,8 @@ workflows:
         pattern: ^pull/\d+(/head)?$
   main:
     jobs:
-    - pkl-cli-windows-amd64-snapshot
+    - gradle-check-jdk17
+    - gradle-check-jdk21
     - gradle-check-jdk17-windows
     - bench
     - gradle-compatibility
@@ -766,7 +770,8 @@ workflows:
     - pkl-cli-windows-amd64-snapshot
     - deploy-snapshot:
         requires:
-        - pkl-cli-windows-amd64-snapshot
+        - gradle-check-jdk17
+        - gradle-check-jdk21
         - gradle-check-jdk17-windows
         - bench
         - gradle-compatibility
@@ -788,7 +793,13 @@ workflows:
       - << pipeline.git.branch >>
   release:
     jobs:
-    - pkl-cli-windows-amd64-snapshot:
+    - gradle-check-jdk17:
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v?\d+\.\d+\.\d+$/
+    - gradle-check-jdk21:
         filters:
           branches:
             ignore: /.*/
@@ -850,7 +861,8 @@ workflows:
             only: /^v?\d+\.\d+\.\d+$/
     - github-release:
         requires:
-        - pkl-cli-windows-amd64-snapshot
+        - gradle-check-jdk17
+        - gradle-check-jdk21
         - gradle-check-jdk17-windows
         - bench
         - gradle-compatibility
@@ -887,7 +899,8 @@ workflows:
             only: /^v?\d+\.\d+\.\d+$/
   release-branch:
     jobs:
-    - pkl-cli-windows-amd64-snapshot
+    - gradle-check-jdk17
+    - gradle-check-jdk21
     - gradle-check-jdk17-windows
     - bench
     - gradle-compatibility

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -136,7 +136,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -197,7 +197,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -329,7 +329,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -425,7 +425,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -486,7 +486,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
             && rm -rf /var/cache/dnf
 
           # install jdk
-          curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+          curl -Lf \
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -52,7 +52,7 @@ jobs:
 
           # install zlib
           if [[ ! -f ~/staticdeps/include/zlib.h ]]; then
-            curl -L https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
+            curl -Lf https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
 
             mkdir -p /tmp/dep_zlib-1.2.13 \
             && cd /tmp/dep_zlib-1.2.13 \
@@ -65,7 +65,7 @@ jobs:
 
           # install musl
           if [[ ! -f ~/staticdeps/bin/x86_64-linux-musl-gcc ]]; then
-            curl -L https://musl.libc.org/releases/musl-1.2.2.tar.gz -o /tmp/musl.tar.gz
+            curl -Lf https://musl.libc.org/releases/musl-1.2.2.tar.gz -o /tmp/musl.tar.gz
 
             mkdir -p /tmp/dep_musl-1.2.2 \
             && cd /tmp/dep_musl-1.2.2 \
@@ -135,8 +135,8 @@ jobs:
             && rm -rf /var/cache/dnf
 
           # install jdk
-          curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+          curl -Lf \
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -148,7 +148,7 @@ jobs:
 
           # install zlib
           if [[ ! -f ~/staticdeps/include/zlib.h ]]; then
-            curl -L https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
+            curl -Lf https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
 
             mkdir -p /tmp/dep_zlib-1.2.13 \
             && cd /tmp/dep_zlib-1.2.13 \
@@ -196,8 +196,8 @@ jobs:
             && rm -rf /var/cache/dnf
 
           # install jdk
-          curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+          curl -Lf \
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -209,7 +209,7 @@ jobs:
 
           # install zlib
           if [[ ! -f ~/staticdeps/include/zlib.h ]]; then
-            curl -L https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
+            curl -Lf https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
 
             mkdir -p /tmp/dep_zlib-1.2.13 \
             && cd /tmp/dep_zlib-1.2.13 \
@@ -222,7 +222,7 @@ jobs:
 
           # install musl
           if [[ ! -f ~/staticdeps/bin/x86_64-linux-musl-gcc ]]; then
-            curl -L https://musl.libc.org/releases/musl-1.2.2.tar.gz -o /tmp/musl.tar.gz
+            curl -Lf https://musl.libc.org/releases/musl-1.2.2.tar.gz -o /tmp/musl.tar.gz
 
             mkdir -p /tmp/dep_musl-1.2.2 \
             && cd /tmp/dep_musl-1.2.2 \
@@ -265,8 +265,8 @@ jobs:
     - run:
         command: |-
           # install jdk
-          curl -L \
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
+          curl -Lf \
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
 
           unzip /tmp/jdk.zip -d /tmp/jdk \
             && cd /tmp/jdk/jdk-* \
@@ -328,8 +328,8 @@ jobs:
             && rm -rf /var/cache/dnf
 
           # install jdk
-          curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+          curl -Lf \
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -341,7 +341,7 @@ jobs:
 
           # install zlib
           if [[ ! -f ~/staticdeps/include/zlib.h ]]; then
-            curl -L https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
+            curl -Lf https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
 
             mkdir -p /tmp/dep_zlib-1.2.13 \
             && cd /tmp/dep_zlib-1.2.13 \
@@ -354,7 +354,7 @@ jobs:
 
           # install musl
           if [[ ! -f ~/staticdeps/bin/x86_64-linux-musl-gcc ]]; then
-            curl -L https://musl.libc.org/releases/musl-1.2.2.tar.gz -o /tmp/musl.tar.gz
+            curl -Lf https://musl.libc.org/releases/musl-1.2.2.tar.gz -o /tmp/musl.tar.gz
 
             mkdir -p /tmp/dep_musl-1.2.2 \
             && cd /tmp/dep_musl-1.2.2 \
@@ -424,8 +424,8 @@ jobs:
             && rm -rf /var/cache/dnf
 
           # install jdk
-          curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+          curl -Lf \
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -437,7 +437,7 @@ jobs:
 
           # install zlib
           if [[ ! -f ~/staticdeps/include/zlib.h ]]; then
-            curl -L https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
+            curl -Lf https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
 
             mkdir -p /tmp/dep_zlib-1.2.13 \
             && cd /tmp/dep_zlib-1.2.13 \
@@ -485,8 +485,8 @@ jobs:
             && rm -rf /var/cache/dnf
 
           # install jdk
-          curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+          curl -Lf \
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -498,7 +498,7 @@ jobs:
 
           # install zlib
           if [[ ! -f ~/staticdeps/include/zlib.h ]]; then
-            curl -L https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
+            curl -Lf https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz -o /tmp/zlib.tar.gz
 
             mkdir -p /tmp/dep_zlib-1.2.13 \
             && cd /tmp/dep_zlib-1.2.13 \
@@ -511,7 +511,7 @@ jobs:
 
           # install musl
           if [[ ! -f ~/staticdeps/bin/x86_64-linux-musl-gcc ]]; then
-            curl -L https://musl.libc.org/releases/musl-1.2.2.tar.gz -o /tmp/musl.tar.gz
+            curl -Lf https://musl.libc.org/releases/musl-1.2.2.tar.gz -o /tmp/musl.tar.gz
 
             mkdir -p /tmp/dep_musl-1.2.2 \
             && cd /tmp/dep_musl-1.2.2 \
@@ -554,8 +554,8 @@ jobs:
     - run:
         command: |-
           # install jdk
-          curl -L \
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
+          curl -Lf \
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
 
           unzip /tmp/jdk.zip -d /tmp/jdk \
             && cd /tmp/jdk/jdk-* \
@@ -611,8 +611,8 @@ jobs:
     - run:
         command: |-
           # install jdk
-          curl -L \
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
+          curl -Lf \
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
 
           unzip /tmp/jdk.zip -d /tmp/jdk \
             && cd /tmp/jdk/jdk-* \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,17 @@ jobs:
     - checkout
     - run:
         command: |-
+          # install jdk
+          curl -L \
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
+
+          mkdir /jdk \
+          && cd /jdk \
+          && unzip /tmp/jdk.tar.gz -d /jdk
+        name: Set up environment
+        shell: bash.exe
+    - run:
+        command: |-
           export PATH=~/staticdeps/bin:$PATH
           ./gradlew --info --stacktrace -DtestReportsDir=${HOME}/test-results -DreleaseBuild=true pkl-cli:windowsExecutableAmd64 pkl-core:testWindowsExecutableAmd64 pkl-server:testWindowsExecutableAmd64
         name: gradle buildNative
@@ -276,6 +287,7 @@ jobs:
         path: ~/test-results
     environment:
       LANG: en_US.UTF-8
+      JAVA_HOME: /jdk
     resource_class: windows.large
     machine:
       image: windows-server-2022-gui:current
@@ -540,6 +552,17 @@ jobs:
     - checkout
     - run:
         command: |-
+          # install jdk
+          curl -L \
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
+
+          mkdir /jdk \
+          && cd /jdk \
+          && unzip /tmp/jdk.tar.gz -d /jdk
+        name: Set up environment
+        shell: bash.exe
+    - run:
+        command: |-
           export PATH=~/staticdeps/bin:$PATH
           ./gradlew --info --stacktrace -DtestReportsDir=${HOME}/test-results pkl-cli:windowsExecutableAmd64 pkl-core:testWindowsExecutableAmd64 pkl-server:testWindowsExecutableAmd64
         name: gradle buildNative
@@ -552,6 +575,7 @@ jobs:
         path: ~/test-results
     environment:
       LANG: en_US.UTF-8
+      JAVA_HOME: /jdk
     resource_class: windows.large
     machine:
       image: windows-server-2022-gui:current
@@ -712,6 +736,9 @@ workflows:
     - gradle-check-jdk17-windows:
         requires:
         - hold
+    - pkl-cli-windows-amd64-snapshot:
+        requires:
+        - hold
     when:
       matches:
         value: << pipeline.git.branch >>
@@ -721,6 +748,7 @@ workflows:
     - gradle-check-jdk17
     - gradle-check-jdk21
     - gradle-check-jdk17-windows
+    - pkl-cli-windows-amd64-snapshot
     - bench
     - gradle-compatibility
     - pkl-cli-macOS-amd64-snapshot
@@ -734,6 +762,7 @@ workflows:
         - gradle-check-jdk17
         - gradle-check-jdk21
         - gradle-check-jdk17-windows
+        - pkl-cli-windows-amd64-snapshot
         - bench
         - gradle-compatibility
         - pkl-cli-macOS-amd64-snapshot
@@ -767,6 +796,12 @@ workflows:
           tags:
             only: /^v?\d+\.\d+\.\d+$/
     - gradle-check-jdk17-windows:
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v?\d+\.\d+\.\d+$/
+    - pkl-cli-windows-amd64-snapshot:
         filters:
           branches:
             ignore: /.*/
@@ -825,6 +860,7 @@ workflows:
         - gradle-check-jdk17
         - gradle-check-jdk21
         - gradle-check-jdk17-windows
+        - pkl-cli-windows-amd64-snapshot
         - bench
         - gradle-compatibility
         - pkl-cli-macOS-amd64-release
@@ -863,6 +899,7 @@ workflows:
     - gradle-check-jdk17
     - gradle-check-jdk21
     - gradle-check-jdk17-windows
+    - pkl-cli-windows-amd64-snapshot
     - bench
     - gradle-compatibility
     - pkl-cli-macOS-amd64-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -136,7 +136,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -197,7 +197,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -266,11 +266,11 @@ jobs:
         command: |-
           # install jdk
           curl -L \
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.1.zip -o /tmp/jdk.zip
 
           mkdir /jdk \
           && cd /jdk \
-          && unzip /tmp/jdk.tar.gz -d /jdk
+          && unzip /tmp/jdk.zip -d /jdk
         name: Set up environment
         shell: bash.exe
     - run:
@@ -328,7 +328,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -424,7 +424,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -485,7 +485,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -554,11 +554,11 @@ jobs:
         command: |-
           # install jdk
           curl -L \
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.1.zip -o /tmp/jdk.zip
 
           mkdir /jdk \
           && cd /jdk \
-          && unzip /tmp/jdk.tar.gz -d /jdk
+          && unzip /tmp/jdk.zip -d /jdk
         name: Set up environment
         shell: bash.exe
     - run:
@@ -607,12 +607,24 @@ jobs:
     steps:
     - checkout
     - run:
+        command: |-
+          # install jdk
+          curl -L \
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.1.zip -o /tmp/jdk.zip
+
+          mkdir /jdk \
+          && cd /jdk \
+          && unzip /tmp/jdk.zip -d /jdk
+        name: Set up environment
+        shell: bash.exe
+    - run:
         command: ./gradlew --info --stacktrace -DtestReportsDir=${HOME}/test-results check
         name: gradle check
     - store_test_results:
         path: ~/test-results
     environment:
       LANG: en_US.UTF-8
+      JAVA_HOME: /jdk
     resource_class: windows.large
     machine:
       image: windows-server-2022-gui:current
@@ -727,16 +739,10 @@ workflows:
         type: approval
     - pr-approval/authenticate:
         context: pkl-pr-approval
-    - gradle-check-jdk17:
-        requires:
-        - hold
-    - gradle-check-jdk21:
+    - pkl-cli-windows-amd64-snapshot:
         requires:
         - hold
     - gradle-check-jdk17-windows:
-        requires:
-        - hold
-    - pkl-cli-windows-amd64-snapshot:
         requires:
         - hold
     when:
@@ -745,10 +751,8 @@ workflows:
         pattern: ^pull/\d+(/head)?$
   main:
     jobs:
-    - gradle-check-jdk17
-    - gradle-check-jdk21
-    - gradle-check-jdk17-windows
     - pkl-cli-windows-amd64-snapshot
+    - gradle-check-jdk17-windows
     - bench
     - gradle-compatibility
     - pkl-cli-macOS-amd64-snapshot
@@ -759,10 +763,8 @@ workflows:
     - pkl-cli-windows-amd64-snapshot
     - deploy-snapshot:
         requires:
-        - gradle-check-jdk17
-        - gradle-check-jdk21
-        - gradle-check-jdk17-windows
         - pkl-cli-windows-amd64-snapshot
+        - gradle-check-jdk17-windows
         - bench
         - gradle-compatibility
         - pkl-cli-macOS-amd64-snapshot
@@ -783,25 +785,13 @@ workflows:
       - << pipeline.git.branch >>
   release:
     jobs:
-    - gradle-check-jdk17:
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /^v?\d+\.\d+\.\d+$/
-    - gradle-check-jdk21:
+    - pkl-cli-windows-amd64-snapshot:
         filters:
           branches:
             ignore: /.*/
           tags:
             only: /^v?\d+\.\d+\.\d+$/
     - gradle-check-jdk17-windows:
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /^v?\d+\.\d+\.\d+$/
-    - pkl-cli-windows-amd64-snapshot:
         filters:
           branches:
             ignore: /.*/
@@ -857,10 +847,8 @@ workflows:
             only: /^v?\d+\.\d+\.\d+$/
     - github-release:
         requires:
-        - gradle-check-jdk17
-        - gradle-check-jdk21
-        - gradle-check-jdk17-windows
         - pkl-cli-windows-amd64-snapshot
+        - gradle-check-jdk17-windows
         - bench
         - gradle-compatibility
         - pkl-cli-macOS-amd64-release
@@ -896,10 +884,8 @@ workflows:
             only: /^v?\d+\.\d+\.\d+$/
   release-branch:
     jobs:
-    - gradle-check-jdk17
-    - gradle-check-jdk21
-    - gradle-check-jdk17-windows
     - pkl-cli-windows-amd64-snapshot
+    - gradle-check-jdk17-windows
     - bench
     - gradle-compatibility
     - pkl-cli-macOS-amd64-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -136,7 +136,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -197,7 +197,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -329,7 +329,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -425,7 +425,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -486,7 +486,7 @@ jobs:
 
           # install jdk
           curl -Lf \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -136,7 +136,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -197,7 +197,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -266,11 +266,12 @@ jobs:
         command: |-
           # install jdk
           curl -L \
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.1.zip -o /tmp/jdk.zip
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
 
-          mkdir /jdk \
-          && cd /jdk \
-          && unzip /tmp/jdk.zip -d /jdk
+          unzip /tmp/jdk.zip -d /tmp/jdk \
+            && cd /tmp/jdk/jdk-* \
+            && mkdir /jdk \
+            && cp -r . /jdk
         name: Set up environment
         shell: bash.exe
     - run:
@@ -328,7 +329,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -424,7 +425,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -485,7 +486,7 @@ jobs:
 
           # install jdk
           curl -L \
-           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.1.tar.gz -o /tmp/jdk.tar.gz
+           https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -o /tmp/jdk.tar.gz
 
           mkdir /jdk \
             && cd /jdk \
@@ -554,11 +555,12 @@ jobs:
         command: |-
           # install jdk
           curl -L \
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.1.zip -o /tmp/jdk.zip
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
 
-          mkdir /jdk \
-          && cd /jdk \
-          && unzip /tmp/jdk.zip -d /jdk
+          unzip /tmp/jdk.zip -d /tmp/jdk \
+            && cd /tmp/jdk/jdk-* \
+            && mkdir /jdk \
+            && cp -r . /jdk
         name: Set up environment
         shell: bash.exe
     - run:
@@ -610,11 +612,12 @@ jobs:
         command: |-
           # install jdk
           curl -L \
-          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9.1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.1.zip -o /tmp/jdk.zip
+          https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_windows_hotspot_17.0.9_9.zip -o /tmp/jdk.zip
 
-          mkdir /jdk \
-          && cd /jdk \
-          && unzip /tmp/jdk.zip -d /jdk
+          unzip /tmp/jdk.zip -d /tmp/jdk \
+            && cd /tmp/jdk/jdk-* \
+            && mkdir /jdk \
+            && cp -r . /jdk
         name: Set up environment
         shell: bash.exe
     - run:

--- a/.circleci/jobs/BuildNativeJob.pkl
+++ b/.circleci/jobs/BuildNativeJob.pkl
@@ -40,8 +40,8 @@ local setupLinuxEnvironment: Config.RunStep =
           && rm -rf /var/cache/dnf
 
         # install jdk
-        curl -L \
-         https://github.com/adoptium/temurin\#(module.majorJdkVersion)-binaries/releases/download/jdk-\#(module.jdkVersionEncoded)/OpenJDK\#(module.majorJdkVersion)U-jdk_\#(if (arch == "amd64") "x64" else "aarch64")_linux_hotspot_\#(module.jdkVersionAlt).tar.gz -o /tmp/jdk.tar.gz
+        curl -Lf \
+         https://github.com/adoptium/temurin\#(module.majorJdkVersion)-binaries/releases/download/jdk-\#(module.jdkGitHubReleaseName)/OpenJDK\#(module.majorJdkVersion)U-jdk_\#(if (arch == "amd64") "x64" else "aarch64")_linux_hotspot_\#(module.jdkVersionAlt).tar.gz -o /tmp/jdk.tar.gz
 
         mkdir /jdk \
           && cd /jdk \
@@ -53,7 +53,7 @@ local setupLinuxEnvironment: Config.RunStep =
 
         # install zlib
         if [[ ! -f ~/staticdeps/include/zlib.h ]]; then
-          curl -L https://github.com/madler/zlib/releases/download/v\#(zlibVersion)/zlib-\#(zlibVersion).tar.gz -o /tmp/zlib.tar.gz
+          curl -Lf https://github.com/madler/zlib/releases/download/v\#(zlibVersion)/zlib-\#(zlibVersion).tar.gz -o /tmp/zlib.tar.gz
 
           mkdir -p /tmp/dep_zlib-\#(zlibVersion) \
           && cd /tmp/dep_zlib-\#(zlibVersion) \
@@ -69,7 +69,7 @@ local setupLinuxEnvironment: Config.RunStep =
             #"""
             # install musl
             if [[ ! -f ~/staticdeps/bin/x86_64-linux-musl-gcc ]]; then
-              curl -L https://musl.libc.org/releases/musl-\#(muslVersion).tar.gz -o /tmp/musl.tar.gz
+              curl -Lf https://musl.libc.org/releases/musl-\#(muslVersion).tar.gz -o /tmp/musl.tar.gz
 
               mkdir -p /tmp/dep_musl-\#(muslVersion) \
               && cd /tmp/dep_musl-\#(muslVersion) \

--- a/.circleci/jobs/BuildNativeJob.pkl
+++ b/.circleci/jobs/BuildNativeJob.pkl
@@ -17,7 +17,6 @@
 extends "GradleJob.pkl"
 
 import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.2#/Config.pkl"
-import "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.0#/URI.pkl"
 
 /// The architecture to use
 arch: "amd64"|"aarch64"
@@ -25,12 +24,7 @@ arch: "amd64"|"aarch64"
 /// Whether to link to musl. Otherwise, links to glibc.
 musl: Boolean = false
 
-/// The JDK version to build against
-local jdkVersion: String = "17.0.9+9"
-
-local jdkVersionEncoded = URI.encodeComponent(jdkVersion)
-local jdkVersionAlt = jdkVersion.replaceLast("+", "_")
-local majorJdkVersion = jdkVersion.split(".").first
+javaVersion = "17.0"
 
 local setupLinuxEnvironment: Config.RunStep =
   let (muslVersion = "1.2.2")
@@ -47,7 +41,7 @@ local setupLinuxEnvironment: Config.RunStep =
 
         # install jdk
         curl -L \
-         https://github.com/adoptium/temurin\#(majorJdkVersion)-binaries/releases/download/jdk-\#(jdkVersionEncoded)/OpenJDK\#(majorJdkVersion)U-jdk_\#(if (arch == "amd64") "x64" else "aarch64")_linux_hotspot_\#(jdkVersionAlt).tar.gz -o /tmp/jdk.tar.gz
+         https://github.com/adoptium/temurin\#(module.majorJdkVersion)-binaries/releases/download/jdk-\#(module.jdkVersionEncoded)/OpenJDK\#(module.majorJdkVersion)U-jdk_\#(if (arch == "amd64") "x64" else "aarch64")_linux_hotspot_\#(module.jdkVersionAlt).tar.gz -o /tmp/jdk.tar.gz
 
         mkdir /jdk \
           && cd /jdk \
@@ -93,24 +87,6 @@ local setupLinuxEnvironment: Config.RunStep =
       }.join("\n\n")
     }
 
-local setupWindowsEnvironment: Config.RunStep =
-  let (jdkVersionEncoded = URI.encodeComponent(jdkVersion))
-  let (jdkVersionAlt = jdkVersion.replaceLast("+", "_"))
-  let (majorJdkVersion = jdkVersion.split(".").first)
-    new {
-      name = "Set up environment"
-      shell = "bash.exe"
-      command = #"""
-        # install jdk
-        curl -L \
-        https://github.com/adoptium/temurin\#(majorJdkVersion)-binaries/releases/download/jdk-\#(jdkVersionEncoded)/OpenJDK\#(majorJdkVersion)U-jdk_\#(if (arch == "amd64") "x64" else "aarch64")_windows_hotspot_\#(jdkVersionAlt).zip -o /tmp/jdk.zip
-
-        mkdir /jdk \
-        && cd /jdk \
-        && unzip /tmp/jdk.tar.gz -d /jdk
-        """#
-    }
-
 steps {
   when (os == "linux") {
     new Config.RestoreCacheStep {
@@ -133,9 +109,6 @@ steps {
         /usr/sbin/softwareupdate --install-rosetta --agree-to-license
         """
     }
-  }
-  when (os == "windows") {
-    setupWindowsEnvironment
   }
   new Config.RunStep {
     name = "gradle buildNative"
@@ -169,7 +142,7 @@ job {
     resource_class = "macos.m1.large.gen1"
   }
   when (os == "linux") {
-    docker {
+    docker = new Listing<Config.DockerImage> {
       new {
         image = if (arch == "aarch64") "arm64v8/oraclelinux:8-slim" else "oraclelinux:8-slim"
       }

--- a/.circleci/jobs/BuildNativeJob.pkl
+++ b/.circleci/jobs/BuildNativeJob.pkl
@@ -41,7 +41,7 @@ local setupLinuxEnvironment: Config.RunStep =
 
         # install jdk
         curl -Lf \
-         https://github.com/adoptium/temurin\#(module.majorJdkVersion)-binaries/releases/download/jdk-\#(module.jdkGitHubReleaseName)/OpenJDK\#(module.majorJdkVersion)U-jdk_\#(if (arch == "amd64") "x64" else "aarch64")_linux_hotspot_\#(module.jdkVersionAlt).tar.gz -o /tmp/jdk.tar.gz
+         https://github.com/adoptium/temurin\#(module.majorJdkVersion)-binaries/releases/download/\#(module.jdkGitHubReleaseName)/OpenJDK\#(module.majorJdkVersion)U-jdk_\#(if (arch == "amd64") "x64" else "aarch64")_linux_hotspot_\#(module.jdkVersionAlt).tar.gz -o /tmp/jdk.tar.gz
 
         mkdir /jdk \
           && cd /jdk \

--- a/.circleci/jobs/BuildNativeJob.pkl
+++ b/.circleci/jobs/BuildNativeJob.pkl
@@ -25,13 +25,16 @@ arch: "amd64"|"aarch64"
 /// Whether to link to musl. Otherwise, links to glibc.
 musl: Boolean = false
 
+/// The JDK version to build against
+local jdkVersion: String = "17.0.9+9"
+
+local jdkVersionEncoded = URI.encodeComponent(jdkVersion)
+local jdkVersionAlt = jdkVersion.replaceLast("+", "_")
+local majorJdkVersion = jdkVersion.split(".").first
+
 local setupLinuxEnvironment: Config.RunStep =
-  let (jdkVersion = "17.0.9+9")
   let (muslVersion = "1.2.2")
   let (zlibVersion = "1.2.13")
-  let (jdkVersionEncoded = URI.encodeComponent(jdkVersion))
-  let (jdkVersionAlt = jdkVersion.replaceLast("+", "_"))
-  let (majorJdkVersion = jdkVersion.split(".").first)
     new {
       name = "Set up environment"
       shell = "#!/bin/bash -exo pipefail"
@@ -90,6 +93,24 @@ local setupLinuxEnvironment: Config.RunStep =
       }.join("\n\n")
     }
 
+local setupWindowsEnvironment: Config.RunStep =
+  let (jdkVersionEncoded = URI.encodeComponent(jdkVersion))
+  let (jdkVersionAlt = jdkVersion.replaceLast("+", "_"))
+  let (majorJdkVersion = jdkVersion.split(".").first)
+    new {
+      name = "Set up environment"
+      shell = "bash.exe"
+      command = #"""
+        # install jdk
+        curl -L \
+        https://github.com/adoptium/temurin\#(majorJdkVersion)-binaries/releases/download/jdk-\#(jdkVersionEncoded)/OpenJDK\#(majorJdkVersion)U-jdk_\#(if (arch == "amd64") "x64" else "aarch64")_windows_hotspot_\#(jdkVersionAlt).zip -o /tmp/jdk.zip
+
+        mkdir /jdk \
+        && cd /jdk \
+        && unzip /tmp/jdk.tar.gz -d /jdk
+        """#
+    }
+
 steps {
   when (os == "linux") {
     new Config.RestoreCacheStep {
@@ -112,6 +133,9 @@ steps {
         /usr/sbin/softwareupdate --install-rosetta --agree-to-license
         """
     }
+  }
+  when (os == "windows") {
+    setupWindowsEnvironment
   }
   new Config.RunStep {
     name = "gradle buildNative"
@@ -160,5 +184,8 @@ job {
       image = "windows-server-2022-gui:current"
     }
     resource_class = "windows.large"
+    environment {
+      ["JAVA_HOME"] = "/jdk"
+    }
   }
 }

--- a/.circleci/jobs/DeployJob.pkl
+++ b/.circleci/jobs/DeployJob.pkl
@@ -19,13 +19,9 @@ import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.2#/Config.pkl"
 
 local self = this
 
-command: String
+javaVersion = "17.0"
 
-job {
-  docker {
-    new { image = "cimg/openjdk:17.0" }
-  }
-}
+command: String
 
 os = "linux"
 

--- a/.circleci/jobs/GradleCheckJob.pkl
+++ b/.circleci/jobs/GradleCheckJob.pkl
@@ -17,29 +17,9 @@ extends "GradleJob.pkl"
 
 import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.2#/Config.pkl"
 
-javaVersion: "17.0"|"21.0"
-
-os = "linux"
-
 steps {
   new Config.RunStep {
     name = "gradle check"
     command = "./gradlew \(module.gradleArgs) check"
-  }
-}
-
-job {
-  when (os == "linux") {
-    docker {
-      new {
-        image = "cimg/openjdk:\(javaVersion)"
-      }
-    }
-  }
-  when (os == "windows") {
-    machine {
-      image = "windows-server-2022-gui:current"
-    }
-    resource_class = "windows.large"
   }
 }

--- a/.circleci/jobs/GradleJob.pkl
+++ b/.circleci/jobs/GradleJob.pkl
@@ -35,7 +35,13 @@ fixed jdkVersionAlt = javaVersionFull.replaceLast("+", "_")
 
 fixed majorJdkVersion = javaVersionFull.split(".").first
 
-fixed jdkVersionEncoded = URI.encodeComponent(javaVersionFull)
+fixed jdkGitHubReleaseName =
+  let (ver =
+    // 17.0.9+9 is missing some binaries (see https://github.com/adoptium/adoptium-support/issues/994)
+    if (javaVersionFull == "17.0.9+9") "jdk-17.0.9+9.1"
+    else "jdk-\(javaVersionFull)"
+  )
+    URI.encodeComponent(ver)
 
 fixed gradleArgs = new Listing {
   "--info"
@@ -76,8 +82,8 @@ job: Config.Job = new {
         shell = "bash.exe"
         command = #"""
           # install jdk
-          curl -L \
-          https://github.com/adoptium/temurin\#(majorJdkVersion)-binaries/releases/download/jdk-\#(jdkVersionEncoded)/OpenJDK\#(majorJdkVersion)U-jdk_x64_windows_hotspot_\#(jdkVersionAlt).zip -o /tmp/jdk.zip
+          curl -Lf \
+          https://github.com/adoptium/temurin\#(majorJdkVersion)-binaries/releases/download/\#(jdkGitHubReleaseName)/OpenJDK\#(majorJdkVersion)U-jdk_x64_windows_hotspot_\#(jdkVersionAlt).zip -o /tmp/jdk.zip
 
           unzip /tmp/jdk.zip -d /tmp/jdk \
             && cd /tmp/jdk/jdk-* \

--- a/.circleci/jobs/GradleJob.pkl
+++ b/.circleci/jobs/GradleJob.pkl
@@ -38,7 +38,7 @@ fixed majorJdkVersion = javaVersionFull.split(".").first
 fixed jdkGitHubReleaseName =
   let (ver =
     // 17.0.9+9 is missing some binaries (see https://github.com/adoptium/adoptium-support/issues/994)
-    if (javaVersionFull == "17.0.9+9") "jdk-17.0.9+9.1"
+    if (javaVersionFull == "17.0.9+9" && os == "windows") "jdk-17.0.9+9.1"
     else "jdk-\(javaVersionFull)"
   )
     URI.encodeComponent(ver)

--- a/.circleci/jobs/GradleJob.pkl
+++ b/.circleci/jobs/GradleJob.pkl
@@ -28,7 +28,7 @@ os: "macOS"|"linux"|"windows"
 javaVersion: "17.0"|"21.0"
 
 fixed javaVersionFull =
-  if (javaVersion == "17.0") "17.0.9+9.1"
+  if (javaVersion == "17.0") "17.0.9+9"
   else "21.0.5+11"
 
 fixed jdkVersionAlt = javaVersionFull.replaceLast("+", "_")
@@ -79,9 +79,10 @@ job: Config.Job = new {
           curl -L \
           https://github.com/adoptium/temurin\#(majorJdkVersion)-binaries/releases/download/jdk-\#(jdkVersionEncoded)/OpenJDK\#(majorJdkVersion)U-jdk_x64_windows_hotspot_\#(jdkVersionAlt).zip -o /tmp/jdk.zip
 
-          mkdir /jdk \
-          && cd /jdk \
-          && unzip /tmp/jdk.zip -d /jdk
+          unzip /tmp/jdk.zip -d /tmp/jdk \
+            && cd /tmp/jdk/jdk-* \
+            && mkdir /jdk \
+            && cp -r . /jdk
           """#
       }
     }

--- a/.circleci/jobs/GradleJob.pkl
+++ b/.circleci/jobs/GradleJob.pkl
@@ -16,12 +16,26 @@
 abstract module GradleJob
 
 import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.2#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.3#/URI.pkl"
 
 /// Whether this is a release build or not.
 isRelease: Boolean = false
 
 /// The OS to run on
 os: "macOS"|"linux"|"windows"
+
+/// The version of Java to use.
+javaVersion: "17.0"|"21.0"
+
+fixed javaVersionFull =
+  if (javaVersion == "17.0") "17.0.9+9.1"
+  else "21.0.5+11"
+
+fixed jdkVersionAlt = javaVersionFull.replaceLast("+", "_")
+
+fixed majorJdkVersion = javaVersionFull.split(".").first
+
+fixed jdkVersionEncoded = URI.encodeComponent(javaVersionFull)
 
 fixed gradleArgs = new Listing {
   "--info"
@@ -37,9 +51,40 @@ steps: Listing<Config.Step>
 job: Config.Job = new {
   environment {
     ["LANG"] = "en_US.UTF-8"
+    when (os == "windows") {
+      ["JAVA_HOME"] = "/jdk"
+    }
+  }
+  when (os == "linux") {
+    docker {
+      new {
+        image = "cimg/openjdk:\(javaVersion)"
+      }
+    }
+  }
+  when (os == "windows") {
+    machine {
+      image = "windows-server-2022-gui:current"
+    }
+    resource_class = "windows.large"
   }
   steps {
     "checkout"
+    when (os == "windows") {
+      new Config.RunStep {
+        name = "Set up environment"
+        shell = "bash.exe"
+        command = #"""
+          # install jdk
+          curl -L \
+          https://github.com/adoptium/temurin\#(majorJdkVersion)-binaries/releases/download/jdk-\#(jdkVersionEncoded)/OpenJDK\#(majorJdkVersion)U-jdk_x64_windows_hotspot_\#(jdkVersionAlt).zip -o /tmp/jdk.zip
+
+          mkdir /jdk \
+          && cd /jdk \
+          && unzip /tmp/jdk.zip -d /jdk
+          """#
+      }
+    }
     ...module.steps
     new Config.StoreTestResults {
       path = "~/test-results"

--- a/.circleci/jobs/SimpleGradleJob.pkl
+++ b/.circleci/jobs/SimpleGradleJob.pkl
@@ -23,17 +23,13 @@ command: String
 
 os = "linux"
 
+javaVersion = "17.0"
+
 steps {
   new Config.RunStep {
     name = module.name
     command = """
       ./gradlew \(module.gradleArgs) \(module.command)
       """
-  }
-}
-
-job {
-  docker {
-    new { image = "cimg/openjdk:17.0" }
   }
 }


### PR DESCRIPTION
Don't use the system Java on Windows builds, instead download them from Adoptium.

Also:

* Fail job if curl returns a 4xx status code
* Add java version to `GradleJob`