### PR TITLE
Do not crash, but suggest '--multiple-file-output-path' when specifying a directory as output file

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliEvaluator.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliEvaluator.kt
@@ -155,8 +155,8 @@ constructor(
           val output = evaluator.evaluateExpressionString(moduleSource, options.expression)
           if (Files.isDirectory(outputFile)) {
             throw CliException(
-              "Ouput file is a directory ('$outputFile'). " +
-                "Did you mean '--multiple-file-output-path'?"
+              "Output file `$outputFile` is a directory. " +
+                "Did you mean `--multiple-file-output-path`?"
             )
           }
           outputFile.createParentDirectories()

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliEvaluator.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliEvaluator.kt
@@ -19,6 +19,7 @@ import java.io.File
 import java.io.Reader
 import java.io.Writer
 import java.net.URI
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import kotlin.io.path.createParentDirectories
@@ -152,6 +153,12 @@ constructor(
         for ((moduleUri, outputFile) in outputFiles) {
           val moduleSource = toModuleSource(moduleUri, consoleReader)
           val output = evaluator.evaluateExpressionString(moduleSource, options.expression)
+          if (Files.isDirectory(outputFile)) {
+            throw CliException(
+              "Ouput file is a directory ('$outputFile'). " +
+                "Did you mean '--multiple-file-output-path'?"
+            )
+          }
           outputFile.createParentDirectories()
           if (!writtenFiles.contains(outputFile)) {
             // write file even if output is empty to overwrite output from previous runs

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
@@ -726,6 +726,39 @@ result = someLib.x
   }
 
   @Test
+  fun `file output throws if output file is a directory`() {
+    val sourceFiles =
+      listOf(
+        writePklFile(
+          "test.pkl",
+          """
+          name = "test"
+          output {
+            files {
+              ["\(name).txt"] {
+                text = "test"
+              }
+            } 
+          }
+        """
+            .trimIndent(),
+        )
+      )
+    val err =
+      assertThrows<CliException> {
+        evalToFiles(
+          CliEvaluatorOptions(
+            CliBaseOptions(sourceModules = sourceFiles),
+            outputPath = tempDir.toString(),
+          )
+        )
+      }
+    assertThat(err)
+      .hasMessageContaining("Output file `$tempDir` is a directory. ")
+      .hasMessageContaining("Did you mean `--multiple-file-output-path`?")
+  }
+
+  @Test
   fun `multiple file output writes multiple files to the provided directory`() {
     val contents =
       """


### PR DESCRIPTION
This PR fixes https://github.com/apple/pkl/issues/989

When specifying a directory instead of a file for the output, `pkl` won't crash anymore, but instead output an error message, suggesting `--multiple-file-output-path`.