### PR TITLE
Upgrade gradle to 8.12.1 (from 8.12) and fix some build warnings

### DIFF
--- a/buildSrc/src/main/kotlin/pklGradlePluginTest.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklGradlePluginTest.gradle.kts
@@ -87,11 +87,11 @@ tasks.addRule("Pattern: compatibilityTest[All|Releases|Latest|Candidate|Nightly|
   }
 }
 
-fun createCompatibilityTestTask(versionInfo: GradleVersionInfo): Task =
+fun createCompatibilityTestTask(versionInfo: GradleVersionInfo) =
   createCompatibilityTestTask(versionInfo.version, versionInfo.downloadUrl)
 
-fun createCompatibilityTestTask(version: String, downloadUrl: String): Task {
-  return tasks.create("compatibilityTest$version", Test::class.java) {
+fun createCompatibilityTestTask(version: String, downloadUrl: String): TaskProvider<Test> {
+  return tasks.register("compatibilityTest$version", Test::class.java) {
     mustRunAfter(tasks.test)
 
     maxHeapSize = tasks.test.get().maxHeapSize

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7a00d51fb93147819aab76024feece20b6b84e420694101f276be952e08bef03
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/pkl-executor/pkl-executor.gradle.kts
+++ b/pkl-executor/pkl-executor.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ sourceSets { main { java { srcDir("src/main/java") } } }
 val prepareHistoricalDistributions by
   tasks.registering {
     val outputDir = layout.buildDirectory.dir("pklHistoricalDistributions")
-    inputs.files(pklHistoricalDistributions.files())
+    inputs.files(pklHistoricalDistributions.files)
     outputs.dir(outputDir)
     doLast {
       val distributionDir = outputDir.get().asFile.toPath().also(Files::createDirectories)

--- a/pkl-tools/pkl-tools.gradle.kts
+++ b/pkl-tools/pkl-tools.gradle.kts
@@ -52,13 +52,13 @@ dependencies {
 
 // TODO: need to figure out how to properly generate javadoc here.
 // For now, we'll include a dummy javadoc jar.
-val javadocDummy by tasks.creating(Javadoc::class) { source = dummy.allJava }
+val javadocDummy by tasks.registering(Javadoc::class) { source = dummy.allJava }
 
 java { withJavadocJar() }
 
 val javadocJar by
   tasks.existing(Jar::class) {
-    from(javadocDummy.outputs.files)
+    from(javadocDummy.get().outputs.files)
     archiveBaseName.set("pkl-tools-all")
   }
 


### PR DESCRIPTION
### Upgrade gradle to 8.12.1 (from 8.12)

Command used:

```
./gradlew wrapper \
          --gradle-version=8.12.1 \
          --gradle-distribution-sha256-sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
```

Release notes: https://docs.gradle.org/8.12.1/release-notes.html

### Return tasks.register as tasks.create is deprecated

Fixes the following warning:

```
buildSrc/src/main/kotlin/pklGradlePluginTest.gradle.kts:94:16 'create(String, Class<T!>, Action<in T!>): T' is deprecated. Deprecated in Java
```

### Use property accessor .files instead of function .files()

Fixes warning:

```
pkl-executor/pkl-executor.gradle.kts:71:45: 'files(vararg Dependency!): (Mutable)Set<File!>!' is deprecated. Deprecated in Java
```

### Return `tasks.registering` as `tasks.creating` is deprecated

Fixes the following warning:

```
pkl-tools/pkl-tools.gradle.kts:55:27: 'creating(KClass<U>, U.() -> Unit): PolymorphicDomainObjectContainerCreatingDelegateProvider<Task!, U>' is deprecated. Use registering instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.
```