### PR TITLE
Fix incorrect substring

### DIFF
--- a/pkl-doc/src/main/kotlin/org/pkl/doc/PackageDataGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/PackageDataGenerator.kt
@@ -414,7 +414,9 @@ private fun findTypesUsedBy(
             enclosingPackage.name,
             enclosingPackage.uri,
             enclosingPackage.version,
-            enclosingType.moduleName.substring(enclosingPackage.name.length + 1).replace('.', '/'),
+            enclosingType.moduleName
+              .substring(enclosingPackage.moduleNamePrefix.length)
+              .replace('.', '/'),
             PClassInfo.MODULE_CLASS_NAME,
           )
         )


### PR DESCRIPTION
This fixes an issue that can possibly cause a StringIndexOutOfBoundsException when generating pkldoc.

The relative path should be based off the module name prefix, not the package name.