### PR TITLE
Allow -DcommitId flag when building Pkl

### DIFF
--- a/buildSrc/src/main/kotlin/BuildInfo.kt
+++ b/buildSrc/src/main/kotlin/BuildInfo.kt
@@ -350,6 +350,8 @@ open class BuildInfo(private val project: Project) {
 
   // could be `commitId: Provider<String> = project.provider { ... }`
   val commitId: String by lazy {
+    // allow -DcommitId=abc123 for build environments that don't have git.
+    System.getProperty("commitId").let { if (it != null) return@lazy it }
     // only run command once per build invocation
     if (project === project.rootProject) {
       val process =


### PR DESCRIPTION
This is to allow building Pkl in environments that don't have access to git.