### PR TITLE
JSR305 integration for `kotlinc`

### DIFF
--- a/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import org.gradle.accessors.dm.LibrariesForLibs
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
   id("pklJavaLibrary")
@@ -37,4 +39,26 @@ dependencies {
 
 tasks.compileKotlin {
   enabled = true // disabled by pklJavaLibrary
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+  compilerOptions {
+    // must match the minimum JVM bytecode target for Pkl
+    jvmTarget = JvmTarget.JVM_17
+
+    // enable java parameter names for stronger Kotlin-Java interop and debugging
+    javaParameters = true
+
+    // @TODO: flip to `true` once compiler warnings are all fixed
+    allWarningsAsErrors = false
+
+    freeCompilerArgs.addAll(
+      listOf(
+        // enable strict nullability checking and integration with pkl's own annotations
+        "-Xjsr305=strict",
+        "-Xjsr305=@org.pkl.core.util.Nullable:strict",
+        "-Xjsr305=@org.pkl.core.util.Nonnull:strict",
+      )
+    )
+  }
 }


### PR DESCRIPTION
## Summary

Applies `-Xjsr305=strict` support for Pkl's own annotations, `org.pkl.core.util.Nullable` and `org.pkl.core.util.Nonnull`. Java parameter names are retained in Kotlin bytecode, enabling smoother Java/Kotlin interop and debugging. Fixes deprecated/outdated use of Kotlin Gradle Plugin.
