### PR TITLE
Bump minimum Gradle version to 8.2

### DIFF
--- a/pkl-gradle/pkl-gradle.gradle.kts
+++ b/pkl-gradle/pkl-gradle.gradle.kts
@@ -88,7 +88,7 @@ gradlePlugin {
 
 gradlePluginTests {
   // keep in sync with `PklPlugin.MIN_GRADLE_VERSION`
-  minGradleVersion = GradleVersion.version("8.1")
+  minGradleVersion = GradleVersion.version("8.2")
   maxGradleVersion = GradleVersion.version("8.99")
   skippedGradleVersions = listOf()
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ import org.pkl.gradle.utils.PluginUtils;
 @SuppressWarnings("unused")
 public class PklPlugin implements Plugin<Project> {
 
-  private static final String MIN_GRADLE_VERSION = "8.1";
+  private static final String MIN_GRADLE_VERSION = "8.2";
 
   @LateInit private Project project;
 


### PR DESCRIPTION
The Kotlin 2.0 version upgrade made us incompatible with Gradle 8.1.

Given that Gradle 8.1 is now over 1.5 years old, this drops support for it, and raises the minimum version to 8.2.