### PR TITLE
Aggregate junit report into one file

### DIFF
--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -381,7 +381,7 @@ pkl eval -m . myFiles.pkl
 pkl eval -m "%{moduleName}" foo.pkl bar.pkl
 ----
 
-For additional details, see xref:language-reference:index.adoc#multiple-file-output[Multiple File Output] 
+For additional details, see xref:language-reference:index.adoc#multiple-file-output[Multiple File Output]
 in the language reference.
 ====
 
@@ -465,7 +465,29 @@ Default: (none) +
 Example: `./build/test-results` +
 Directory where to store JUnit reports.
 
+One file will be created for each test module.
+
 No JUnit reports will be generated if this option is not present.
+====
+
+[[junit-aggregate-reports]]
+.--junit-aggregate-reports
+[%collapsible]
+====
+Aggregate JUnit reports into a single file.
+
+By default it will be `test.xml` but you can override it using `--junit-suite-name` flag.
+====
+
+[[junit-suite-name]]
+.--junit-suite-name
+[%collapsible]
+====
+Default: (none) +
+Example: `my-tests` +
+The name of the root JUnit test suite.
+
+Used in combination with `--junit-aggregate-reports` flag.
 ====
 
 [[overwrite]]
@@ -553,6 +575,26 @@ Example: `./build/test-results` +
 Directory where to store JUnit reports.
 
 No JUnit reports will be generated if this option is not present.
+====
+
+[[junit-aggregate-reports]]
+.--junit-aggregate-reports
+[%collapsible]
+====
+Aggregate JUnit reports into a single file.
+
+By default it will be `test.xml` but you can override it using `--junit-suite-name` flag.
+====
+
+[[junit-suite-name]]
+.--junit-suite-name
+[%collapsible]
+====
+Default: (none) +
+Example: `my-tests` +
+The name of the root JUnit test suite.
+
+Used in combination with `--junit-aggregate-reports` flag.
 ====
 
 .--overwrite

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -195,7 +195,7 @@ Example 1: `multipleFileOutputDir = layout.projectDirectory.dir("output")` +
 Example 2: `+multipleFileOutputDir = layout.projectDirectory.file("%{moduleDir}/output")+`
 The directory where a module's output files are placed.
 
-Setting this option causes Pkl to evaluate a module's `output.files` property 
+Setting this option causes Pkl to evaluate a module's `output.files` property
 and write the files specified therein.
 Within `output.files`, a key determines a file's path relative to `multipleFileOutputDir`,
 and a value determines the file's contents.
@@ -207,7 +207,7 @@ This option cannot be used together with any of the following:
 
 This option supports the same placeholders as xref:output-file[outputFile].
 
-For additional details, see xref:language-reference:index.adoc#multiple-file-output[Multiple File Output] 
+For additional details, see xref:language-reference:index.adoc#multiple-file-output[Multiple File Output]
 in the language reference.
 ====
 
