### PR TITLE
Make Test Report locale independent 

### DIFF
--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
@@ -35,6 +35,7 @@ import org.pkl.commons.readString
 import org.pkl.commons.toUri
 import org.pkl.commons.writeString
 import org.pkl.core.Release
+import java.util.Locale
 
 class CliTestRunnerTest {
   @Test
@@ -512,8 +513,8 @@ class CliTestRunnerTest {
     runner.run()
 
     assertThat(out.toString().stripFileAndLines(tempDir))
-        .isEqualTo(
-            """
+      .isEqualTo(
+        """
             module test
               facts
                 ✔ localeTest
@@ -521,12 +522,12 @@ class CliTestRunnerTest {
             100.0% tests pass [1 passed], 100.0% asserts pass [1 passed]
 
             """
-                .trimIndent()
-        )
+          .trimIndent()
+      )
     assertThat(err.toString()).isEqualTo("")
 
     Locale.setDefault(originalLocale)
-}
+  }
 
   private fun String.stripFileAndLines(tmpDir: Path): String {
     // handle platform differences in handling of file URIs

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
@@ -21,6 +21,7 @@ import java.io.StringWriter
 import java.io.Writer
 import java.net.URI
 import java.nio.file.Path
+import java.util.Locale
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
@@ -35,7 +36,6 @@ import org.pkl.commons.readString
 import org.pkl.commons.toUri
 import org.pkl.commons.writeString
 import org.pkl.core.Release
-import java.util.Locale
 
 class CliTestRunnerTest {
   @Test
@@ -494,7 +494,7 @@ class CliTestRunnerTest {
     Locale.setDefault(Locale.GERMANY)
 
     val code =
-        """
+      """
         amends "pkl:test"
 
         facts {
@@ -503,7 +503,7 @@ class CliTestRunnerTest {
             }
         }
         """
-            .trimIndent()
+        .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     val out = StringWriter()
     val err = StringWriter()

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
@@ -493,8 +493,9 @@ class CliTestRunnerTest {
     val originalLocale = Locale.getDefault()
     Locale.setDefault(Locale.GERMANY)
 
-    val code =
-      """
+    try {
+      val code =
+        """
         amends "pkl:test"
 
         facts {
@@ -503,18 +504,19 @@ class CliTestRunnerTest {
             }
         }
         """
-        .trimIndent()
-    val input = tempDir.resolve("test.pkl").writeString(code).toString()
-    val out = StringWriter()
-    val err = StringWriter()
-    val opts = CliBaseOptions(sourceModules = listOf(input.toUri()), settings = URI("pkl:settings"))
-    val testOpts = CliTestOptions()
-    val runner = CliTestRunner(opts, testOpts, consoleWriter = out, errWriter = err)
-    runner.run()
+          .trimIndent()
+      val input = tempDir.resolve("test.pkl").writeString(code).toString()
+      val out = StringWriter()
+      val err = StringWriter()
+      val opts =
+        CliBaseOptions(sourceModules = listOf(input.toUri()), settings = URI("pkl:settings"))
+      val testOpts = CliTestOptions()
+      val runner = CliTestRunner(opts, testOpts, consoleWriter = out, errWriter = err)
+      runner.run()
 
-    assertThat(out.toString().stripFileAndLines(tempDir))
-      .isEqualTo(
-        """
+      assertThat(out.toString().stripFileAndLines(tempDir))
+        .isEqualTo(
+          """
             module test
               facts
                 ✔ localeTest
@@ -522,11 +524,12 @@ class CliTestRunnerTest {
             100.0% tests pass [1 passed], 100.0% asserts pass [1 passed]
 
             """
-          .trimIndent()
-      )
-    assertThat(err.toString()).isEqualTo("")
-
-    Locale.setDefault(originalLocale)
+            .trimIndent()
+        )
+      assertThat(err.toString()).isEqualTo("")
+    } finally {
+      Locale.setDefault(originalLocale)
+    }
   }
 
   private fun String.stripFileAndLines(tmpDir: Path): String {

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/SimpleReport.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/SimpleReport.java
@@ -17,8 +17,8 @@ package org.pkl.core.stdlib.test.report;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Locale;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import org.pkl.core.TestResults;
 import org.pkl.core.TestResults.TestResult;
@@ -145,7 +145,10 @@ public final class SimpleReport implements TestReport {
     sb.append(
         color,
         () ->
-            sb.append(String.format(Locale.ROOT, "%.1f%%", passRate)).append(" ").append(kind).append(" pass"));
+            sb.append(String.format(Locale.ROOT, "%.1f%%", passRate))
+                .append(" ")
+                .append(kind)
+                .append(" pass"));
 
     if (isFailed) {
       sb.append(" [").append(failed).append('/').append(total).append(" failed]");

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/SimpleReport.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/SimpleReport.java
@@ -17,6 +17,7 @@ package org.pkl.core.stdlib.test.report;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Locale;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.pkl.core.TestResults;
@@ -144,7 +145,7 @@ public final class SimpleReport implements TestReport {
     sb.append(
         color,
         () ->
-            sb.append(String.format("%.1f%%", passRate)).append(" ").append(kind).append(" pass"));
+            sb.append(String.format(Locale.ROOT, "%.1f%%", passRate)).append(" ").append(kind).append(" pass"));
 
     if (isFailed) {
       sb.append(" [").append(failed).append('/').append(total).append(" failed]");


### PR DESCRIPTION
fixes #861

According to AI (and javadoc 😅) the problem is that String.format takes Locale.getDefault if not specified. Indeed I have set de-EN on my machine so it takes comma decimals instead of dot decimals. 

~I haven't tested this yet, just created it on mobile...~

This is my macobok setting (not sure if relevant or the correct screen):
![Screenshot 2024-12-24 at 7 05 15 AM](https://github.com/user-attachments/assets/2e84ef16-63e6-4633-a264-d8af7a9a1fb4)

If I run the newly added test without `Locale.ROOT` in `SimpleReport`, I get the following error:
![Screenshot 2024-12-24 at 7 06 36 AM](https://github.com/user-attachments/assets/651932b6-362f-4a9f-862b-9d6c123d5fbc)

Running with that `Locale.ROOT`:
`BUILD SUCCESSFUL in 37s` 🎉 

---

AI summary 

This pull request includes changes to improve locale independence in the `CliTestRunner` and to ensure consistent locale usage in the `SimpleReport` class. The most important changes include adding a locale independence test for `CliTestRunner` and specifying the root locale for formatting in `SimpleReport`.

Locale independence improvements:

* [`pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt`](diffhunk://#diff-37144b29baadf10353a60ee1a542ada8b1988d561989383347319eb2fbce7c06R490-R530): Added a new test `CliTestRunner locale independence test` to verify that `CliTestRunner` works correctly regardless of the default locale.
* [`pkl-core/src/main/java/org/pkl/core/stdlib/test/report/SimpleReport.java`](diffhunk://#diff-66bf95f097f7f82c74ddfb08bd576eca3353c82e16a1cd1fa905562152f92c1eR20): Imported `java.util.Locale` to use for specifying locale in formatting.
* [`pkl-core/src/main/java/org/pkl/core/stdlib/test/report/SimpleReport.java`](diffhunk://#diff-66bf95f097f7f82c74ddfb08bd576eca3353c82e16a1cd1fa905562152f92c1eL147-R148): Modified the `makeStatsLine` method to use `Locale.ROOT` in `String.format` to ensure consistent formatting regardless of the default locale.