### PR TITLE
fix calculation of spans in parser

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/parser/BaseParserVisitor.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/BaseParserVisitor.java
@@ -55,6 +55,7 @@ import org.pkl.core.parser.ast.Expr.UnqualifiedAccessExpr;
 import org.pkl.core.parser.ast.ExtendsOrAmendsClause;
 import org.pkl.core.parser.ast.Identifier;
 import org.pkl.core.parser.ast.ImportClause;
+import org.pkl.core.parser.ast.Keyword;
 import org.pkl.core.parser.ast.Modifier;
 import org.pkl.core.parser.ast.ModuleDecl;
 import org.pkl.core.parser.ast.Node;
@@ -86,6 +87,7 @@ import org.pkl.core.parser.ast.Type.UnionType;
 import org.pkl.core.parser.ast.Type.UnknownType;
 import org.pkl.core.parser.ast.TypeAlias;
 import org.pkl.core.parser.ast.TypeAnnotation;
+import org.pkl.core.parser.ast.TypeArgumentList;
 import org.pkl.core.parser.ast.TypeParameter;
 import org.pkl.core.parser.ast.TypeParameterList;
 
@@ -454,6 +456,16 @@ public abstract class BaseParserVisitor<T> implements ParserVisitor<T> {
   @Override
   public T visitReplInput(ReplInput replInput) {
     return visitChildren(replInput);
+  }
+
+  @Override
+  public T visitKeyword(Keyword keyword) {
+    return defaultValue();
+  }
+
+  @Override
+  public T visitTypeArgumentList(TypeArgumentList typeArgumentList) {
+    return visitChildren(typeArgumentList);
   }
 
   private T visitChildren(Node node) {

--- a/pkl-core/src/main/java/org/pkl/core/parser/ParserVisitor.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ParserVisitor.java
@@ -55,6 +55,7 @@ import org.pkl.core.parser.ast.Expr.UnqualifiedAccessExpr;
 import org.pkl.core.parser.ast.ExtendsOrAmendsClause;
 import org.pkl.core.parser.ast.Identifier;
 import org.pkl.core.parser.ast.ImportClause;
+import org.pkl.core.parser.ast.Keyword;
 import org.pkl.core.parser.ast.Modifier;
 import org.pkl.core.parser.ast.Module;
 import org.pkl.core.parser.ast.ModuleDecl;
@@ -70,6 +71,7 @@ import org.pkl.core.parser.ast.StringPart;
 import org.pkl.core.parser.ast.Type;
 import org.pkl.core.parser.ast.TypeAlias;
 import org.pkl.core.parser.ast.TypeAnnotation;
+import org.pkl.core.parser.ast.TypeArgumentList;
 import org.pkl.core.parser.ast.TypeParameter;
 import org.pkl.core.parser.ast.TypeParameterList;
 
@@ -220,4 +222,8 @@ public interface ParserVisitor<Result> {
   Result visitObjectBody(ObjectBody objectBody);
 
   Result visitReplInput(ReplInput replInput);
+
+  Result visitKeyword(Keyword keyword);
+
+  Result visitTypeArgumentList(TypeArgumentList typeArgumentList);
 }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ArgumentList.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ArgumentList.java
@@ -20,7 +20,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("unchecked")
 public class ArgumentList extends AbstractNode {
 
   public ArgumentList(List<Expr> arguments, Span span) {
@@ -32,6 +31,7 @@ public class ArgumentList extends AbstractNode {
     return visitor.visitArgumentList(this);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Expr> getArguments() {
     assert children != null;
     return (List<Expr>) children;

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Class.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Class.java
@@ -20,7 +20,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings({"unchecked", "DataFlowIssue"})
 public final class Class extends AbstractNode {
   private final int modifiersOffset;
   private final int keywordOffset;
@@ -37,40 +36,51 @@ public final class Class extends AbstractNode {
   }
 
   public @Nullable DocComment getDocComment() {
+    assert children != null;
     return (DocComment) children.get(0);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Annotation> getAnnotations() {
+    assert children != null;
     return (List<Annotation>) children.subList(1, modifiersOffset);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Modifier> getModifiers() {
+    assert children != null;
     return (List<Modifier>) children.subList(modifiersOffset, keywordOffset);
   }
 
   public Keyword getClassKeyword() {
+    assert children != null;
     return (Keyword) children.get(keywordOffset);
   }
 
   public Identifier getName() {
+    assert children != null;
     return (Identifier) children.get(keywordOffset + 1);
   }
 
   public @Nullable TypeParameterList getTypeParameterList() {
+    assert children != null;
     return (TypeParameterList) children.get(keywordOffset + 2);
   }
 
   public @Nullable Type getSuperClass() {
+    assert children != null;
     return (Type) children.get(keywordOffset + 3);
   }
 
   public @Nullable ClassBody getBody() {
+    assert children != null;
     return (ClassBody) children.get(keywordOffset + 4);
   }
 
   @SuppressWarnings("DuplicatedCode")
   public Span getHeaderSpan() {
     Span start = null;
+    assert children != null;
     for (var i = modifiersOffset; i < children.size(); i++) {
       var child = children.get(i);
       if (child != null) {
@@ -86,6 +96,7 @@ public final class Class extends AbstractNode {
     } else {
       end = getName().span();
     }
+    assert start != null;
     return start.endWith(end);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Class.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Class.java
@@ -23,16 +23,16 @@ import org.pkl.core.util.Nullable;
 @SuppressWarnings({"unchecked", "DataFlowIssue"})
 public final class Class extends AbstractNode {
   private final int modifiersOffset;
-  private final int nameOffset;
+  private final int keywordOffset;
 
-  public Class(List<Node> nodes, int modifiersOffset, int nameOffset, Span span) {
+  public Class(List<Node> nodes, int modifiersOffset, int keywordOffset, Span span) {
     super(span, nodes);
     this.modifiersOffset = modifiersOffset;
-    this.nameOffset = nameOffset;
+    this.keywordOffset = keywordOffset;
   }
 
   @Override
-  public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+  public <T> T accept(ParserVisitor<? extends T> visitor) {
     return visitor.visitClass(this);
   }
 
@@ -45,26 +45,39 @@ public final class Class extends AbstractNode {
   }
 
   public List<Modifier> getModifiers() {
-    return (List<Modifier>) children.subList(modifiersOffset, nameOffset);
+    return (List<Modifier>) children.subList(modifiersOffset, keywordOffset);
+  }
+
+  public Keyword getClassKeyword() {
+    return (Keyword) children.get(keywordOffset);
   }
 
   public Identifier getName() {
-    return (Identifier) children.get(nameOffset);
+    return (Identifier) children.get(keywordOffset + 1);
   }
 
   public @Nullable TypeParameterList getTypeParameterList() {
-    return (TypeParameterList) children.get(nameOffset + 1);
+    return (TypeParameterList) children.get(keywordOffset + 2);
   }
 
   public @Nullable Type getSuperClass() {
-    return (Type) children.get(nameOffset + 2);
+    return (Type) children.get(keywordOffset + 3);
   }
 
   public @Nullable ClassBody getBody() {
-    return (ClassBody) children.get(nameOffset + 3);
+    return (ClassBody) children.get(keywordOffset + 4);
   }
 
+  @SuppressWarnings("DuplicatedCode")
   public Span getHeaderSpan() {
+    Span start = null;
+    for (var i = modifiersOffset; i < children.size(); i++) {
+      var child = children.get(i);
+      if (child != null) {
+        start = child.span();
+        break;
+      }
+    }
     Span end;
     if (getSuperClass() != null) {
       end = getSuperClass().span();
@@ -73,6 +86,6 @@ public final class Class extends AbstractNode {
     } else {
       end = getName().span();
     }
-    return span.endWith(end);
+    return start.endWith(end);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ClassMethod.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ClassMethod.java
@@ -20,7 +20,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("unchecked")
 public class ClassMethod extends AbstractNode {
   private final int modifiersOffset;
   private final int nameOffset;
@@ -44,11 +43,13 @@ public class ClassMethod extends AbstractNode {
     return (DocComment) children.get(0);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Annotation> getAnnotations() {
     assert children != null;
     return (List<Annotation>) children.subList(1, modifiersOffset);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Modifier> getModifiers() {
     assert children != null;
     return (List<Modifier>) children.subList(modifiersOffset, nameOffset);

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ClassProperty.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ClassProperty.java
@@ -32,7 +32,7 @@ public final class ClassProperty extends AbstractNode {
   }
 
   @Override
-  public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+  public <T> T accept(ParserVisitor<? extends T> visitor) {
     return visitor.visitClassProperty(this);
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ClassProperty.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ClassProperty.java
@@ -20,7 +20,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings({"DuplicatedCode", "unchecked"})
 public final class ClassProperty extends AbstractNode {
   private final int modifiersOffset;
   private final int nameOffset;
@@ -41,11 +40,13 @@ public final class ClassProperty extends AbstractNode {
     return (DocComment) children.get(0);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Annotation> getAnnotations() {
     assert children != null;
     return (List<Annotation>) children.subList(1, modifiersOffset);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Modifier> getModifiers() {
     assert children != null;
     return (List<Modifier>) children.subList(modifiersOffset, nameOffset);
@@ -66,6 +67,7 @@ public final class ClassProperty extends AbstractNode {
     return (Expr) children.get(nameOffset + 2);
   }
 
+  @SuppressWarnings("unchecked")
   public List<ObjectBody> getBodyList() {
     assert children != null;
     return (List<ObjectBody>) children.subList(nameOffset + 3, children.size());

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Expr.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Expr.java
@@ -23,7 +23,7 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("ALL")
+@SuppressWarnings({"unchecked", "DataFlowIssue"})
 public abstract sealed class Expr extends AbstractNode {
 
   public Expr(Span span, @Nullable List<? extends @Nullable Node> children) {
@@ -36,7 +36,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitThisExpr(this);
     }
   }
@@ -47,7 +47,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitOuterExpr(this);
     }
   }
@@ -58,7 +58,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitModuleExpr(this);
     }
   }
@@ -69,7 +69,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitNullLiteralExpr(this);
     }
   }
@@ -83,7 +83,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitBoolLiteralExpr(this);
     }
 
@@ -101,7 +101,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitIntLiteralExpr(this);
     }
 
@@ -119,7 +119,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitFloatLiteralExpr(this);
     }
 
@@ -140,7 +140,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitSingleLineStringLiteralExpr(this);
     }
 
@@ -170,7 +170,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitMultiLineStringLiteralExpr(this);
     }
 
@@ -193,7 +193,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitThrowExpr(this);
     }
 
@@ -208,7 +208,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitTraceExpr(this);
     }
 
@@ -226,7 +226,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitImportExpr(this);
     }
 
@@ -248,7 +248,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitReadExpr(this);
     }
 
@@ -274,7 +274,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitUnqualifiedAccessExpr(this);
     }
 
@@ -301,7 +301,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitQualifiedAccessExpr(this);
     }
 
@@ -328,7 +328,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitSuperAccessExpr(this);
     }
 
@@ -347,7 +347,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitSuperSubscriptExpr(this);
     }
 
@@ -362,7 +362,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitSubscriptExpr(this);
     }
 
@@ -381,7 +381,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitIfExpr(this);
     }
 
@@ -404,7 +404,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitLetExpr(this);
     }
 
@@ -427,7 +427,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitFunctionLiteralExpr(this);
     }
 
@@ -446,7 +446,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitParenthesizedExpr(this);
     }
 
@@ -461,7 +461,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitNewExpr(this);
     }
 
@@ -484,7 +484,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitAmendsExpr(this);
     }
 
