### PR TITLE
[RFC] Add properties to `List` for byte-based encodings/hashes

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmList.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,6 +134,15 @@ public final class VmList extends VmCollection {
   @TruffleBoundary
   public boolean isEmpty() {
     return rrbt.isEmpty();
+  }
+
+  @TruffleBoundary
+  public byte[] getBytes() {
+    var result = new byte[rrbt.size()];
+    for (var i = 0; i < rrbt.size(); i++) {
+      result[i] = VmUtils.checkByte(rrbt.get(i));
+    }
+    return result;
   }
 
   @Override

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmUtils.java
@@ -485,6 +485,14 @@ public final class VmUtils {
     }
   }
 
+  public static byte checkByte(Object n) {
+    if (n instanceof Long l && l >= 0 && l <= 255) {
+      return l.byteValue();
+    }
+    CompilerDirectives.transferToInterpreter();
+    throw new VmExceptionBuilder().evalError("expectedByte", n).build();
+  }
+
   public static Source loadSource(ResolvedModuleKey resolvedKey) {
     try {
       var text = resolvedKey.loadSource();

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/ListNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/ListNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.LoopNode;
+import java.util.Base64;
 import org.pkl.core.ast.expression.binary.*;
 import org.pkl.core.ast.internal.IsInstanceOfNode;
 import org.pkl.core.ast.internal.IsInstanceOfNodeGen;
@@ -28,6 +29,7 @@ import org.pkl.core.stdlib.*;
 import org.pkl.core.stdlib.base.CollectionNodes.CompareByNode;
 import org.pkl.core.stdlib.base.CollectionNodes.CompareNode;
 import org.pkl.core.stdlib.base.CollectionNodes.CompareWithNode;
+import org.pkl.core.util.ByteArrayUtils;
 import org.pkl.core.util.EconomicSets;
 
 // duplication between ListNodes and SetNodes is "intentional"
@@ -48,6 +50,45 @@ public final class ListNodes {
     @Specialization
     protected boolean eval(VmList self) {
       return self.isEmpty();
+    }
+  }
+
+  public abstract static class md5 extends ExternalPropertyNode {
+    @TruffleBoundary
+    @Specialization
+    protected String eval(VmList self) {
+      return ByteArrayUtils.md5(self.getBytes());
+    }
+  }
+
+  public abstract static class sha1 extends ExternalPropertyNode {
+    @TruffleBoundary
+    @Specialization
+    protected String eval(VmList self) {
+      return ByteArrayUtils.sha1(self.getBytes());
+    }
+  }
+
+  public abstract static class sha256 extends ExternalPropertyNode {
+    @TruffleBoundary
+    @Specialization
+    protected String eval(VmList self) {
+      return ByteArrayUtils.sha256(self.getBytes());
+    }
+  }
+
+  public abstract static class sha256Int extends ExternalPropertyNode {
+    @TruffleBoundary
+    @Specialization
+    protected long eval(VmList self) {
+      return ByteArrayUtils.sha256Int(self.getBytes());
+    }
+  }
+
+  public abstract static class base64 extends ExternalPropertyNode {
+    @Specialization
+    protected String eval(VmList self) {
+      return Base64.getEncoder().encodeToString(self.getBytes());
     }
   }
 

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -542,6 +542,9 @@ Int value `{0}` is too large (only Int32 supported here).
 expectedPositiveNumber=\
 Expected a positive number, but got `{0}`.
 
+expectedByte=\
+Expected an Int value between 0 and 255, but got `{0}`.
+
 cannotFindResource=\
 Cannot find resource `{0}`.
 

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2793,6 +2793,40 @@ external class List<out Element> extends Collection<Element> {
   external length: Int
 
   external isEmpty: Boolean
+
+  /// The [MD5](https://en.wikipedia.org/wiki/MD5)
+  /// hash of this list's byte sequence as hexadecimal string.
+  ///
+  /// MD5 is cryptographically broken and should not be used for secure applications.
+  /// 
+  /// Throws an error when [Element] is not [UInt8].
+  external md5: String
+
+  /// The [SHA-1](https://en.wikipedia.org/wiki/SHA-1)
+  /// hash of this list's byte sequence.
+  ///
+  /// SHA-1 is cryptographically broken and should not be used for secure applications.
+  /// 
+  /// Throws an error when [Element] is not [UInt8].
+  external sha1: String
+
+  /// The [SHA-256](https://en.wikipedia.org/wiki/SHA-2)
+  /// cryptographic hash of this list's byte sequence
+  /// as hexadecimal string.
+  /// 
+  /// Throws an error when [Element] is not [UInt8].
+  external sha256: String
+
+  /// The first 64 bits of the [SHA-256](https://en.wikipedia.org/wiki/SHA-2)
+  /// cryptographic hash of this list's byte sequence.
+  /// 
+  /// Throws an error when [Element] is not [UInt8].
+  external sha256Int: Int
+
+  /// The Base64 encoding of this string's UTF-8 byte sequence.
+  /// 
+  /// Throws an error when [Element] is not [UInt8].
+  external base64: String
 
   /// The index of the last element in this list (same as `length - 1`).
   ///


### PR DESCRIPTION
The primary motivation here is to allow Pkl to properly work with arbitrary binary data. String can be abused to some extent, but because text encoding (and unicode normalization) is involved, what you see isn't what you get:
```
❯ pkl eval pkl:base -x 'let (_ = trace(0xff.toRadixString(16))) trace(0xff.toChar())' | hexdump                 
pkl: TRACE: 0xff.toRadixString(16) = "ff" (repl:text)
pkl: TRACE: 0xff.toChar() = "ÿ" (repl:text)
0000000 bfc3                                   
0000002
```

I'm most focused on `base64` here, but I don't see an reason to omit the hashes either.

This can actually be implemented in-langage, but it's far from performant:
```pkl
const local base64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".chars
const function base64Bytes(bytes: List<UInt8>|Listing<UInt8>): String =
  let (padding = if (bytes.length % 3 == 0) "" else "=".repeat(3 - (bytes.length % 3)))
    bytes.fold(List(List()), (acc, elem) ->
      if (acc.last.length == 3) acc + List(List(elem))
      else acc.dropLast(1) + List(acc.last + List(elem))
    )
      .map((tuple) ->
      let (n = tuple[0].shl(16) + (tuple.getOrNull(1)?.shl(8) ?? 0) + (tuple.getOrNull(2) ?? 0))
        "\(base64Chars[n.ushr(18).and(63)])\(base64Chars[n.ushr(12).and(63)])\(base64Chars[n.ushr(6).and(63)])\(base64Chars[n.and(63)])"
    )
      .join("") + padding
```

 Here's a test encoding a 16kB buffer:
```
❯ time ../pkl/pkl-cli/build/executable/jpkl eval test.pkl > /dev/null
../pkl/pkl-cli/build/executable/jpkl eval test.pkl > /dev/null  19.55s user 0.36s system 125% cpu 15.862 total
```

And here's the exact same evaluation switched to use the `List.base64` property introduced in this PR:
```
❯ time ../pkl/pkl-cli/build/executable/jpkl eval test.pkl > /dev/null
../pkl/pkl-cli/build/executable/jpkl eval test.pkl > /dev/null  4.22s user 0.19s system 325% cpu 1.356 total
```

This is roughly a 12x speedup!

Methods on generic types that only work for some type arguments don't really exist in Pkl yet. I considered an entirely separate stdlib class (possibly even a `List` subclass?) that forces the element type to `UInt8` I'm interested in hearing thoughts on how to best approach this, but this was the most expedient path to prove the concept.

As for why I'm doing this at all, here's a teaser:
<img width="789" alt="Screenshot 2025-02-01 at 16 58 38" src="https://github.com/user-attachments/assets/97828383-d261-4b52-80ce-a68e4f8afc56" />