### PR TITLE
Fix typo in tutorial

### DIFF
--- a/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
+++ b/docs/modules/language-tutorial/pages/02_filling_out_a_template.adoc
@@ -213,7 +213,7 @@ adultBirdFoods {
 
 A `.pkl` file describes a _module_.
 Modules are objects that can be referred to from other modules.
-Going back to the example above, you can write `parrot` as a separate module.
+Going back to the example above, you can write `pigeon` as a separate module.
 
 [source,{pkl}]
 .pigeon.pkl


### PR DESCRIPTION
Should mean `pigeon` instead of `parrot` as a separate module