@@ -296,6 +296,22 @@ pkl {
 Default: `null` +
 Example: `junitReportsDir = layout.buildDirectory.dir("reports")` +
 Whether and where to generate JUnit XML reports.
+====
+
+[[junit-aggregate-reports]]
+.junitAggregateReports: Property<Boolean>
+[%collapsible]
+====
+Default: `false` +
+Aggregate JUnit reports into a single file.
+====
+
+[[junit-suite-name]]
+.junitSuiteName: Property<String>
+[%collapsible]
+====
+Default: `null` +
+The name of the root JUnit test suite.
 ====
 
 [[overwrite]]
@@ -391,7 +407,7 @@ For Spring Boot applications, and for users of `pkl-config-java` compiling the g
 Default: `"org.pkl.config.java.mapper.NonNull"` +
 Example: `nonNullAnnotation = "org.project.MyAnnotation"` +
 Fully qualified name of the annotation type to use for annotating non-null types. +
-The specified annotation type must be annotated with `@java.lang.annotation.Target(ElementType.TYPE_USE)` 
+The specified annotation type must be annotated with `@java.lang.annotation.Target(ElementType.TYPE_USE)`
 or the generated code may not compile.
 ====
 
@@ -431,7 +447,7 @@ build.gradle.kts::
 +
 [source,kotlin]
 ----
-pkl { 
+pkl {
   kotlinCodeGenerators {
     register("genKotlin") {
       sourceModules.addAll(files("Template1.pkl", "Template2.pkl"))

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
@@ -386,6 +386,170 @@ class CliTestRunnerTest {
   }
 
   @Test
+  fun `CliTestRunner test per module`(@TempDir tempDir: Path) {
+    val code1 =
+      """
+      amends "pkl:test"
+
+      facts {
+        ["foo"] {
+          true
+        }
+      }
+    """
+        .trimIndent()
+
+    val code2 =
+      """
+      amends "pkl:test"
+
+      facts {
+        ["bar"] {
+          true
+        }
+      }
+    """
+        .trimIndent()
+    val input1 = tempDir.resolve("test1.pkl").writeString(code1).toString()
+    val input2 = tempDir.resolve("test2.pkl").writeString(code2).toString()
+    val noopWriter = noopWriter()
+    val opts =
+      CliBaseOptions(
+        sourceModules = listOf(input1.toUri(), input2.toUri()),
+        settings = URI("pkl:settings"),
+      )
+    val testOpts = CliTestOptions(junitDir = tempDir)
+    val runner = CliTestRunner(opts, testOpts, noopWriter, noopWriter)
+    runner.run()
+
+    assertThat(tempDir.resolve("test1.xml")).isNotEmptyFile()
+    assertThat(tempDir.resolve("test2.xml")).isNotEmptyFile()
+  }
+
+  @Test
+  fun `CliTestRunner test aggregate`(@TempDir tempDir: Path) {
+    val code1 =
+      """
+      amends "pkl:test"
+
+      facts {
+        ["foo"] {
+          true
+        }
+        ["bar"] {
+          5 == 9
+        }
+      }
+    """
+        .trimIndent()
+
+    val code2 =
+      """
+      amends "pkl:test"
+
+      facts {
+        ["xxx"] {
+          false
+        }
+        ["yyy"] {
+          false
+        }
+        ["zzz"] {
+          true
+        }
+      }
+    """
+        .trimIndent()
+    val input1 = tempDir.resolve("test1.pkl").writeString(code1).toString()
+    val input2 = tempDir.resolve("test2.pkl").writeString(code2).toString()
+    val noopWriter = noopWriter()
+    val opts =
+      CliBaseOptions(
+        sourceModules = listOf(input1.toUri(), input2.toUri()),
+        settings = URI("pkl:settings"),
+      )
+    val testOpts = CliTestOptions(junitDir = tempDir, junitAggregateReports = true)
+    val runner = CliTestRunner(opts, testOpts, noopWriter, noopWriter)
+    assertThatCode { runner.run() }.hasMessageContaining("failed")
+
+    assertThat(tempDir.resolve("test.xml")).isNotEmptyFile()
+    assertThat(tempDir.resolve("test1.xml")).doesNotExist()
+    assertThat(tempDir.resolve("test2.xml")).doesNotExist()
+
+    val junitReport = tempDir.resolve("test.xml").readString().stripFileAndLines(tempDir)
+
+    assertThat(junitReport)
+      .isEqualTo(
+        """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites name="test" tests="5" failures="3">
+          <testsuite name="test1" tests="2" failures="1">
+              <testcase classname="test1.facts" name="foo"></testcase>
+              <testcase classname="test1.facts" name="bar">
+                  <failure message="Fact Failure">5 == 9 (/tempDir/test1.pkl, line xx)</failure>
+              </testcase>
+          </testsuite>
+          <testsuite name="test2" tests="3" failures="2">
+              <testcase classname="test2.facts" name="xxx">
+                  <failure message="Fact Failure">false (/tempDir/test2.pkl, line xx)</failure>
+              </testcase>
+              <testcase classname="test2.facts" name="yyy">
+                  <failure message="Fact Failure">false (/tempDir/test2.pkl, line xx)</failure>
+              </testcase>
+              <testcase classname="test2.facts" name="zzz"></testcase>
+          </testsuite>
+      </testsuites>
+      
+    """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `CliTestRunner test aggregate suite name`(@TempDir tempDir: Path) {
+    val code1 =
+      """
+      amends "pkl:test"
+
+      facts {
+        ["foo"] {
+          true
+        }
+      }
+    """
+        .trimIndent()
+
+    val code2 =
+      """
+      amends "pkl:test"
+
+      facts {
+        ["bar"] {
+          true
+        }
+      }
+    """
+        .trimIndent()
+    val input1 = tempDir.resolve("test1.pkl").writeString(code1).toString()
+    val input2 = tempDir.resolve("test2.pkl").writeString(code2).toString()
+    val noopWriter = noopWriter()
+    val opts =
+      CliBaseOptions(
+        sourceModules = listOf(input1.toUri(), input2.toUri()),
+        settings = URI("pkl:settings"),
+      )
+    val testOpts =
+      CliTestOptions(junitDir = tempDir, junitAggregateReports = true, junitSuiteName = "custom")
+    val runner = CliTestRunner(opts, testOpts, noopWriter, noopWriter)
+    runner.run()
+
+    assertThat(tempDir.resolve("custom.xml")).isNotEmptyFile()
+    assertThat(tempDir.resolve("test.xml")).doesNotExist()
+    assertThat(tempDir.resolve("test1.xml")).doesNotExist()
+    assertThat(tempDir.resolve("test2.xml")).doesNotExist()
+  }
+
+  @Test
   fun `no source modules specified has same message as pkl eval`() {
     val e1 = assertThrows<CliException> { CliTestRunner(CliBaseOptions(), CliTestOptions()).run() }
     val e2 = RootCommand().test("eval")

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliTestOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliTestOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,4 +17,9 @@ package org.pkl.commons.cli
 
 import java.nio.file.Path
 
-class CliTestOptions(val junitDir: Path? = null, val overwrite: Boolean = false)
+class CliTestOptions(
+  val junitDir: Path? = null,
+  val overwrite: Boolean = false,
+  val junitAggregateReports: Boolean = false,
+  val junitSuiteName: String? = null,
+)

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/TestOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/TestOptions.kt
@@ -31,8 +31,25 @@ class TestOptions : OptionGroup() {
       )
       .path()
 
+  private val junitAggregateReports: Boolean by
+    option(
+        names = arrayOf("--junit-aggregate-reports"),
+        help = "Aggregate JUnit reports into a single file.",
+      )
+      .flag()
+
+  private val junitSuiteName: String? by
+    option(
+        names = arrayOf("--junit-suite-name"),
+        metavar = "name",
+        help = "The name of the root JUnit test suite.",
+      )
+      .single()
+
   private val overwrite: Boolean by
     option(names = arrayOf("--overwrite"), help = "Force generation of expected examples.").flag()
 
-  val cliTestOptions: CliTestOptions by lazy { CliTestOptions(junitReportDir, overwrite) }
+  val cliTestOptions: CliTestOptions by lazy {
+    CliTestOptions(junitReportDir, overwrite, junitAggregateReports, junitSuiteName)
+  }
 }

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/JUnitAggregateReport.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/JUnitAggregateReport.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.stdlib.test.report;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.pkl.core.PklBugException;
+import org.pkl.core.TestResults;
+import org.pkl.core.runtime.VmDynamic;
+
+public final class JUnitAggregateReport extends TestReport {
+
+  @Override
+  public void report(TestResults results, Writer writer) throws IOException {
+    throw new PklBugException("One file report not supported for aggregate reporter.", new IOException());
+  }
+
+  public void report(String name, List<TestResults> results, Writer writer) throws IOException {
+    var reporter = new JUnitReport();
+
+    var totalTests = results.stream().collect(Collectors.summingLong(r -> r.totalTests()));
+    var totalFailures = results.stream().collect(Collectors.summingLong(r -> r.totalFailures()));
+
+    var attrs =
+        reporter.buildAttributes(
+            "name", name,
+            "tests", totalTests,
+            "failures", totalFailures);
+
+    var tests = results.stream().map(r -> reporter.buildSuite(r)).collect(Collectors.toCollection(ArrayList::new));
+
+    var suite =
+        reporter.buildXmlElement("testsuites", attrs, tests.toArray(new VmDynamic[0]));
+
+    writer.append(JUnitReport.renderXML("    ", "1.0", suite));
+  }
+
+  public void reportToPath(String name, List<TestResults> results, Path path) throws IOException {
+    try (var writer = new FileWriter(path.toFile(), StandardCharsets.UTF_8)) {
+      report(name, results, writer);
+    }
+  }
+}

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/JUnitReport.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/JUnitReport.java
@@ -36,14 +36,13 @@ import org.pkl.core.stdlib.PklConverter;
 import org.pkl.core.stdlib.xml.RendererNodes.Renderer;
 import org.pkl.core.util.EconomicMaps;
 
-public final class JUnitReport implements TestReport {
-
+public class JUnitReport extends TestReport {
   @Override
   public void report(TestResults results, Writer writer) throws IOException {
     writer.append(renderXML("    ", "1.0", buildSuite(results)));
   }
 
-  private VmDynamic buildSuite(TestResults results) {
+  public VmDynamic buildSuite(TestResults results) {
     if (results.error() != null) {
       var testCase = rootTestCase(results, results.error());
       var attrs =
@@ -142,7 +141,7 @@ public final class JUnitReport implements TestReport {
     return list;
   }
 
-  private VmDynamic buildXmlElement(String name, VmMapping attributes, VmDynamic... elements) {
+  public VmDynamic buildXmlElement(String name, VmMapping attributes, VmDynamic... elements) {
     return buildXmlElement(
         name,
         attributes,
@@ -173,7 +172,7 @@ public final class JUnitReport implements TestReport {
         members.size() - 4);
   }
 
-  private VmMapping buildAttributes(Object... attributes) {
+  public VmMapping buildAttributes(Object... attributes) {
     EconomicMap<Object, ObjectMember> attrs = EconomicMaps.create(attributes.length);
     for (int i = 0; i < attributes.length; i += 2) {
       attrs.put(
@@ -201,7 +200,7 @@ public final class JUnitReport implements TestReport {
     return str.replaceAll("\033\\[[;\\d]*m", "");
   }
 
-  private static String renderXML(String indent, String version, VmDynamic value) {
+  public static String renderXML(String indent, String version, VmDynamic value) {
     var builder = new StringBuilder();
     var converter = new PklConverter(VmMapping.empty());
     var renderer = new Renderer(builder, indent, version, "", VmMapping.empty(), converter);

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/SimpleReport.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/SimpleReport.java
@@ -28,7 +28,7 @@ import org.pkl.core.util.AnsiStringBuilder.AnsiCode;
 import org.pkl.core.util.AnsiTheme;
 import org.pkl.core.util.StringUtils;
 
-public final class SimpleReport implements TestReport {
+public final class SimpleReport extends TestReport {
 
   private static final String passingMark = "✔ ";
   private static final String failingMark = "✘ ";

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/TestReport.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/test/report/TestReport.java
@@ -24,11 +24,11 @@ import org.pkl.core.PklBugException;
 import org.pkl.core.TestResults;
 import org.pkl.core.util.StringBuilderWriter;
 
-public interface TestReport {
+abstract class TestReport {
 
-  void report(TestResults results, Writer writer) throws IOException;
+  public abstract void report(TestResults results, Writer writer) throws IOException;
 
-  default String report(TestResults results) {
+  public String report(TestResults results) throws IOException {
     try {
       var builder = new StringBuilder();
       var writer = new StringBuilderWriter(builder);
@@ -39,7 +39,7 @@ public interface TestReport {
     }
   }
 
-  default void reportToPath(TestResults results, Path path) throws IOException {
+  public void reportToPath(TestResults results, Path path) throws IOException {
     try (var writer = new FileWriter(path.toFile(), StandardCharsets.UTF_8)) {
       report(results, writer);
     }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/ProjectPackageTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/ProjectPackageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,14 @@ public abstract class ProjectPackageTask extends BasePklTask {
   public abstract DirectoryProperty getJunitReportsDir();
 
   @Input
+  @Optional
+  public abstract Property<Boolean> getJunitAggregateReports();
+
+  @Input
+  @Optional
+  public abstract Property<String> getJunitSuiteName();
+
+  @Input
   public abstract Property<Boolean> getOverwrite();
 
   @Input
@@ -64,7 +72,9 @@ public abstract class ProjectPackageTask extends BasePklTask {
             projectDirectories,
             new CliTestOptions(
                 mapAndGetOrNull(getJunitReportsDir(), it -> it.getAsFile().toPath()),
-                getOverwrite().get()),
+                getOverwrite().get(),
+                getJunitAggregateReports().getOrElse(false),
+                getJunitSuiteName().getOrElse(null)),
             getOutputPath().get().getAsFile().getAbsolutePath(),
             getSkipPublishCheck().getOrElse(false),
             new PrintWriter(System.out),

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/TestTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/TestTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,14 @@ public abstract class TestTask extends ModulesTask {
   public abstract DirectoryProperty getJunitReportsDir();
 
   @Input
+  @Optional
+  public abstract Property<Boolean> getJunitAggregateReports();
+
+  @Input
+  @Optional
+  public abstract Property<String> getJunitSuiteName();
+
+  @Input
   public abstract Property<Boolean> getOverwrite();
 
   @Override
@@ -38,7 +46,9 @@ public abstract class TestTask extends ModulesTask {
             getCliBaseOptions(),
             new CliTestOptions(
                 mapAndGetOrNull(getJunitReportsDir(), it -> it.getAsFile().toPath()),
-                getOverwrite().get()),
+                getOverwrite().get(),
+                getJunitAggregateReports().getOrElse(false),
+                getJunitSuiteName().getOrElse(null)),
             new PrintWriter(System.out),
             new PrintWriter(System.err))
         .run();


### PR DESCRIPTION
Some systems require junit report to be in a single file. For example `bazel` https://bazel.build/reference/test-encyclopedia needs single file to be available in `XML_OUTPUT_FILE` path.

To avoid implementing junit aggregation in pkl wrappers in different places this PR instead adds a `--junit-aggregate-reports` flag to return all junit reports as a single file.

Additional flag `--junit-suite-name` is added to allow overriding global test suite name from default `test` 