### PR TITLE
`YamlRenderer`: allow all primitive scalar types as map keys

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/stdlib/AbstractRenderer.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/AbstractRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -410,6 +410,16 @@ public abstract class AbstractRenderer implements VmValueVisitor {
     var isMap = enclosingValue instanceof VmMap;
     throw new VmExceptionBuilder()
         .evalError(isMap ? "cannotRenderNonStringMap" : "cannotRenderObjectWithNonStringKey", name)
+        .withProgramValue(isMap ? "Map" : "Object", enclosingValue)
+        .withProgramValue("Key", key)
+        .build();
+  }
+
+  protected void cannotRenderNonScalarKey(Object key) {
+    assert enclosingValue != null;
+    var isMap = enclosingValue instanceof VmMap;
+    throw new VmExceptionBuilder()
+        .evalError(isMap ? "cannotRenderNonScalarMap" : "cannotRenderObjectWithNonScalarKey", name)
         .withProgramValue(isMap ? "Map" : "Object", enclosingValue)
         .withProgramValue("Key", key)
         .build();

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/YamlRendererNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/YamlRendererNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,8 +278,24 @@ public final class YamlRendererNodes {
         startNewLine();
       }
 
-      if (key instanceof String string) {
-        emitter.emit(string, currIndent, true);
+      if (key instanceof String stringKey) {
+        emitter.emit(stringKey, currIndent, true);
+        builder.append(':');
+        return;
+      } else if (key instanceof Long longKey) {
+        emitter.emit(longKey);
+        builder.append(':');
+        return;
+      } else if (key instanceof Double doubleKey) {
+        emitter.emit(doubleKey);
+        builder.append(':');
+        return;
+      } else if (key instanceof Boolean booleanKey) {
+        emitter.emit(booleanKey);
+        builder.append(':');
+        return;
+      } else if (key instanceof VmNull) {
+        emitter.emitNull();
         builder.append(':');
         return;
       }
@@ -290,7 +306,7 @@ public final class YamlRendererNodes {
         return;
       }
 
-      cannotRenderNonStringKey(key);
+      cannotRenderNonScalarKey(key);
     }
 
     @Override

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/protobuf/RendererNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/protobuf/RendererNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -310,7 +310,7 @@ public final class RendererNodes {
           isDirective || key instanceof Long || key instanceof Boolean || key instanceof String;
       if (!isValidKey) {
         throw new VmExceptionBuilder()
-            .evalError("cannotRenderNonScalarMapKey")
+            .evalError("cannotRenderProtobufMapKey")
             .withProgramValue("Key", key)
             .build();
       }
@@ -583,7 +583,7 @@ public final class RendererNodes {
             || keyType instanceof StringTypeNode
             || keyType instanceof BooleanTypeNode)) {
           throw new VmExceptionBuilder()
-              .evalError("cannotRenderNonScalarMapKeyType")
+              .evalError("cannotRenderProtobufMapKeyType")
               .withSourceSection(type.getSourceSection())
               .build();
         }

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -608,10 +608,16 @@ Cannot render map with non-string key as {0}.
 cannotRenderObjectWithNonStringKey=\
 Cannot render object with non-string key as {0}.
 
-cannotRenderNonScalarMapKey=\
+cannotRenderNonScalarMap=\
+Cannot render map with non-scalar key as {0}.
+
+cannotRenderObjectWithNonScalarKey=\
+Cannot render object with non-scalar key as {0}.
+
+cannotRenderProtobufMapKey=\
 Cannot render map with a non-scalar, floating point or byte array key.
 
-cannotRenderNonScalarMapKeyType=\
+cannotRenderProtobufMapKeyType=\
 Cannot render map with a non-scalar, floating point or byte array key type.
 
 cannotRenderObjectWithElementsAndOtherMembers=\

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/yamlRenderer8.yml.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/yamlRenderer8.yml.pkl
@@ -1,0 +1,33 @@
+// Test that non-String scalars can be rendered as YAML map keys.
+mappingInt = new Mapping {
+  [5] = "abc"
+  [10] = "def"
+  [20] = "ghi"
+}
+
+mapInt = mappingInt.toMap()
+
+mappingFloat = new Mapping {
+  [5.0] = "abc"
+  [10.5] = "def"
+  [20.999999990] = "ghi"
+}
+
+mapFloat = mappingFloat.toMap()
+
+mappingBool = new Mapping {
+  [true] = "abc"
+  [false] = "def"
+}
+
+mapBool = mappingBool.toMap()
+
+mappingNull = new Mapping {
+  [null] = "abc"
+}
+
+mapNull = mappingNull.toMap()
+
+output {
+  renderer = new YamlRenderer {}
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/yamlRenderer8.yml
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/yamlRenderer8.yml
@@ -1,0 +1,26 @@
+mappingInt:
+  5: abc
+  10: def
+  20: ghi
+mapInt:
+  5: abc
+  10: def
+  20: ghi
+mappingFloat:
+  5.0: abc
+  10.5: def
+  20.99999999: ghi
+mapFloat:
+  5.0: abc
+  10.5: def
+  20.99999999: ghi
+mappingBool:
+  true: abc
+  false: def
+mapBool:
+  true: abc
+  false: def
+mappingNull:
+  null: abc
+mapNull:
+  null: abc


### PR DESCRIPTION
[YAML (1.2) explicitly allows _any_ value as a mapping key](https://yaml.org/spec/1.2.2/#3211-nodes), just like Pkl! This PR allows all of Pkl's primitive scalars (those that can already be natively rendered in YAML: Int, Float, Boolean, Null) to be rendered as mapping keys by `YamlRenderer`.

This PR does not attempt to allow non-scalar YAML mapping keys (see Example 2.11 at https://yaml.org/spec/1.2.2/#22-structures). This doesn't appear to be a commonly used YAML feature—I've never seen it in the wild—but may be interesting for Pkl to support. If this is desired, it could be taken on as follow-up work, but it might require significant modifications to `YamlRendererNodes.YamlRenderer`.

Resolves #878 