### PR TITLE
Execute typechecks eagerly when within a constraint

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
@@ -406,7 +406,7 @@ public class AstBuilder extends AbstractAstBuilder<Object> {
             var expr = visitExpr(exprs.get(i));
             constraints[i] = TypeConstraintNodeGen.create(expr.getSourceSection(), expr);
           }
-          return new Constrained(createSourceSection(type), childNode, constraints);
+          return new Constrained(createSourceSection(type), language, childNode, constraints);
         });
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,14 +36,18 @@ public abstract class UnresolvedTypeNode extends PklNode {
   public abstract TypeNode execute(VirtualFrame frame);
 
   public static final class Constrained extends UnresolvedTypeNode {
+
+    private final VmLanguage language;
     @Child UnresolvedTypeNode childNode;
     TypeConstraintNode[] constraintCheckNodes;
 
     public Constrained(
         SourceSection sourceSection,
+        VmLanguage language,
         UnresolvedTypeNode childNode,
         TypeConstraintNode[] constraintCheckNodes) {
       super(sourceSection);
+      this.language = language;
       this.childNode = childNode;
       this.constraintCheckNodes = constraintCheckNodes;
     }
@@ -52,7 +56,8 @@ public abstract class UnresolvedTypeNode extends PklNode {
     public TypeNode execute(VirtualFrame frame) {
       CompilerDirectives.transferToInterpreter();
 
-      return new ConstrainedTypeNode(sourceSection, childNode.execute(frame), constraintCheckNodes);
+      return new ConstrainedTypeNode(
+          sourceSection, language, childNode.execute(frame), constraintCheckNodes);
     }
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmLanguage.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmLanguage.java
@@ -16,6 +16,7 @@
 package org.pkl.core.runtime;
 
 import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.ContextThreadLocal;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.TruffleLanguage.ContextPolicy;
 import com.oracle.truffle.api.nodes.Node;
@@ -44,6 +45,9 @@ public final class VmLanguage extends TruffleLanguage<VmContext> {
   public static VmLanguage get(@Nullable Node node) {
     return REFERENCE.get(node);
   }
+
+  public final ContextThreadLocal<VmLocalContext> localContext =
+      locals.createContextThreadLocal((ignoredCtx, ignoredThread) -> new VmLocalContext());
 
   @Override
   protected VmContext createContext(Env env) {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmLocalContext.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmLocalContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.runtime;
+
+/** A per-context thread-local value that can be used to influence execution. */
+public class VmLocalContext {
+  private boolean shouldEagerTypecheck = false;
+
+  public VmLocalContext() {}
+
+  public void shouldEagerTypecheck(boolean shouldEagerTypecheck) {
+    this.shouldEagerTypecheck = shouldEagerTypecheck;
+  }
+
+  public boolean shouldEagerTypecheck() {
+    return this.shouldEagerTypecheck;
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/classes/MyClass.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/classes/MyClass.pkl
@@ -1,0 +1,9 @@
+typealias EmailAddress = String(matches(Regex(#".+@\S+|.+<\S+@\S+>"#)))
+
+class MyClass {
+  emails: Listing<EmailAddress>
+}
+
+myClass: MyClass
+
+others: Listing<module(this != module)>

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/classes/myClass1.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/classes/myClass1.pkl
@@ -1,0 +1,7 @@
+amends ".../input-helper/classes/MyClass.pkl"
+
+myClass {
+  emails {
+    "baz@bar.com"
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/classes/constraints13.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/classes/constraints13.pkl
@@ -1,0 +1,16 @@
+import "pkl:test"
+
+const local isOddLengthOfBirds = (it: Listing<Bird>) -> it.length.isOdd
+
+class Bird
+
+class MyTest {
+  // function parameter type should be checked eagerly
+  birds: Listing(isOddLengthOfBirds) = new {
+    1
+    2
+    3
+  }
+}
+
+res = test.catch(() -> new MyTest {}.birds)

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/classes/constraints14.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/classes/constraints14.pkl
@@ -1,0 +1,14 @@
+// This test executes constraint `EmailAddress` within `MyClass` from two different root nodes:
+//   - ListingOrMappingTypeCastNode
+//   - PropertyTypeNode
+amends ".../input-helper/classes/MyClass.pkl"
+
+myClass {
+  emails {
+    "foo@bar.com"
+  }
+}
+
+others {
+  import(".../input-helper/classes/myClass1.pkl")
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/constraintDetails1.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/constraintDetails1.pkl
@@ -1,0 +1,9 @@
+// Error message should include `new Bird { name = "Bob" }`
+birds: Listing(firstOneIsSandy) = new {
+  new Bird { name = "Bob" }
+  new Bird { name = "Bob" }
+}
+
+hidden firstOneIsSandy = (it: Listing<Bird>) -> it[0].name == "Sandy"
+
+class Bird { name: String }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/constraintDetails2.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/constraintDetails2.pkl
@@ -1,0 +1,11 @@
+// Error message should include `new Bird { name = "Bob" }`
+birds: Listing(
+    let (myself: Listing<Bird> = this)
+      myself[0].name == "Sandy"
+  ) =
+  new {
+    new Bird { name = "Bob" }
+    new Bird { name = "Bob" }
+  }
+
+class Bird { name: String }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/constraintDetails3.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/constraintDetails3.pkl
@@ -1,0 +1,9 @@
+// typechecks within child frames should also be eagerly checked
+foo: Listing(toList().every((it: Listing<Bird>) -> it[0].name == "Bob")) = new {
+  new Listing {
+    new Bird { name = "Eagle" }
+    new Bird { name = "Quail" }
+  }
+}
+
+class Bird { name: String }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/constraints13.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/constraints13.pcf
@@ -1,0 +1,1 @@
+res = "Expected value of type `constraints13#Bird`, but got type `Int`. Value: 1"

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/constraints14.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/constraints14.pcf
@@ -1,0 +1,15 @@
+myClass {
+  emails {
+    "foo@bar.com"
+  }
+}
+others {
+  new {
+    myClass {
+      emails {
+        "baz@bar.com"
+      }
+    }
+    others {}
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails1.err
@@ -1,0 +1,15 @@
+–– Pkl Error ––
+Type constraint `firstOneIsSandy` violated.
+Value: new Listing { new Bird { name = "Bob" }; new Bird { name = ? } }
+
+x | birds: Listing(firstOneIsSandy) = new {
+                   ^^^^^^^^^^^^^^^
+at constraintDetails1#birds (file:///$snippetsDir/input/errors/constraintDetails1.pkl)
+
+x | birds: Listing(firstOneIsSandy) = new {
+                                      ^^^^^
+at constraintDetails1#birds (file:///$snippetsDir/input/errors/constraintDetails1.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails2.err
@@ -1,0 +1,16 @@
+–– Pkl Error ––
+Type constraint `let (myself: Listing<Bird> = this)
+      myself[0].name == "Sandy"` violated.
+Value: new Listing { new Bird { name = "Bob" }; new Bird { name = ? } }
+
+x | let (myself: Listing<Bird> = this)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at constraintDetails2#birds (file:///$snippetsDir/input/errors/constraintDetails2.pkl)
+
+x | new {
+    ^^^^^
+at constraintDetails2#birds (file:///$snippetsDir/input/errors/constraintDetails2.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails3.err
@@ -1,0 +1,15 @@
+–– Pkl Error ––
+Type constraint `toList().every((it: Listing<Bird>) -> it[0].name == "Bob")` violated.
+Value: new Listing { new Listing { new Bird { name = "Eagle" }; new Bird { name = ? ...
+
+x | foo: Listing(toList().every((it: Listing<Bird>) -> it[0].name == "Bob")) = new {
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at constraintDetails3#foo (file:///$snippetsDir/input/errors/constraintDetails3.pkl)
+
+x | foo: Listing(toList().every((it: Listing<Bird>) -> it[0].name == "Bob")) = new {
+                                                                               ^^^^^
+at constraintDetails3#foo (file:///$snippetsDir/input/errors/constraintDetails3.pkl)
+
+xxx | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)


### PR DESCRIPTION
This changes the language to check all types eagerly when within a type constraint.

This addresses a regression where error messages might show objects that are missing details (see https://github.com/apple/pkl/issues/918).

Another implication of this change is: type constraints are stricter. Now, type annotations will check `Mapping` and `Listing` members if the annotation is executed from a constraint.

This currently does not throw, and will after this change:

```pkl
import "pkl:test"

const local isBirds = (it: Listing<Bird>) -> true

birds: Listing(isBirds) = new { 1; 2; 3 }

class Bird
```