### PR TITLE
Use GitHub Actions for checks

### DIFF
--- a/.github/pkl-workflows/CheckActionsConverted.pkl
+++ b/.github/pkl-workflows/CheckActionsConverted.pkl
@@ -1,0 +1,37 @@
+amends "package://pkg.pkl-lang.org/github.com/stefma/pkl-gha/com.github.action@0.0.4#/GitHubAction.pkl"
+
+name = "Check Pkl Actions Converted"
+
+on {
+  push {}
+}
+
+jobs {
+  ["check-actions-converted"] {
+    name = "Check Actions converted"
+    `runs-on` = "ubuntu-latest"
+    steps {
+      new {
+        name = "Checkout"
+        uses = "actions/checkout@v4"
+      }
+      new {
+        name = "Install pkl"
+        uses = "pkl-community/setup-pkl@v0"
+        with {
+          ["pkl-version"] = "0.27.0"
+        }
+      }
+      new {
+        name = "Convert pkl actions to yaml"
+        run = """
+          pkl eval .github/pkl-workflows/*.pkl -o .github/workflows/%{moduleName}.generated.yml
+          """
+      }
+      new {
+        name = "Verify if pkl actions are converted"
+        run = "git diff --exit-code"
+      }
+    }
+  }
+}

--- a/.github/pkl-workflows/Checks.pkl
+++ b/.github/pkl-workflows/Checks.pkl
@@ -3,11 +3,7 @@ amends "package://pkg.pkl-lang.org/github.com/stefma/pkl-gha/com.github.action@0
 name = "Checks"
 
 on {
-  push {
-    branches {
-      "main"
-    }
-  }
+  push {}
   pull_request {}
 }
 

--- a/.github/pkl-workflows/Checks.pkl
+++ b/.github/pkl-workflows/Checks.pkl
@@ -1,0 +1,67 @@
+amends "package://pkg.pkl-lang.org/github.com/stefma/pkl-gha/com.github.action@0.0.4#/GitHubAction.pkl"
+
+name = "Checks"
+
+on {
+  push {
+    branches {
+      "main"
+    }
+  }
+  pull_request {}
+}
+
+jobs {
+  ["gradle-checks"] {
+    permissions = new {
+      checks = "write"
+    }
+    strategy {
+      matrix {
+        ["os"] {
+          "ubuntu-latest"
+          "windows-latest"
+        }
+        ["jdk"] {
+          "17"
+          "21"
+        }
+      }
+    }
+    `runs-on` = "${{ matrix.os }}"
+    steps {
+      new {
+        name = "Checkout"
+        uses = "actions/checkout@v4"
+        with {
+          ["fetch-depth"] = 0
+        }
+      }
+      new {
+        name = "Setup JDK"
+        uses = "actions/setup-java@v4"
+        with {
+          ["distribution"] = "adopt"
+          ["java-version"] = "${{ matrix.jdk }}"
+        }
+      }
+      new {
+        name = "Setup Gradle"
+        uses = "gradle/actions/setup-gradle@v4"
+      }
+      new {
+        name = "Gradle check"
+        run = "./gradlew --info --stacktrace check"
+      }
+      new {
+        name = "Report test results"
+        uses = "mikepenz/action-junit-report@v5"
+        `if` = "${{ always() }}"
+        with {
+          ["check_name"] = "Test Results JDK ${{ matrix.jdk }} on ${{ matrix.os }}"
+          ["report_paths"] = "**/build/test-results/test/*.xml"
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/CheckActionsConverted.generated.yml
+++ b/.github/workflows/CheckActionsConverted.generated.yml
@@ -1,0 +1,21 @@
+# Do not modify!
+# This file was generated from a template using https://github.com/StefMa/pkl-gha
+
+name: Check Pkl Actions Converted
+'on':
+  push: {}
+jobs:
+  check-actions-converted:
+    name: Check Actions converted
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install pkl
+      uses: pkl-community/setup-pkl@v0
+      with:
+        pkl-version: 0.27.0
+    - name: Convert pkl actions to yaml
+      run: pkl eval .github/pkl-workflows/*.pkl -o .github/workflows/%{moduleName}.generated.yml
+    - name: Verify if pkl actions are converted
+      run: git diff --exit-code

--- a/.github/workflows/Checks.generated.yml
+++ b/.github/workflows/Checks.generated.yml
@@ -1,0 +1,42 @@
+# Do not modify!
+# This file was generated from a template using https://github.com/StefMa/pkl-gha
+
+name: Checks
+'on':
+  pull_request: {}
+  push:
+    branches:
+    - main
+jobs:
+  gradle-checks:
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - windows-latest
+        jdk:
+        - '17'
+        - '21'
+    permissions:
+      checks: write
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: adopt
+        java-version: ${{ matrix.jdk }}
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+    - name: Gradle check
+      run: ./gradlew --info --stacktrace check
+    - name: Report test results
+      if: ${{ always() }}
+      uses: mikepenz/action-junit-report@v5
+      with:
+        check_name: Test Results JDK ${{ matrix.jdk }} on ${{ matrix.os }}
+        report_paths: '**/build/test-results/test/*.xml'

--- a/.github/workflows/Checks.generated.yml
+++ b/.github/workflows/Checks.generated.yml
@@ -4,9 +4,7 @@
 name: Checks
 'on':
   pull_request: {}
-  push:
-    branches:
-    - main
+  push: {}
 jobs:
   gradle-checks:
     strategy:


### PR DESCRIPTION
Hello everyone ✌️ 

this PR might fix #152 and therefore also contributes to #225.

Two reasons why this would be a step forward:
* Forks can simply check in their own repo if something isn't broken. Right now they have to check stuff locally and we all know this might not happen all the time 😅 
* PRs, depending on the [setting](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories), can run automatically run checks without an approval.
* Since this is the "start" of using GitHub actions, we can also start implemeting #225 as dependabot would also run on actions and we can create workflows that "do something after they run" or after "dependabot created a PR"... See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
* ???

I just converted the `checks` from the circleci config for now because 
1. I wanted to hear your opinion about this first (generally)
2. What do you think about using my pkl-gha project 🙃 
3. Other comments 🙃 
Le me know if this is "fine" or if I also convert all the other jobs.
On the other side we can also do this as follow-ups in other PRs. 
Let me know what you prefer.

Because using a matrix is super easy to setup on actions, I also decided to run jdk 21 on windows 🤷 
This isn't in the circleci config but doesn't hurt i guess?! 

If you want to see how this looks like in action, checkout this run on my fork:
* [Check Pkl Actions Converted](https://github.com/StefMa/pkl/actions/runs/12783766972)
* [Checks](https://github.com/StefMa/pkl/actions/runs/12783766976)

