### PR TITLE
Document missing reserved keywords

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -5269,6 +5269,8 @@ They cannot be used as a regular identifier, and currently do not have any meani
 
 To use these names in an identifier, <<quoted-identifiers, surround them with backticks>>.
 
+For a complete list of reserved keywords, consult link:{uri-github-PklLexer}[PklLexer.g4].
+
 [[blank-identifiers]]
 === Blank Identifiers
 

--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -5269,7 +5269,7 @@ They cannot be used as a regular identifier, and currently do not have any meani
 
 To use these names in an identifier, <<quoted-identifiers, surround them with backticks>>.
 
-For a complete list of reserved keywords, consult link:{uri-github-PklLexer}[PklLexer.g4].
+For a complete list of keywords, consult link:{uri-github-PklLexer}[PklLexer.g4].
 
 [[blank-identifiers]]
 === Blank Identifiers


### PR DESCRIPTION
It's not possible to use external without backticks.