@@ -503,7 +503,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitNonNullExpr(this);
     }
 
@@ -518,7 +518,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitUnaryMinusExpr(this);
     }
 
@@ -533,7 +533,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitLogicalNotExpr(this);
     }
 
@@ -551,7 +551,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitBinaryOperatorExpr(this);
     }
 
@@ -569,7 +569,7 @@ public abstract sealed class Expr extends AbstractNode {
 
     @Override
     public String toString() {
-      return "BinaryOp{" + "children=" + children + ", op=" + op + ", span=" + span + '}';
+      return "BinaryOp{children=" + children + ", op=" + op + ", span=" + span + '}';
     }
 
     @Override
@@ -598,7 +598,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitTypeCheckExpr(this);
     }
 
@@ -617,7 +617,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitTypeCastExpr(this);
     }
 
@@ -640,7 +640,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       // should never be called
       throw PklBugException.unreachableCode();
     }
@@ -679,7 +679,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       // should never be called
       throw PklBugException.unreachableCode();
     }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Expr.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Expr.java
@@ -23,7 +23,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings({"unchecked", "DataFlowIssue"})
 public abstract sealed class Expr extends AbstractNode {
 
   public Expr(Span span, @Nullable List<? extends @Nullable Node> children) {
@@ -144,6 +143,7 @@ public abstract sealed class Expr extends AbstractNode {
       return visitor.visitSingleLineStringLiteralExpr(this);
     }
 
+    @SuppressWarnings("unchecked")
     public List<StringPart> getParts() {
       assert children != null;
       return (List<StringPart>) children;
@@ -174,7 +174,9 @@ public abstract sealed class Expr extends AbstractNode {
       return visitor.visitMultiLineStringLiteralExpr(this);
     }
 
+    @SuppressWarnings("unchecked")
     public List<StringPart> getParts() {
+      assert children != null;
       return (List<StringPart>) children;
     }
 
@@ -198,6 +200,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
   }
@@ -213,6 +216,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
   }
@@ -231,6 +235,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public StringConstant getImportStr() {
+      assert children != null;
       return (StringConstant) children.get(0);
     }
 
@@ -253,6 +258,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
@@ -279,10 +285,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Identifier getIdentifier() {
+      assert children != null;
       return (Identifier) children.get(0);
     }
 
     public @Nullable ArgumentList getArgumentList() {
+      assert children != null;
       return (ArgumentList) children.get(1);
     }
   }
@@ -306,10 +314,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public Identifier getIdentifier() {
+      assert children != null;
       return (Identifier) children.get(1);
     }
 
@@ -318,6 +328,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public @Nullable ArgumentList getArgumentList() {
+      assert children != null;
       return (ArgumentList) children.get(2);
     }
   }
@@ -333,10 +344,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Identifier getIdentifier() {
+      assert children != null;
       return (Identifier) children.get(0);
     }
 
     public @Nullable ArgumentList getArgumentList() {
+      assert children != null;
       return (ArgumentList) children.get(1);
     }
   }
@@ -352,6 +365,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getArg() {
+      assert children != null;
       return (Expr) children.get(0);
     }
   }
@@ -367,10 +381,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public Expr getArg() {
+      assert children != null;
       return (Expr) children.get(1);
     }
   }
@@ -386,14 +402,17 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getCond() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public Expr getThen() {
+      assert children != null;
       return (Expr) children.get(1);
     }
 
     public Expr getEls() {
+      assert children != null;
       return (Expr) children.get(2);
     }
   }
@@ -409,14 +428,17 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Parameter getParameter() {
+      assert children != null;
       return (Parameter) children.get(0);
     }
 
     public Expr getBindingExpr() {
+      assert children != null;
       return (Expr) children.get(1);
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(2);
     }
   }
@@ -432,10 +454,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public ParameterList getParameterList() {
+      assert children != null;
       return (ParameterList) children.get(0);
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(1);
     }
   }
@@ -451,6 +475,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
   }
@@ -466,10 +491,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public @Nullable Type getType() {
+      assert children != null;
       return (Type) children.get(0);
     }
 
     public ObjectBody getBody() {
+      assert children != null;
       return (ObjectBody) children.get(1);
     }
 
@@ -489,10 +516,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public ObjectBody getBody() {
+      assert children != null;
       return (ObjectBody) children.get(1);
     }
   }
@@ -508,6 +537,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
   }
@@ -523,6 +553,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
   }
@@ -538,6 +569,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
   }
@@ -556,10 +588,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getLeft() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public Expr getRight() {
+      assert children != null;
       return (Expr) children.get(1);
     }
 
@@ -572,6 +606,7 @@ public abstract sealed class Expr extends AbstractNode {
       return "BinaryOp{children=" + children + ", op=" + op + ", span=" + span + '}';
     }
 
+    @SuppressWarnings("ConstantValue")
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -603,10 +638,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public Type getType() {
+      assert children != null;
       return (Type) children.get(1);
     }
   }
@@ -622,10 +659,12 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public Type getType() {
+      assert children != null;
       return (Type) children.get(1);
     }
   }
@@ -654,6 +693,7 @@ public abstract sealed class Expr extends AbstractNode {
       return "OperatorExpr{op=" + op + ", span=" + span + '}';
     }
 
+    @SuppressWarnings("ConstantValue")
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -685,6 +725,7 @@ public abstract sealed class Expr extends AbstractNode {
     }
 
     public Type getType() {
+      assert children != null;
       return (Type) children.get(0);
     }
   }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ImportClause.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ImportClause.java
