### PR TITLE
Make CliktCommands classes

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/commands/AnalyzeCommand.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/commands/AnalyzeCommand.kt
@@ -32,11 +32,11 @@ class AnalyzeCommand :
     epilog = "For more information, visit $helpLink",
   ) {
   init {
-    subcommands(AnalyzeImportsCommand)
+    subcommands(AnalyzeImportsCommand())
   }
 }
 
-object AnalyzeImportsCommand :
+class AnalyzeImportsCommand :
   ModulesCommand(
     name = "imports",
     helpLink = helpLink,

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
@@ -28,10 +28,10 @@ import org.pkl.core.Release
 
 /** Main method for the Java code generator CLI. */
 internal fun main(args: Array<String>) {
-  cliMain { PklJavaCodegenCommand.main(args) }
+  cliMain { PklJavaCodegenCommand().main(args) }
 }
 
-object PklJavaCodegenCommand :
+class PklJavaCodegenCommand :
   ModulesCommand(
     name = "pkl-codegen-java",
     helpLink = Release.current().documentation().homepage(),

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
@@ -31,10 +31,10 @@ import org.pkl.core.Release
 
 /** Main method for the Kotlin code generator CLI. */
 internal fun main(args: Array<String>) {
-  cliMain { PklKotlinCodegenCommand.main(args) }
+  cliMain { PklKotlinCodegenCommand().main(args) }
 }
 
-object PklKotlinCodegenCommand :
+class PklKotlinCodegenCommand :
   ModulesCommand(
     name = "pkl-codegen-kotlin",
     helpLink = Release.current().documentation().homepage(),


### PR DESCRIPTION
Missed these three classes.

This prevents the AOT compiler from statically initializing CLI argument default values (like working dir).