### PR TITLE
Ensure `findOrAddAuxiliarySlot` is not called during compilation

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
@@ -2538,9 +2538,17 @@ public abstract class TypeNode extends PklNode {
 
     @ExplodeLoop
     protected Object executeLazily(VirtualFrame frame, Object value) {
-      var customThisSlot =
-          frame.getFrameDescriptor().findOrAddAuxiliarySlot(CustomThisScope.FRAME_SLOT_ID);
-
+      int customThisSlot;
+      var numberOfAuxiliarySlots = frame.getFrameDescriptor().getNumberOfAuxiliarySlots();
+      if (numberOfAuxiliarySlots == 0) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        customThisSlot =
+            frame.getFrameDescriptor().findOrAddAuxiliarySlot(CustomThisScope.FRAME_SLOT_ID);
+      } else {
+        // assertion: we only use auxiliary slots for custom `this`.
+        assert numberOfAuxiliarySlots == 1;
+        customThisSlot = 0;
+      }
       var ret = childNode.executeLazily(frame, value);
 
       var localContext = language.localContext.get();


### PR DESCRIPTION
Fixes an issue that is preventing the native executable from building