### PR TITLE
Add `getOrDefault` method to `Listing` and `Mapping`

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/MappingNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/MappingNodes.java
@@ -19,7 +19,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import java.util.HashSet;
-import org.pkl.core.PklBugException;
 import org.pkl.core.ast.lambda.ApplyVmFunction1Node;
 import org.pkl.core.ast.lambda.ApplyVmFunction2Node;
 import org.pkl.core.ast.lambda.ApplyVmFunction2NodeGen;
@@ -126,10 +125,9 @@ public final class MappingNodes {
       if (value != null) {
         return value;
       }
-      if (VmUtils.readMember(self, Identifier.DEFAULT) instanceof VmFunction defaultFn) {
-        return applyNode.execute(defaultFn, key);
-      }
-      throw PklBugException.unreachableCode();
+
+      var defaultFunction = (VmFunction) VmUtils.readMember(self, Identifier.DEFAULT, callNode);
+      return applyNode.execute(defaultFunction, key);
     }
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/MappingNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/MappingNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import java.util.HashSet;
+import org.pkl.core.PklBugException;
+import org.pkl.core.ast.lambda.ApplyVmFunction1Node;
 import org.pkl.core.ast.lambda.ApplyVmFunction2Node;
 import org.pkl.core.ast.lambda.ApplyVmFunction2NodeGen;
 import org.pkl.core.ast.lambda.ApplyVmFunction3Node;
@@ -111,6 +113,23 @@ public final class MappingNodes {
     @Specialization
     protected Object eval(VmMapping self, Object key) {
       return VmNull.lift(VmUtils.readMemberOrNull(self, key, callNode));
+    }
+  }
+
+  public abstract static class getOrDefault extends ExternalMethod1Node {
+    @Child private IndirectCallNode callNode = IndirectCallNode.create();
+    @Child private ApplyVmFunction1Node applyNode = ApplyVmFunction1Node.create();
+
+    @Specialization
+    protected Object eval(VmMapping self, Object key) {
+      var value = VmUtils.readMemberOrNull(self, key, callNode);
+      if (value != null) {
+        return value;
+      }
+      if (VmUtils.readMember(self, Identifier.DEFAULT) instanceof VmFunction defaultFn) {
+        return applyNode.execute(defaultFn, key);
+      }
+      throw PklBugException.unreachableCode();
     }
   }
 

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/listings/default.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/listings/default.pkl
@@ -29,3 +29,7 @@ res4 = (res3) {
     name = "Barn Owl"
   }
 }
+
+res5 = (res4.getOrDefault(99)) {
+  name = "Bald Eagle"
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/mappings/default.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/mappings/default.pkl
@@ -38,3 +38,7 @@ res3: Mapping<String, Person> = new {
     age = 60
   }
 }
+
+res4 = (res3.getOrDefault("Bald Eagle")) {
+  age = 99
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/listings/default.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/listings/default.pcf
@@ -38,3 +38,7 @@ res4 {
     age = 5
   }
 }
+res5 {
+  name = "Bald Eagle"
+  age = 99
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/mappings/default.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/mappings/default.pcf
@@ -32,3 +32,7 @@ res3 {
     age = 60
   }
 }
+res4 {
+  name = "Bald Eagle"
+  age = 99
+}

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -1839,7 +1839,7 @@ class Listing<out Element> extends Object {
   ///
   /// Returns [default] applied to [index] if [index] is outside the bounds of this listing.
   /// 
-  /// This is equivalent to `getOrNull([index]) ?? default.apply([index])`.
+  /// This is equivalent to `getOrNull(index) ?? default.apply(index)`.
   @Since { version = "0.29.0" }
   external function getOrDefault(index: Int): Element
 
@@ -2009,7 +2009,7 @@ class Mapping<out Key, out Value> extends Object {
   /// Returns the value associated with [key] or [default] applied to [key] if this mapping does
   /// not contain [key].
   ///
-  /// This is equivalent to `getOrNull([key]) ?? default.apply([key])`.
+  /// This is equivalent to `getOrNull(key) ?? default.apply(key)`.
   @Since { version = "0.29.0" } 
   external function getOrDefault(key: Any): Value
 

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -1838,6 +1838,7 @@ class Listing<out Element> extends Object {
   /// Returns the element at [index].
   ///
   /// Returns [default] applied to [index] if [index] is outside the bounds of this listing.
+  /// 
   /// This is equivalent to `getOrNull([index]) ?? default.apply([index])`.
   @Since { version = "0.29.0" }
   external function getOrDefault(index: Int): Element
@@ -2005,7 +2006,8 @@ class Mapping<out Key, out Value> extends Object {
   /// This is the nullable equivalent of the subscript operator (`object[key]`).
   external function getOrNull(key: Any): Value?
 
-  /// Returns the value associated with [key] or [default] applied to [key] if this mapping does not contain [key].
+  /// Returns the value associated with [key] or [default] applied to [key] if this mapping does
+  /// not contain [key].
   ///
   /// This is equivalent to `getOrNull([key]) ?? default.apply([key])`.
   @Since { version = "0.29.0" } 

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -1835,6 +1835,13 @@ class Listing<out Element> extends Object {
   @Since { version = "0.27.0" }
   external function getOrNull(index: Int): Element?
 
+  /// Returns the element at [index].
+  ///
+  /// Returns [default] applied to [index] if [index] is outside the bounds of this listing.
+  /// This is equivalent to `getOrNull([index]) ?? default.apply([index])`.
+  @Since { version = "0.29.0" }
+  external function getOrDefault(index: Int): Element
+
   /// Tells if this listing has no duplicate elements.
   ///
   /// Facts:
@@ -1997,6 +2004,12 @@ class Mapping<out Key, out Value> extends Object {
   ///
   /// This is the nullable equivalent of the subscript operator (`object[key]`).
   external function getOrNull(key: Any): Value?
+
+  /// Returns the value associated with [key] or [default] applied to [key] if this mapping does not contain [key].
+  ///
+  /// This is equivalent to `getOrNull([key]) ?? default.apply([key])`.
+  @Since { version = "0.29.0" } 
+  external function getOrDefault(key: Any): Value
 
   /// Folds the entries of this mapping in iteration order using [operator], starting with [initial].
   external function fold<Result>(initial: Result, operator: (Result, Key, Value) -> Result): Result


### PR DESCRIPTION
This PR adds methods to `Listing` and `Mapping` that can be used to retrieve members. If the member for the index/key isn't present, it applies `default` to the index/key. In both cases, this is essentially sugar for `getOrNull(<index/key>) ?? default.apply(<index/key>)`.

I considered adding another method called something like `getOrElse` to these types (as well as `List` and `Map`). This two-argument method would work like `getOrNull` but in the event of no member being present would return the second argument.

I opted not to implement `getOrElse` since the null coalescing operator `??` already implements this in a more convenient way: `getOrNull(<index/key>) ?? <default value>`. I think the pattern of applying `default` should have its own method: for many users it's not always obvious that `default` is a lambda, especially when it's defined via the sugared anonymous function object body syntax where the argument may be elided if unused.

I'm definitely open to naming suggestions here!

I'm also unsure if `Dynamic` warrants a similar change. I'm currently of the mind that `Dynamic.default` should be considered harmful due to #700.