### PR TITLE
Build with `m2pro.large` instances, not `macos.m1.large.gen1`

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===// 
 // File gets rendered to .circleci/config.yml via git hook.
-amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.1.1#/PklCI.pkl"
+amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.2.0#/PklCI.pkl"
 
 import "jobs/BuildNativeJob.pkl"
 import "jobs/GradleCheckJob.pkl"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
-    resource_class: macos.m1.large.gen1
+    resource_class: m2pro.large
     macos:
       xcode: 15.3.0
   pkl-cli-linux-amd64-release:
@@ -142,7 +142,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
-    resource_class: macos.m1.large.gen1
+    resource_class: m2pro.large
     macos:
       xcode: 15.3.0
   pkl-cli-linux-aarch64-release:
@@ -347,7 +347,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
-    resource_class: macos.m1.large.gen1
+    resource_class: m2pro.large
     macos:
       xcode: 15.3.0
   pkl-cli-linux-amd64-snapshot:
@@ -455,7 +455,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
-    resource_class: macos.m1.large.gen1
+    resource_class: m2pro.large
     macos:
       xcode: 15.3.0
   pkl-cli-linux-aarch64-snapshot:

--- a/.circleci/jobs/BuildNativeJob.pkl
+++ b/.circleci/jobs/BuildNativeJob.pkl
@@ -158,7 +158,7 @@ job {
     macos {
       xcode = "15.3.0"
     }
-    resource_class = "macos.m1.large.gen1"
+    resource_class = "m2pro.large"
     environment {
       ["JAVA_HOME"] = "/Users/distiller/jdk/Contents/Home"
     }

--- a/.circleci/jobs/BuildNativeJob.pkl
+++ b/.circleci/jobs/BuildNativeJob.pkl
@@ -16,7 +16,7 @@
 /// Builds the native `pkl` CLI
 extends "GradleJob.pkl"
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.2#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.5.0#/Config.pkl"
 
 /// The architecture to use
 arch: "amd64"|"aarch64"

--- a/.circleci/jobs/DeployJob.pkl
+++ b/.circleci/jobs/DeployJob.pkl
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 extends "GradleJob.pkl"
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.2#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.5.0#/Config.pkl"
 
 local self = this
 

--- a/.circleci/jobs/GradleCheckJob.pkl
+++ b/.circleci/jobs/GradleCheckJob.pkl
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 extends "GradleJob.pkl"
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.2#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.5.0#/Config.pkl"
 
 steps {
   new Config.RunStep {

--- a/.circleci/jobs/GradleJob.pkl
+++ b/.circleci/jobs/GradleJob.pkl
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 abstract module GradleJob
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.2#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.5.0#/Config.pkl"
 import "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.3#/URI.pkl"
 
 /// Whether this is a release build or not.

--- a/.circleci/jobs/SimpleGradleJob.pkl
+++ b/.circleci/jobs/SimpleGradleJob.pkl
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 extends "GradleJob.pkl"
 
-import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.1.2#/Config.pkl"
+import "package://pkg.pkl-lang.org/pkl-pantry/com.circleci.v2@1.5.0#/Config.pkl"
 
 name: String = command
 


### PR DESCRIPTION
This should speed up our Mac release builds