### PR TITLE
Document how to install pkl with Mise

### DIFF
--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -1,6 +1,8 @@
 = CLI
 include::ROOT:partial$component-attributes.adoc[]
 :uri-homebrew: https://brew.sh
+:uri-mise: https://mise.jdx.dev
+:uri-ubi: https://github.com/houseabsolute/ubi
 
 :uri-sonatype-snapshot-download: https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.pkl-lang&v={pkl-artifact-version}
 :uri-pkl-macos-amd64-download: {uri-sonatype-snapshot-download}&a=pkl-cli-macos-amd64&e=bin
@@ -82,6 +84,28 @@ endif::[]
 
 ifndef::is-release-version[]
 For instructions, switch to a release version of this page.
+endif::[]
+
+[[mise]]
+=== Mise
+
+On macOS and Linux, release versions can be installed using {uri-ubi}[the Universal Binary Installer (UBI)] with {uri-mise}[Mise].
+
+ifdef::is-release-version[]
+To install Pkl, run:
+
+[source,shell]
+----
+mise install -g ubi:apple/pkl@latest
+----
+
+You can then run `mise use` to activate the latest version either globally or locally:
+
+[source,shell]
+----
+mise use -g ubi:apple/pkl@latest # Activate it globally
+mise use ubi:apple/pkl@latest
+----
 endif::[]
 
 [[download]]


### PR DESCRIPTION
[Mise](https://mise.jdx.dev) has been popularised as a frontend tool for dev environments. [Rails](https://guides.rubyonrails.org/install_ruby_on_rails.html) recommends it as a tool to install Ruby.

Mise integrates with multiple installation backends, one of which is [the Universal Binary Installer](https://github.com/houseabsolute/ubi), which can install tools by pulling binaries from their GitHub releases if they follow a certain convention to indicate the target OS and architecture. I tried it against pkl and it works.

This PR documents how to use Mise for those developers who are using it as a tool to manage the dependencies of their projects.

> [!NOTE]
> Unlike Homebrew, Mise can scope versions to directories, activating and deactivating them automatically for the user, which is handy for teams seeking determinism in their tools' versions.