### PR TITLE
Fix incorrect glob example

### DIFF
--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -4914,8 +4914,8 @@ TIP: If incorporating escape characters into a glob pattern, use <<custom-string
 |===
 |Pattern |Description
 
-|`*.pc[lf]`
-|Anything suffixed by `.pkl`, or `.pcf`.
+|`*.pk[lf]`
+|Anything suffixed by `.pkl`, or `.pkf`.
 
 |`**.y{a,}ml`
 |Anything suffixed by either `yml` or `yaml`, crossing directory boundaries. 

--- a/docs/modules/language-reference/pages/index.adoc
+++ b/docs/modules/language-reference/pages/index.adoc
@@ -4914,8 +4914,8 @@ TIP: If incorporating escape characters into a glob pattern, use <<custom-string
 |===
 |Pattern |Description
 
-|`*.pk[lf]`
-|Anything suffixed by `.pkl`, or `.pkf`.
+|`*.pk[lg]`
+|Anything suffixed by `.pkl`, or `.pkg`.
 
 |`**.y{a,}ml`
 |Anything suffixed by either `yml` or `yaml`, crossing directory boundaries. 


### PR DESCRIPTION
Found a mistake in the glob pattern documentation: https://pkl-lang.org/main/current/language-reference/index.html#examples

> `*.pc[lf]`  --  Anything suffixed by `.pkl` or `.pcf`

Changed the pattern to `*.pk[lg]`, matching `.pkl` and `.pkg`