@@ -21,7 +21,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("DataFlowIssue")
 public final class ImportClause extends AbstractNode {
   private final boolean isGlob;
 
@@ -32,11 +31,12 @@ public final class ImportClause extends AbstractNode {
   }
 
   @Override
-  public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+  public <T> T accept(ParserVisitor<? extends T> visitor) {
     return visitor.visitImportClause(this);
   }
 
   public StringConstant getImportStr() {
+    assert children != null;
     return (StringConstant) children.get(0);
   }
 
@@ -45,6 +45,7 @@ public final class ImportClause extends AbstractNode {
   }
 
   public @Nullable Identifier getAlias() {
+    assert children != null;
     return (Identifier) children.get(1);
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Keyword.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Keyword.java
@@ -15,29 +15,17 @@
  */
 package org.pkl.core.parser.ast;
 
-import java.util.List;
 import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 
-@SuppressWarnings({"unchecked", "DataFlowIssue"})
-public final class ObjectBody extends AbstractNode {
-  private final int membersOffset;
+public class Keyword extends AbstractNode {
 
-  public ObjectBody(List<Node> nodes, int membersOffset, Span span) {
-    super(span, nodes);
-    this.membersOffset = membersOffset;
+  public Keyword(Span span) {
+    super(span, null);
   }
 
   @Override
   public <T> T accept(ParserVisitor<? extends T> visitor) {
-    return visitor.visitObjectBody(this);
-  }
-
-  public List<Parameter> getParameters() {
-    return (List<Parameter>) children.subList(0, membersOffset);
-  }
-
-  public List<ObjectMember> getMembers() {
-    return (List<ObjectMember>) children.subList(membersOffset, children.size());
+    return visitor.visitKeyword(this);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Modifier.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Modifier.java
@@ -18,7 +18,6 @@ package org.pkl.core.parser.ast;
 import java.util.Objects;
 import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
-import org.pkl.core.util.Nullable;
 
 public final class Modifier extends AbstractNode {
   private final ModifierValue value;
@@ -29,7 +28,7 @@ public final class Modifier extends AbstractNode {
   }
 
   @Override
-  public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+  public <T> T accept(ParserVisitor<? extends T> visitor) {
     return visitor.visitModifier(this);
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Module.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Module.java
@@ -21,22 +21,23 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("DataFlowIssue")
 public final class Module extends AbstractNode {
   public Module(List<Node> nodes, Span span) {
     super(span, nodes);
   }
 
   @Override
-  public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+  public <T> T accept(ParserVisitor<? extends T> visitor) {
     return visitor.visitModule(this);
   }
 
   public @Nullable ModuleDecl getDecl() {
+    assert children != null;
     return (ModuleDecl) children.get(0);
   }
 
   public List<ImportClause> getImports() {
+    assert children != null;
     if (children.size() < 2) return List.of();
     var res = new ArrayList<ImportClause>();
     for (int i = 1; i < children.size(); i++) {
@@ -53,6 +54,7 @@ public final class Module extends AbstractNode {
 
   public List<Class> getClasses() {
     var res = new ArrayList<Class>();
+    assert children != null;
     for (var child : children) {
       if (child instanceof Class clazz) {
         res.add(clazz);
@@ -63,6 +65,7 @@ public final class Module extends AbstractNode {
 
   public List<TypeAlias> getTypeAliases() {
     var res = new ArrayList<TypeAlias>();
+    assert children != null;
     for (var child : children) {
       if (child instanceof TypeAlias typeAlias) {
         res.add(typeAlias);
@@ -73,6 +76,7 @@ public final class Module extends AbstractNode {
 
   public List<ClassProperty> getProperties() {
     var res = new ArrayList<ClassProperty>();
+    assert children != null;
     for (var child : children) {
       if (child instanceof ClassProperty classProperty) {
         res.add(classProperty);
@@ -83,6 +87,7 @@ public final class Module extends AbstractNode {
 
   public List<ClassMethod> getMethods() {
     var res = new ArrayList<ClassMethod>();
+    assert children != null;
     for (var child : children) {
       if (child instanceof ClassMethod classMethod) {
         res.add(classMethod);

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ModuleDecl.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ModuleDecl.java
@@ -20,7 +20,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings({"DataFlowIssue", "unchecked"})
 public final class ModuleDecl extends AbstractNode {
   private final int modifiersOffset;
   private final int nameOffset;
@@ -32,36 +31,46 @@ public final class ModuleDecl extends AbstractNode {
   }
 
   @Override
-  public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+  public <T> T accept(ParserVisitor<? extends T> visitor) {
     return visitor.visitModuleDecl(this);
   }
 
   public @Nullable DocComment getDocComment() {
+    assert children != null;
     return (DocComment) children.get(0);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Annotation> getAnnotations() {
+    assert children != null;
     return (List<Annotation>) children.subList(1, modifiersOffset);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Modifier> getModifiers() {
+    assert children != null;
     return (List<Modifier>) children.subList(modifiersOffset, nameOffset);
   }
 
   public @Nullable Keyword getModuleKeyword() {
+    assert children != null;
     return (Keyword) children.get(nameOffset);
   }
 
   public @Nullable QualifiedIdentifier getName() {
+    assert children != null;
     return (QualifiedIdentifier) children.get(nameOffset + 1);
   }
 
   public @Nullable ExtendsOrAmendsClause getExtendsOrAmendsDecl() {
+    assert children != null;
     return (ExtendsOrAmendsClause) children.get(nameOffset + 2);
   }
 
+  @SuppressWarnings("DuplicatedCode")
   public Span headerSpan() {
     Span start = null;
+    assert children != null;
     for (var i = modifiersOffset; i < children.size(); i++) {
       var child = children.get(i);
       if (child != null) {
@@ -70,6 +79,7 @@ public final class ModuleDecl extends AbstractNode {
       }
     }
     var extendsOrAmends = children.get(nameOffset + 2);
+    assert start != null;
     if (extendsOrAmends != null) {
       return start.endWith(extendsOrAmends.span());
     }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ModuleDecl.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ModuleDecl.java
@@ -48,26 +48,31 @@ public final class ModuleDecl extends AbstractNode {
     return (List<Modifier>) children.subList(modifiersOffset, nameOffset);
   }
 
+  public @Nullable Keyword getModuleKeyword() {
+    return (Keyword) children.get(nameOffset);
+  }
+
   public @Nullable QualifiedIdentifier getName() {
-    return (QualifiedIdentifier) children.get(nameOffset);
+    return (QualifiedIdentifier) children.get(nameOffset + 1);
   }
 
   public @Nullable ExtendsOrAmendsClause getExtendsOrAmendsDecl() {
-    return (ExtendsOrAmendsClause) children.get(nameOffset + 1);
+    return (ExtendsOrAmendsClause) children.get(nameOffset + 2);
   }
 
   public Span headerSpan() {
     Span start = null;
-    Span end = null;
     for (var i = modifiersOffset; i < children.size(); i++) {
       var child = children.get(i);
       if (child != null) {
-        if (start == null) {
-          start = child.span();
-        }
-        end = child.span();
+        start = child.span();
+        break;
       }
     }
-    return start.endWith(end);
+    var extendsOrAmends = children.get(nameOffset + 2);
+    if (extendsOrAmends != null) {
+      return start.endWith(extendsOrAmends.span());
+    }
+    return start.endWith(children.get(nameOffset + 1).span());
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ObjectBody.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ObjectBody.java
@@ -19,7 +19,6 @@ import java.util.List;
 import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 
-@SuppressWarnings({"unchecked", "DataFlowIssue"})
 public final class ObjectBody extends AbstractNode {
   private final int membersOffset;
 
@@ -33,11 +32,15 @@ public final class ObjectBody extends AbstractNode {
     return visitor.visitObjectBody(this);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Parameter> getParameters() {
+    assert children != null;
     return (List<Parameter>) children.subList(0, membersOffset);
   }
 
+  @SuppressWarnings("unchecked")
   public List<ObjectMember> getMembers() {
+    assert children != null;
     return (List<ObjectMember>) children.subList(membersOffset, children.size());
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ObjectMember.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ObjectMember.java
@@ -22,7 +22,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("DataFlowIssue")
 public abstract sealed class ObjectMember extends AbstractNode {
 
   public ObjectMember(Span span, @Nullable List<? extends @Nullable Node> children) {
@@ -40,11 +39,11 @@ public abstract sealed class ObjectMember extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
   }
 
-  @SuppressWarnings("unchecked")
   public static final class ObjectProperty extends ObjectMember {
     private final int identifierOffset;
 
@@ -54,27 +53,34 @@ public abstract sealed class ObjectMember extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitObjectProperty(this);
     }
 
+    @SuppressWarnings("unchecked")
     public List<Modifier> getModifiers() {
+      assert children != null;
       return (List<Modifier>) children.subList(0, identifierOffset);
     }
 
     public Identifier getIdentifier() {
+      assert children != null;
       return (Identifier) children.get(identifierOffset);
     }
 
     public @Nullable TypeAnnotation getTypeAnnotation() {
+      assert children != null;
       return (TypeAnnotation) children.get(identifierOffset + 1);
     }
 
     public @Nullable Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(identifierOffset + 2);
     }
 
+    @SuppressWarnings("unchecked")
     public List<ObjectBody> getBodyList() {
+      assert children != null;
       return (List<ObjectBody>) children.subList(identifierOffset + 3, children.size());
     }
   }
@@ -88,42 +94,50 @@ public abstract sealed class ObjectMember extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitObjectMethod(this);
     }
 
     @SuppressWarnings("unchecked")
     public List<Modifier> getModifiers() {
+      assert children != null;
       return (List<Modifier>) children.subList(0, identifierOffset);
     }
 
     public Keyword getFunctionKeyword() {
+      assert children != null;
       return (Keyword) children.get(identifierOffset);
     }
 
     public Identifier getIdentifier() {
+      assert children != null;
       return (Identifier) children.get(identifierOffset + 1);
     }
 
     public @Nullable TypeParameterList getTypeParameterList() {
+      assert children != null;
       return (TypeParameterList) children.get(identifierOffset + 2);
     }
 
     public ParameterList getParamList() {
+      assert children != null;
       return (ParameterList) children.get(identifierOffset + 3);
     }
 
     public @Nullable TypeAnnotation getTypeAnnotation() {
+      assert children != null;
       return (TypeAnnotation) children.get(identifierOffset + 4);
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(identifierOffset + 5);
     }
 
     @SuppressWarnings("DuplicatedCode")
     public Span headerSpan() {
       Span start = null;
+      assert children != null;
       for (var child : children) {
         if (child != null) {
           start = child.span();
@@ -137,6 +151,7 @@ public abstract sealed class ObjectMember extends AbstractNode {
       } else {
         end = typeAnnotation.span();
       }
+      assert start != null;
       return start.endWith(end);
     }
   }
@@ -147,20 +162,23 @@ public abstract sealed class ObjectMember extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitMemberPredicate(this);
     }
 
     public Expr getPred() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public @Nullable Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(1);
     }
 
     @SuppressWarnings("unchecked")
     public List<ObjectBody> getBodyList() {
+      assert children != null;
       return (List<ObjectBody>) children.subList(2, children.size());
     }
   }
@@ -171,20 +189,23 @@ public abstract sealed class ObjectMember extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitObjectEntry(this);
     }
 
     public Expr getKey() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public @Nullable Expr getValue() {
+      assert children != null;
       return (Expr) children.get(1);
     }
 
     @SuppressWarnings("unchecked")
     public List<ObjectBody> getBodyList() {
+      assert children != null;
       return (List<ObjectBody>) children.subList(2, children.size());
     }
   }
@@ -198,11 +219,12 @@ public abstract sealed class ObjectMember extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitObjectSpread(this);
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
@@ -222,6 +244,7 @@ public abstract sealed class ObjectMember extends AbstractNode {
           + '}';
     }
 
+    @SuppressWarnings("ConstantValue")
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -250,19 +273,22 @@ public abstract sealed class ObjectMember extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitWhenGenerator(this);
     }
 
     public Expr getPredicate() {
+      assert children != null;
       return (Expr) children.get(0);
     }
 
     public ObjectBody getThenClause() {
+      assert children != null;
       return (ObjectBody) children.get(1);
     }
 
     public @Nullable ObjectBody getElseClause() {
+      assert children != null;
       return (ObjectBody) children.get(2);
     }
   }
@@ -274,23 +300,27 @@ public abstract sealed class ObjectMember extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitForGenerator(this);
     }
 
     public Parameter getP1() {
+      assert children != null;
       return (Parameter) children.get(0);
     }
 
     public @Nullable Parameter getP2() {
+      assert children != null;
       return (Parameter) children.get(1);
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(2);
     }
 
     public ObjectBody getBody() {
+      assert children != null;
       return (ObjectBody) children.get(3);
     }
 

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Parameter.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Parameter.java
@@ -21,7 +21,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("ALL")
 public abstract sealed class Parameter extends AbstractNode {
 
   public Parameter(Span span, @Nullable List<? extends @Nullable Node> children) {
@@ -46,10 +45,12 @@ public abstract sealed class Parameter extends AbstractNode {
     }
 
     public Identifier getIdentifier() {
+      assert children != null;
       return (Identifier) children.get(0);
     }
 
     public @Nullable TypeAnnotation getTypeAnnotation() {
+      assert children != null;
       return (TypeAnnotation) children.get(1);
     }
   }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/ParameterList.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/ParameterList.java
@@ -20,7 +20,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("unchecked")
 public class ParameterList extends AbstractNode {
   public ParameterList(List<Parameter> parameters, Span span) {
     super(span, parameters);
@@ -31,6 +30,7 @@ public class ParameterList extends AbstractNode {
     return visitor.visitParameterList(this);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Parameter> getParameters() {
     assert children != null;
     return (List<Parameter>) children;

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/QualifiedIdentifier.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/QualifiedIdentifier.java
@@ -18,7 +18,6 @@ package org.pkl.core.parser.ast;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.pkl.core.parser.ParserVisitor;
-import org.pkl.core.util.Nullable;
 
 public final class QualifiedIdentifier extends AbstractNode {
   public QualifiedIdentifier(List<Identifier> identifiers) {
@@ -27,12 +26,13 @@ public final class QualifiedIdentifier extends AbstractNode {
   }
 
   @Override
-  public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+  public <T> T accept(ParserVisitor<? extends T> visitor) {
     return visitor.visitQualifiedIdentifier(this);
   }
 
-  @SuppressWarnings({"unchecked", "DataFlowIssue"})
+  @SuppressWarnings("unchecked")
   public List<Identifier> getIdentifiers() {
+    assert children != null;
     return (List<Identifier>) children;
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/StringConstantPart.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/StringConstantPart.java
@@ -21,7 +21,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("ALL")
 public abstract sealed class StringConstantPart extends AbstractNode {
 
   public StringConstantPart(Span span, @Nullable List<? extends @Nullable Node> children) {
@@ -56,6 +55,7 @@ public abstract sealed class StringConstantPart extends AbstractNode {
       return "ConstantPart{str='" + str + '\'' + ", span=" + span + '}';
     }
 
+    @SuppressWarnings("ConstantValue")
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -91,6 +91,7 @@ public abstract sealed class StringConstantPart extends AbstractNode {
       return "StringUnicodeEscape{escape='" + escape + '\'' + ", span=" + span + '}';
     }
 
+    @SuppressWarnings("ConstantValue")
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -126,6 +127,7 @@ public abstract sealed class StringConstantPart extends AbstractNode {
       return "StringEscape{type=" + type + ", span=" + span + '}';
     }
 
+    @SuppressWarnings("ConstantValue")
     @Override
     public boolean equals(Object o) {
       if (this == o) {

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/StringPart.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/StringPart.java
@@ -20,7 +20,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("ALL")
 public abstract sealed class StringPart extends AbstractNode {
 
   public StringPart(Span span, @Nullable List<? extends @Nullable Node> children) {
@@ -37,7 +36,9 @@ public abstract sealed class StringPart extends AbstractNode {
       super(span, parts);
     }
 
+    @SuppressWarnings("unchecked")
     public List<StringConstantPart> getParts() {
+      assert children != null;
       return (List<StringConstantPart>) children;
     }
   }
@@ -48,6 +49,7 @@ public abstract sealed class StringPart extends AbstractNode {
     }
 
     public Expr getExpr() {
+      assert children != null;
       return (Expr) children.get(0);
     }
   }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Type.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Type.java
@@ -22,7 +22,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("ALL")
 public abstract sealed class Type extends AbstractNode {
 
   public Type(Span span, @Nullable List<? extends @Nullable Node> children) {
@@ -35,7 +34,7 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitUnknownType(this);
     }
   }
@@ -46,7 +45,7 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitNothingType(this);
     }
   }
@@ -57,7 +56,7 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitModuleType(this);
     }
   }
@@ -68,11 +67,12 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitStringConstantType(this);
     }
 
     public StringConstant getStr() {
+      assert children != null;
       return (StringConstant) children.get(0);
     }
   }
@@ -83,15 +83,17 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitDeclaredType(this);
     }
 
     public QualifiedIdentifier getName() {
+      assert children != null;
       return (QualifiedIdentifier) children.get(0);
     }
 
     public @Nullable TypeArgumentList getArgs() {
+      assert children != null;
       return (TypeArgumentList) children.get(1);
     }
   }
@@ -102,11 +104,12 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitParenthesizedType(this);
     }
 
     public Type getType() {
+      assert children != null;
       return (Type) children.get(0);
     }
   }
@@ -117,11 +120,12 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitNullableType(this);
     }
 
     public Type getType() {
+      assert children != null;
       return (Type) children.get(0);
     }
   }
@@ -132,15 +136,18 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitConstrainedType(this);
     }
 
     public Type getType() {
+      assert children != null;
       return (Type) children.get(0);
     }
 
+    @SuppressWarnings("unchecked")
     public List<Expr> getExprs() {
+      assert children != null;
       return (List<Expr>) children.subList(1, children.size());
     }
   }
@@ -154,11 +161,13 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitUnionType(this);
     }
 
+    @SuppressWarnings("unchecked")
     public List<Type> getTypes() {
+      assert children != null;
       return (List<Type>) children;
     }
 
@@ -178,6 +187,7 @@ public abstract sealed class Type extends AbstractNode {
           + '}';
     }
 
+    @SuppressWarnings("ConstantValue")
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -205,15 +215,18 @@ public abstract sealed class Type extends AbstractNode {
     }
 
     @Override
-    public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+    public <T> T accept(ParserVisitor<? extends T> visitor) {
       return visitor.visitFunctionType(this);
     }
 
+    @SuppressWarnings("unchecked")
     public List<Type> getArgs() {
+      assert children != null;
       return (List<Type>) children.subList(0, children.size() - 1);
     }
 
     public Type getRet() {
+      assert children != null;
       return (Type) children.get(children.size() - 1);
     }
   }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/Type.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/Type.java
@@ -15,6 +15,7 @@
  */
 package org.pkl.core.parser.ast;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.pkl.core.parser.ParserVisitor;
@@ -77,8 +78,8 @@ public abstract sealed class Type extends AbstractNode {
   }
 
   public static final class DeclaredType extends Type {
-    public DeclaredType(List<Node> nodes, Span span) {
-      super(span, nodes);
+    public DeclaredType(QualifiedIdentifier name, @Nullable TypeArgumentList typeArgs, Span span) {
+      super(span, Arrays.asList(name, typeArgs));
     }
 
     @Override
@@ -90,8 +91,8 @@ public abstract sealed class Type extends AbstractNode {
       return (QualifiedIdentifier) children.get(0);
     }
 
-    public List<Type> getArgs() {
-      return (List<Type>) children.subList(1, children.size());
+    public @Nullable TypeArgumentList getArgs() {
+      return (TypeArgumentList) children.get(1);
     }
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeAlias.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeAlias.java
@@ -20,7 +20,7 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings("ALL")
+@SuppressWarnings({"unchecked", "DataFlowIssue"})
 public final class TypeAlias extends AbstractNode {
   private final int modifiersOffset;
   private final int nameOffset;
@@ -32,7 +32,7 @@ public final class TypeAlias extends AbstractNode {
   }
 
   @Override
-  public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+  public <T> T accept(ParserVisitor<? extends T> visitor) {
     return visitor.visitTypeAlias(this);
   }
 
@@ -48,24 +48,36 @@ public final class TypeAlias extends AbstractNode {
     return (List<Modifier>) children.subList(modifiersOffset, nameOffset);
   }
 
+  public Keyword getTypealiasKeyword() {
+    return (Keyword) children.get(nameOffset);
+  }
+
   public Identifier getName() {
-    return (Identifier) children.get(nameOffset);
+    return (Identifier) children.get(nameOffset + 1);
   }
 
   public @Nullable TypeParameterList getTypeParameterList() {
-    return (TypeParameterList) children.get(nameOffset + 1);
+    return (TypeParameterList) children.get(nameOffset + 2);
   }
 
   public Type getType() {
-    return (Type) children.get(nameOffset + 2);
+    return (Type) children.get(nameOffset + 3);
   }
 
   public Span getHeaderSpan() {
-    var end = children.get(nameOffset).span();
-    var tparList = children.get(nameOffset + 1);
+    Span start = null;
+    for (var i = modifiersOffset; i < children.size(); i++) {
+      var child = children.get(i);
+      if (child != null) {
+        start = child.span();
+        break;
+      }
+    }
+    var end = children.get(nameOffset + 1).span();
+    var tparList = children.get(nameOffset + 2);
     if (tparList != null) {
       end = tparList.span();
     }
-    return span.endWith(end);
+    return start.endWith(end);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeAlias.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeAlias.java
@@ -20,7 +20,6 @@ import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 import org.pkl.core.util.Nullable;
 
-@SuppressWarnings({"unchecked", "DataFlowIssue"})
 public final class TypeAlias extends AbstractNode {
   private final int modifiersOffset;
   private final int nameOffset;
@@ -37,35 +36,46 @@ public final class TypeAlias extends AbstractNode {
   }
 
   public @Nullable DocComment getDocComment() {
+    assert children != null;
     return (DocComment) children.get(0);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Annotation> getAnnotations() {
+    assert children != null;
     return (List<Annotation>) children.subList(1, modifiersOffset);
   }
 
+  @SuppressWarnings("unchecked")
   public List<Modifier> getModifiers() {
+    assert children != null;
     return (List<Modifier>) children.subList(modifiersOffset, nameOffset);
   }
 
   public Keyword getTypealiasKeyword() {
+    assert children != null;
     return (Keyword) children.get(nameOffset);
   }
 
   public Identifier getName() {
+    assert children != null;
     return (Identifier) children.get(nameOffset + 1);
   }
 
   public @Nullable TypeParameterList getTypeParameterList() {
+    assert children != null;
     return (TypeParameterList) children.get(nameOffset + 2);
   }
 
   public Type getType() {
+    assert children != null;
     return (Type) children.get(nameOffset + 3);
   }
 
+  @SuppressWarnings("DuplicatedCode")
   public Span getHeaderSpan() {
     Span start = null;
+    assert children != null;
     for (var i = modifiersOffset; i < children.size(); i++) {
       var child = children.get(i);
       if (child != null) {
@@ -78,6 +88,7 @@ public final class TypeAlias extends AbstractNode {
     if (tparList != null) {
       end = tparList.span();
     }
+    assert start != null;
     return start.endWith(end);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeArgumentList.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeArgumentList.java
@@ -19,25 +19,20 @@ import java.util.List;
 import org.pkl.core.parser.ParserVisitor;
 import org.pkl.core.parser.Span;
 
-@SuppressWarnings({"unchecked", "DataFlowIssue"})
-public final class ObjectBody extends AbstractNode {
-  private final int membersOffset;
+public class TypeArgumentList extends AbstractNode {
 
-  public ObjectBody(List<Node> nodes, int membersOffset, Span span) {
-    super(span, nodes);
-    this.membersOffset = membersOffset;
+  public TypeArgumentList(List<Type> children, Span span) {
+    super(span, children);
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<Type> getTypes() {
+    assert children != null;
+    return (List<Type>) children;
   }
 
   @Override
   public <T> T accept(ParserVisitor<? extends T> visitor) {
-    return visitor.visitObjectBody(this);
-  }
-
-  public List<Parameter> getParameters() {
-    return (List<Parameter>) children.subList(0, membersOffset);
-  }
-
-  public List<ObjectMember> getMembers() {
-    return (List<ObjectMember>) children.subList(membersOffset, children.size());
+    return visitor.visitTypeArgumentList(this);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeParameter.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeParameter.java
@@ -55,6 +55,7 @@ public final class TypeParameter extends AbstractNode {
         + '}';
   }
 
+  @SuppressWarnings("ConstantValue")
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeParameter.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/ast/TypeParameter.java
@@ -30,7 +30,7 @@ public final class TypeParameter extends AbstractNode {
   }
 
   @Override
-  public <T> @Nullable T accept(ParserVisitor<? extends T> visitor) {
+  public <T> T accept(ParserVisitor<? extends T> visitor) {
     return visitor.visitTypeParameter(this);
   }
 

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/projects/badPklProject1/bug.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/projects/badPklProject1/bug.err
@@ -2,7 +2,7 @@
 Expected `output.value` of module `file:///$snippetsDir/input/projects/badPklProject1/PklProject` to be of type `pkl.Project`, but got type `invalid.project.Module`.
 
 x | module invalid.project.Module
-           ^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at invalid.project.Module (file:///$snippetsDir/input/projects/badPklProject1/PklProject)
 
 Try adding `amends "pkl:Project"` to the module header.

--- a/pkl-core/src/test/kotlin/org/pkl/core/parser/ANTLRSexpRenderer.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/parser/ANTLRSexpRenderer.kt
@@ -356,10 +356,20 @@ class ANTLRSexpRenderer {
     renderQualifiedIdent(type.qualifiedIdentifier())
     val args = type.typeArgumentList()
     if (args != null) {
-      for (arg in args.type()) {
-        buf.append('\n')
-        renderType(arg)
-      }
+      buf.append('\n')
+      renderTypeArgumentList(args)
+    }
+    buf.append(')')
+    tab = oldTab
+  }
+
+  fun renderTypeArgumentList(ctx: TypeArgumentListContext) {
+    buf.append(tab)
+    buf.append("(typeArgumentList")
+    val oldTab = increaseTab()
+    for (arg in ctx.type()) {
+      buf.append('\n')
+      renderType(arg)
     }
     buf.append(')')
     tab = oldTab
@@ -420,21 +430,6 @@ class ANTLRSexpRenderer {
     }
     buf.append(')')
     tab = oldTab
-  }
-
-  private fun flattenUnion(type: UnionTypeContext): List<TypeContext> {
-    val types = mutableListOf<TypeContext>()
-    val toCheck = mutableListOf(type.l, type.r)
-    while (toCheck.isNotEmpty()) {
-      val typ = toCheck.removeAt(0)
-      if (typ is UnionTypeContext) {
-        toCheck.add(0, typ.r)
-        toCheck.add(0, typ.l)
-      } else {
-        types += typ
-      }
-    }
-    return types
   }
 
   fun renderFunctionType(type: FunctionTypeContext) {
@@ -1053,6 +1048,21 @@ class ANTLRSexpRenderer {
       res += body.classMethod()
       res.sortWith(compareBy { it.sourceInterval.a })
       return res
+    }
+
+    fun flattenUnion(type: UnionTypeContext): List<TypeContext> {
+      val types = mutableListOf<TypeContext>()
+      val toCheck = mutableListOf(type.l, type.r)
+      while (toCheck.isNotEmpty()) {
+        val typ = toCheck.removeAt(0)
+        if (typ is UnionTypeContext) {
+          toCheck.add(0, typ.r)
+          toCheck.add(0, typ.l)
+        } else {
+          types += typ
+        }
+      }
+      return types
     }
   }
 }

--- a/pkl-core/src/test/kotlin/org/pkl/core/parser/SexpRenderer.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/parser/SexpRenderer.kt
@@ -763,7 +763,19 @@ class SexpRenderer {
     val oldTab = increaseTab()
     buf.append('\n')
     renderQualifiedIdent(type.name)
-    for (arg in type.args) {
+    if (type.args !== null) {
+      buf.append('\n')
+      renderTypeArgumentList(type.args!!)
+    }
+    buf.append(')')
+    tab = oldTab
+  }
+
+  fun renderTypeArgumentList(typeArgumentList: TypeArgumentList) {
+    buf.append(tab)
+    buf.append("(typeArgumentList")
+    val oldTab = increaseTab()
+    for (arg in typeArgumentList.types) {
       buf.append('\n')
       renderType(arg)
     }
@@ -976,9 +988,9 @@ class SexpRenderer {
     buf.append("(whenGenerator")
     val oldTab = increaseTab()
     buf.append('\n')
-    renderExpr(generator.thenClause)
+    renderExpr(generator.predicate)
     buf.append('\n')
-    renderObjectBody(generator.body)
+    renderObjectBody(generator.thenClause)
     if (generator.elseClause !== null) {
       buf.append('\n')
       renderObjectBody(generator.elseClause!!)

--- a/pkl-core/src/test/kotlin/org/pkl/core/parser/SpanComparison.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/parser/SpanComparison.kt
@@ -1,0 +1,463 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.parser
+
+import org.antlr.v4.runtime.ParserRuleContext
+import org.antlr.v4.runtime.tree.TerminalNode
+import org.assertj.core.api.SoftAssertions
+import org.pkl.core.parser.antlr.PklParser.*
+import org.pkl.core.parser.ast.*
+import org.pkl.core.parser.ast.Annotation
+import org.pkl.core.parser.ast.Expr.AmendsExpr
+import org.pkl.core.parser.ast.Expr.BinaryOperatorExpr
+import org.pkl.core.parser.ast.Expr.FunctionLiteralExpr
+import org.pkl.core.parser.ast.Expr.IfExpr
+import org.pkl.core.parser.ast.Expr.ImportExpr
+import org.pkl.core.parser.ast.Expr.LetExpr
+import org.pkl.core.parser.ast.Expr.LogicalNotExpr
+import org.pkl.core.parser.ast.Expr.MultiLineStringLiteralExpr
+import org.pkl.core.parser.ast.Expr.NewExpr
+import org.pkl.core.parser.ast.Expr.NonNullExpr
+import org.pkl.core.parser.ast.Expr.ParenthesizedExpr
+import org.pkl.core.parser.ast.Expr.QualifiedAccessExpr
+import org.pkl.core.parser.ast.Expr.ReadExpr
+import org.pkl.core.parser.ast.Expr.SingleLineStringLiteralExpr
+import org.pkl.core.parser.ast.Expr.SubscriptExpr
+import org.pkl.core.parser.ast.Expr.SuperAccessExpr
+import org.pkl.core.parser.ast.Expr.SuperSubscriptExpr
+import org.pkl.core.parser.ast.Expr.ThrowExpr
+import org.pkl.core.parser.ast.Expr.TraceExpr
+import org.pkl.core.parser.ast.Expr.TypeCastExpr
+import org.pkl.core.parser.ast.Expr.TypeCheckExpr
+import org.pkl.core.parser.ast.Expr.UnaryMinusExpr
+import org.pkl.core.parser.ast.Expr.UnqualifiedAccessExpr
+import org.pkl.core.parser.ast.ObjectMember.ForGenerator
+import org.pkl.core.parser.ast.ObjectMember.MemberPredicate
+import org.pkl.core.parser.ast.ObjectMember.ObjectElement
+import org.pkl.core.parser.ast.ObjectMember.ObjectEntry
+import org.pkl.core.parser.ast.ObjectMember.ObjectMethod
+import org.pkl.core.parser.ast.ObjectMember.ObjectProperty
+import org.pkl.core.parser.ast.ObjectMember.ObjectSpread
+import org.pkl.core.parser.ast.ObjectMember.WhenGenerator
+import org.pkl.core.parser.ast.Parameter.TypedIdentifier
+import org.pkl.core.parser.ast.Type.ConstrainedType
+import org.pkl.core.parser.ast.Type.DeclaredType
+import org.pkl.core.parser.ast.Type.FunctionType
+import org.pkl.core.parser.ast.Type.NullableType
+import org.pkl.core.parser.ast.Type.ParenthesizedType
+import org.pkl.core.parser.ast.Type.StringConstantType
+import org.pkl.core.parser.ast.Type.UnionType
+
+class SpanComparison(val path: String, private val softly: SoftAssertions) {
+
+  fun compare(module: Module, modCtx: ModuleContext) {
+    compareSpan(module, modCtx)
+    if (module.decl !== null) {
+      compareModuleDecl(module.decl!!, modCtx.moduleDecl())
+    }
+    module.imports.zip(modCtx.importClause()).forEach { (i1, i2) -> compareImport(i1, i2) }
+    module.classes.zip(modCtx.clazz()).forEach { (class1, class2) -> compareClass(class1, class2) }
+    module.typeAliases.zip(modCtx.typeAlias()).forEach { (ta1, ta2) -> compareTypealias(ta1, ta2) }
+    module.properties.zip(modCtx.classProperty()).forEach { (prop1, prop2) ->
+      compareProperty(prop1, prop2)
+    }
+    module.methods.zip(modCtx.classMethod()).forEach { (m1, m2) -> compareMethod(m1, m2) }
+  }
+
+  private fun compareModuleDecl(node: ModuleDecl, ctx: ModuleDeclContext) {
+    compareSpan(node, ctx)
+    compareDocComment(node.docComment, ctx.DocComment())
+    node.annotations.zip(ctx.annotation()).forEach { (a1, a2) -> compareAnnotation(a1, a2) }
+    val header = ctx.moduleHeader()
+    node.modifiers.zip(header.modifier()).forEach { (m1, m2) -> compareSpan(m1, m2) }
+    compareQualifiedIdentifier(node.name, header.qualifiedIdentifier())
+    compareExtendsOrAmendsClause(node.extendsOrAmendsDecl, header.moduleExtendsOrAmendsClause())
+  }
+
+  private fun compareImport(node: ImportClause, ctx: ImportClauseContext) {
+    compareSpan(node, ctx)
+    compareSpan(node.importStr, ctx.stringConstant())
+    compareSpan(node.alias, ctx.Identifier())
+  }
+
+  private fun compareClass(node: Class, ctx: ClazzContext) {
+    compareSpan(node, ctx)
+    compareDocComment(node.docComment, ctx.DocComment())
+    node.annotations.zip(ctx.annotation()).forEach { (a1, a2) -> compareAnnotation(a1, a2) }
+    val header = ctx.classHeader()
+    node.modifiers.zip(header.modifier()).forEach { (m1, m2) -> compareSpan(m1, m2) }
+    compareSpan(node.classKeyword, header.CLASS())
+    compareSpan(node.name, header.Identifier())
+    compareTypeParameterList(node.typeParameterList, header.typeParameterList())
+    compareType(node.superClass, header.type())
+    compareClassBody(node.body, ctx.classBody())
+    compareSpan(node.headerSpan, header)
+  }
+
+  private fun compareTypealias(node: TypeAlias, ctx: TypeAliasContext) {
+    compareSpan(node, ctx)
+    compareDocComment(node.docComment, ctx.DocComment())
+    node.annotations.zip(ctx.annotation()).forEach { (a1, a2) -> compareAnnotation(a1, a2) }
+    val header = ctx.typeAliasHeader()
+    node.modifiers.zip(header.modifier()).forEach { (m1, m2) -> compareSpan(m1, m2) }
+    compareSpan(node.typealiasKeyword, header.TYPE_ALIAS())
+    compareSpan(node.name, header.Identifier())
+    compareTypeParameterList(node.typeParameterList, header.typeParameterList())
+    compareType(node.type, ctx.type())
+    compareSpan(node.headerSpan, header)
+  }
+
+  private fun compareProperty(node: ClassProperty, ctx: ClassPropertyContext) {
+    if (node.docComment === null) {
+      compareSpan(node, ctx)
+    }
+    compareDocComment(node.docComment, ctx.DocComment())
+    node.annotations.zip(ctx.annotation()).forEach { (a1, a2) -> compareAnnotation(a1, a2) }
+    node.modifiers.zip(ctx.modifier()).forEach { (m1, m2) -> compareSpan(m1, m2) }
+    compareSpan(node.name, ctx.Identifier())
+    compareTypeAnnotation(node.typeAnnotation, ctx.typeAnnotation())
+    compareExpr(node.expr, ctx.expr())
+    node.bodyList.zip(ctx.objectBody()).forEach { (b1, b2) -> compareObjectBody(b1, b2) }
+  }
+
+  private fun compareMethod(node: ClassMethod, ctx: ClassMethodContext) {
+    compareSpan(node, ctx)
+    compareDocComment(node.docComment, ctx.DocComment())
+    node.annotations.zip(ctx.annotation()).forEach { (a1, a2) -> compareAnnotation(a1, a2) }
+    val header = ctx.methodHeader()
+    compareSpan(node.headerSpan, header)
+    node.modifiers.zip(header.modifier()).forEach { (m1, m2) -> compareSpan(m1, m2) }
+    compareSpan(node.name, header.Identifier())
+    compareTypeParameterList(node.typeParameterList, header.typeParameterList())
+    compareParameterList(node.parameterList, header.parameterList())
+    compareTypeAnnotation(node.typeAnnotation, header.typeAnnotation())
+    compareExpr(node.expr, ctx.expr())
+  }
+
+  private fun compareAnnotation(node: Annotation, ctx: AnnotationContext) {
+    compareSpan(node, ctx)
+    compareType(node.type, ctx.type())
+    compareObjectBody(node.body, ctx.objectBody())
+  }
+
+  private fun compareParameterList(node: ParameterList?, ctx: ParameterListContext?) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    node.parameters.zip(ctx.parameter()).forEach { (p1, p2) -> compareParameter(p1, p2) }
+  }
+
+  private fun compareParameter(node: Parameter?, ctx: ParameterContext?) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    if (node is TypedIdentifier) {
+      val tident = ctx.typedIdentifier()
+      compareSpan(node.identifier, tident.Identifier())
+      compareTypeAnnotation(node.typeAnnotation, tident.typeAnnotation())
+    }
+  }
+
+  private fun compareTypeParameterList(node: TypeParameterList?, ctx: TypeParameterListContext?) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    node.parameters.zip(ctx.typeParameter()).forEach { (p1, p2) -> compareTypeParameter(p1, p2) }
+  }
+
+  private fun compareTypeParameter(node: TypeParameter, ctx: TypeParameterContext) {
+    compareSpan(node, ctx)
+    compareSpan(node.identifier, ctx.Identifier())
+  }
+
+  private fun compareClassBody(node: ClassBody?, ctx: ClassBodyContext?) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    node.properties.zip(ctx.classProperty()).forEach { (p1, p2) -> compareProperty(p1, p2) }
+    node.methods.zip(ctx.classMethod()).forEach { (m1, m2) -> compareMethod(m1, m2) }
+  }
+
+  private fun compareTypeAnnotation(node: TypeAnnotation?, ctx: TypeAnnotationContext?) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    compareSpan(node.type, ctx.type())
+  }
+
+  private fun compareObjectBody(node: ObjectBody?, ctx: ObjectBodyContext?) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    node.parameters.zip(ctx.parameter()).forEach { (p1, p2) -> compareParameter(p1, p2) }
+    node.members.zip(ctx.objectMember()).forEach { (m1, m2) -> compareObjectMember(m1, m2) }
+  }
+
+  private fun compareType(node: Type?, actx: TypeContext?) {
+    if (node === null) return
+    val ctx = if (actx is DefaultUnionTypeContext) actx.type() else actx
+    compareSpan(node, ctx!!)
+    when (node) {
+      is StringConstantType ->
+        compareSpan(node.str, (ctx as StringLiteralTypeContext).stringConstant())
+      is DeclaredType -> {
+        val decl = ctx as DeclaredTypeContext
+        compareQualifiedIdentifier(node.name, decl.qualifiedIdentifier())
+        compareTypeArgumentList(node.args, ctx.typeArgumentList())
+      }
+      is ParenthesizedType -> compareType(node.type, (ctx as ParenthesizedTypeContext).type())
+      is NullableType -> compareType(node.type, (ctx as NullableTypeContext).type())
+      is ConstrainedType -> {
+        val cons = ctx as ConstrainedTypeContext
+        compareType(node.type, cons.type())
+        node.exprs.zip(cons.expr()).forEach { (e1, e2) -> compareExpr(e1, e2) }
+      }
+      is UnionType -> {
+        val flattened = ANTLRSexpRenderer.flattenUnion(ctx as UnionTypeContext)
+        node.types.zip(flattened).forEach { (t1, t2) -> compareType(t1, t2) }
+      }
+      is FunctionType -> {
+        val func = ctx as FunctionTypeContext
+        node.args.zip(func.ps).forEach { (t1, t2) -> compareType(t1, t2) }
+        compareType(node.ret, func.r)
+      }
+      else -> {}
+    }
+  }
+
+  private fun compareObjectMember(node: ObjectMember, ctx: ObjectMemberContext) {
+    compareSpan(node, ctx)
+    when (node) {
+      is ObjectElement -> compareExpr(node.expr, (ctx as ObjectElementContext).expr())
+      is ObjectProperty -> {
+        ctx as ObjectPropertyContext
+        node.modifiers.zip(ctx.modifier()).forEach { (m1, m2) -> compareSpan(m1, m2) }
+        compareSpan(node.identifier, ctx.Identifier())
+        compareTypeAnnotation(node.typeAnnotation, ctx.typeAnnotation())
+        compareExpr(node.expr, ctx.expr())
+        if (node.bodyList.isNotEmpty()) {
+          node.bodyList.zip(ctx.objectBody()).forEach { (b1, b2) -> compareObjectBody(b1, b2) }
+        }
+      }
+      is ObjectMethod -> {
+        ctx as ObjectMethodContext
+        val header = ctx.methodHeader()
+        node.modifiers.zip(header.modifier()).forEach { (m1, m2) -> compareSpan(m1, m2) }
+        compareSpan(node.functionKeyword, header.FUNCTION())
+        compareSpan(node.identifier, header.Identifier())
+        compareTypeParameterList(node.typeParameterList, header.typeParameterList())
+        compareParameterList(node.paramList, header.parameterList())
+        compareTypeAnnotation(node.typeAnnotation, header.typeAnnotation())
+        compareExpr(node.expr, ctx.expr())
+        compareSpan(node.headerSpan(), header)
+      }
+      is MemberPredicate -> {
+        ctx as MemberPredicateContext
+        compareExpr(node.pred, ctx.k)
+        compareExpr(node.expr, ctx.v)
+        if (node.bodyList.isNotEmpty()) {
+          node.bodyList.zip(ctx.objectBody()).forEach { (b1, b2) -> compareObjectBody(b1, b2) }
+        }
+      }
+      is ObjectEntry -> {
+        ctx as ObjectEntryContext
+        compareExpr(node.key, ctx.k)
+        compareExpr(node.value, ctx.v)
+        if (node.bodyList.isNotEmpty()) {
+          node.bodyList.zip(ctx.objectBody()).forEach { (b1, b2) -> compareObjectBody(b1, b2) }
+        }
+      }
+      is ObjectSpread -> compareExpr(node.expr, (ctx as ObjectSpreadContext).expr())
+      is WhenGenerator -> {
+        ctx as WhenGeneratorContext
+        compareExpr(node.predicate, ctx.expr())
+        compareObjectBody(node.thenClause, ctx.b1)
+        compareObjectBody(node.elseClause, ctx.b2)
+      }
+      is ForGenerator -> {
+        ctx as ForGeneratorContext
+        compareParameter(node.p1, ctx.t1)
+        compareParameter(node.p2, ctx.t2)
+        compareExpr(node.expr, ctx.expr())
+        compareObjectBody(node.body, ctx.objectBody())
+      }
+    }
+  }
+
+  private fun compareExpr(node: Expr?, ctx: ExprContext?) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    when (node) {
+      is SingleLineStringLiteralExpr -> {
+        node.parts.zip((ctx as SingleLineStringLiteralContext).singleLineStringPart()).forEach {
+          (s1, s2) ->
+          compareSpan(s1, s2)
+        }
+      }
+      is MultiLineStringLiteralExpr -> {
+        node.parts.zip((ctx as MultiLineStringLiteralContext).multiLineStringPart()).forEach {
+          (s1, s2) ->
+          compareSpan(s1, s2)
+        }
+      }
+      is ThrowExpr -> compareExpr(node.expr, (ctx as ThrowExprContext).expr())
+      is TraceExpr -> compareExpr(node.expr, (ctx as TraceExprContext).expr())
+      is ImportExpr -> compareSpan(node.importStr, (ctx as ImportExprContext).stringConstant())
+      is ReadExpr -> compareExpr(node.expr, (ctx as ReadExprContext).expr())
+      is UnqualifiedAccessExpr -> {
+        ctx as UnqualifiedAccessExprContext
+        compareSpan(node.identifier, ctx.Identifier())
+        compareArgumentList(node.argumentList, ctx.argumentList())
+      }
+      is QualifiedAccessExpr -> {
+        ctx as QualifiedAccessExprContext
+        compareExpr(node.expr, ctx.expr())
+        compareSpan(node.identifier, ctx.Identifier())
+        compareArgumentList(node.argumentList, ctx.argumentList())
+      }
+      is SuperAccessExpr -> {
+        ctx as SuperAccessExprContext
+        compareSpan(node.identifier, ctx.Identifier())
+        compareArgumentList(node.argumentList, ctx.argumentList())
+      }
+      is SuperSubscriptExpr -> compareExpr(node.arg, (ctx as SuperSubscriptExprContext).expr())
+      is SubscriptExpr -> {
+        ctx as SubscriptExprContext
+        compareExpr(node.expr, ctx.l)
+        compareExpr(node.arg, ctx.r)
+      }
+      is IfExpr -> {
+        ctx as IfExprContext
+        compareExpr(node.cond, ctx.c)
+        compareExpr(node.then, ctx.l)
+        compareExpr(node.els, ctx.r)
+      }
+      is LetExpr -> {
+        ctx as LetExprContext
+        compareParameter(node.parameter, ctx.parameter())
+        compareExpr(node.bindingExpr, ctx.l)
+        compareExpr(node.expr, ctx.r)
+      }
+      is FunctionLiteralExpr -> {
+        ctx as FunctionLiteralContext
+        compareParameterList(node.parameterList, ctx.parameterList())
+        compareExpr(node.expr, ctx.expr())
+      }
+      is ParenthesizedExpr -> compareExpr(node.expr, (ctx as ParenthesizedExprContext).expr())
+      is NewExpr -> {
+        ctx as NewExprContext
+        compareType(node.type, ctx.type())
+        compareObjectBody(node.body, ctx.objectBody())
+      }
+      is AmendsExpr -> {
+        ctx as AmendExprContext
+        compareExpr(node.expr, ctx.expr())
+        compareObjectBody(node.body, ctx.objectBody())
+      }
+      is NonNullExpr -> compareExpr(node.expr, (ctx as NonNullExprContext).expr())
+      is UnaryMinusExpr -> compareExpr(node.expr, (ctx as UnaryMinusExprContext).expr())
+      is LogicalNotExpr -> compareExpr(node.expr, (ctx as LogicalNotExprContext).expr())
+      is BinaryOperatorExpr -> {
+        val (l, r) =
+          when (ctx) {
+            is ExponentiationExprContext -> ctx.l to ctx.r
+            is MultiplicativeExprContext -> ctx.l to ctx.r
+            is AdditiveExprContext -> ctx.l to ctx.r
+            is ComparisonExprContext -> ctx.l to ctx.r
+            is EqualityExprContext -> ctx.l to ctx.r
+            is LogicalAndExprContext -> ctx.l to ctx.r
+            is LogicalOrExprContext -> ctx.l to ctx.r
+            is PipeExprContext -> ctx.l to ctx.r
+            is NullCoalesceExprContext -> ctx.l to ctx.r
+            else -> throw RuntimeException("unreacheable code")
+          }
+        compareExpr(node.left, l)
+        compareExpr(node.right, r)
+      }
+      is TypeCheckExpr -> {
+        ctx as TypeTestExprContext
+        compareExpr(node.expr, ctx.expr())
+        compareType(node.type, ctx.type())
+      }
+      is TypeCastExpr -> {
+        ctx as TypeTestExprContext
+        compareExpr(node.expr, ctx.expr())
+        compareType(node.type, ctx.type())
+      }
+      else -> {}
+    }
+  }
+
+  private fun compareArgumentList(node: ArgumentList?, ctx: ArgumentListContext?) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    node.arguments.zip(ctx.expr()).forEach { (e1, e2) -> compareExpr(e1, e2) }
+  }
+
+  private fun compareTypeArgumentList(node: TypeArgumentList?, ctx: TypeArgumentListContext?) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    node.types.zip(ctx.type()).forEach { (t1, t2) -> compareType(t1, t2) }
+  }
+
+  private fun compareQualifiedIdentifier(
+    node: QualifiedIdentifier?,
+    ctx: QualifiedIdentifierContext?,
+  ) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    node.identifiers.zip(ctx.Identifier()).forEach { (id1, id2) -> compareSpan(id1, id2) }
+  }
+
+  private fun compareExtendsOrAmendsClause(
+    node: ExtendsOrAmendsClause?,
+    ctx: ModuleExtendsOrAmendsClauseContext?,
+  ) {
+    if (node === null) return
+    compareSpan(node, ctx!!)
+    compareSpan(node.url, ctx.stringConstant())
+  }
+
+  private fun compareSpan(node: Node?, ctx: ParserRuleContext) {
+    if (node != null) {
+      compareSpan(node, ctx.start.startIndex, ctx.stop.stopIndex)
+    }
+  }
+
+  private fun compareSpan(node: Node?, ctx: TerminalNode?) {
+    if (node != null) {
+      compareSpan(node, ctx!!.symbol.startIndex, ctx.symbol.stopIndex)
+    }
+  }
+
+  private fun compareSpan(node: Node, charIndex: Int, tokenStop: Int) {
+    compareSpan(node.span(), charIndex, tokenStop)
+  }
+
+  private fun compareSpan(span: Span, ctx: ParserRuleContext) {
+    compareSpan(span, ctx.start.startIndex, ctx.stop.stopIndex)
+  }
+
+  private fun compareSpan(span: Span, charIndex: Int, tokenStop: Int) {
+    val length = tokenStop - charIndex + 1
+    softly.assertThat(span.charIndex).`as`("$span, index for path: $path").isEqualTo(charIndex)
+    softly.assertThat(span.length).`as`("$span, length for path: $path").isEqualTo(length)
+  }
+
+  private fun compareDocComment(node: Node?, ctx: TerminalNode?) {
+    if (node == null) return
+    val charIndex = ctx!!.symbol.startIndex
+    // for some reason antlr's doc coments are off by one
+    val length = ctx.symbol.stopIndex - charIndex
+    val span = node.span()
+    softly.assertThat(span.charIndex).`as`("$span, index for path: $path").isEqualTo(charIndex)
+    softly.assertThat(span.length).`as`("$span, length for path: $path").isEqualTo(length)
+  }
+}


### PR DESCRIPTION
Fix many span calculations that were wrong. Also adds a test that compares spans between the old ANTLR parser and the current one.