### PR TITLE
Run a simple eval script

### DIFF
--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -184,7 +184,7 @@ val testStartJavaExecutableOnOtherJdks =
     emptyList()
   }
 
-val evalTestFlags = arrayOf("eval", "./.circleci/config.pkl")
+val evalTestFlags = arrayOf("eval", "-x", "1 + 1", "pkl:base")
 
 fun Exec.useRootDirAndSuppressOutput() {
   workingDir = rootProject.layout.projectDirectory.asFile


### PR DESCRIPTION
Execute `1 + 1` instead of eval'ing `circleci.pkl` (might cause spurious failures due to requirement on network connection).