### PR TITLE
Remove stacking of block comments

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/parser/Lexer.java
+++ b/pkl-core/src/main/java/org/pkl/core/parser/Lexer.java
@@ -575,11 +575,11 @@ public class Lexer {
   private void lexBlockComment() {
     if (lookahead == EOF) throw unexpectedEndOfFile();
     var prev = nextChar();
-    // block comments in Pkl can stack
-    var stack = 1;
-    while (stack > 0 && lookahead != EOF) {
-      if (prev == '*' && lookahead == '/') stack--;
-      if (prev == '/' && lookahead == '*') stack++;
+    while (lookahead != EOF) {
+      if (prev == '*' && lookahead == '/') {
+        nextChar();
+        break;
+      }
       prev = nextChar();
     }
     if (lookahead == EOF) throw unexpectedEndOfFile();

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/basic/comments.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/basic/comments.pkl
@@ -3,7 +3,6 @@ x = 10 // end-of-line comment
 y = 20 /*
 multi
 line
-/* nested */
 comment
 */ z = 30
 


### PR DESCRIPTION
Our old parser allowed block comment stacking, but it also allowed the user to not close the block comments properly:

```pkl
/* /* */ foo = 1
```

This can lead to a massive backtracking in the lexer, so we decided to remove this feature. Block comments don't stack anymore, so this previously valid Pkl code is not valid anymore:

```pkl
/* top /* nested */ top */ foo = 1
```

This is breaking change, but it's pretty easy to fix. Also our editor parsers (IntelliJ, tree-sitter, textMate) don't allow stacking.

Fixes #1014