### PR TITLE
chore: use javac -release and kotlinc -Xjdk-release so the generated bytecode adheres to the APIs for the target Java release

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,16 +35,18 @@ dependencies {
 }
 
 java {
-  sourceCompatibility = JavaVersion.toVersion(toolchainVersion)
-  targetCompatibility = JavaVersion.toVersion(toolchainVersion)
-
   toolchain {
     languageVersion = JavaLanguageVersion.of(toolchainVersion)
     vendor = JvmVendorSpec.ADOPTIUM
   }
 }
 
+tasks.withType<JavaCompile>().configureEach { options.release = toolchainVersion }
+
 kotlin {
   jvmToolchain(toolchainVersion)
-  compilerOptions { jvmTarget = JvmTarget.fromTarget(toolchainVersion.toString()) }
+  compilerOptions {
+    jvmTarget = JvmTarget.fromTarget(toolchainVersion.toString())
+    freeCompilerArgs.add("-Xjdk-release=$toolchainVersion")
+  }
 }

--- a/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklAllProjects.gradle.kts
@@ -16,7 +16,7 @@
 import com.diffplug.gradle.spotless.KotlinGradleExtension
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins { id("com.diffplug.spotless") }
 
@@ -52,15 +52,14 @@ configurations.all {
 }
 
 plugins.withType(JavaPlugin::class).configureEach {
-  val java = project.extensions.getByType<JavaPluginExtension>()
-  java.sourceCompatibility = JavaVersion.VERSION_17
-  java.targetCompatibility = JavaVersion.VERSION_17
+  tasks.withType<JavaCompile>().configureEach { options.release = 17 }
 }
 
-tasks.withType<KotlinCompile>().configureEach {
+tasks.withType<KotlinJvmCompile>().configureEach {
   compilerOptions {
     jvmTarget = JvmTarget.JVM_17
     freeCompilerArgs.addAll("-Xjsr305=strict", "-Xjvm-default=all")
+    freeCompilerArgs.add("-Xjdk-release=17")
   }
 }
 

--- a/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
@@ -34,13 +34,8 @@ val libs = the<LibrariesForLibs>()
 val info = project.extensions.getByType<BuildInfo>()
 
 java {
-  val jvmTarget = JavaVersion.toVersion(info.jvmTarget)
-
   withSourcesJar() // creates `sourcesJar` task
   withJavadocJar()
-
-  sourceCompatibility = jvmTarget
-  targetCompatibility = jvmTarget
 
   toolchain {
     languageVersion = info.jdkToolchainVersion
@@ -112,10 +107,8 @@ tasks.compileJava {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-  val jvmTarget = JavaVersion.toVersion(info.jvmTarget)
   javaCompiler = info.javaCompiler
-  sourceCompatibility = jvmTarget.majorVersion
-  targetCompatibility = jvmTarget.majorVersion
+  options.release = info.jvmTarget
 }
 
 tasks.withType<JavaExec>().configureEach { jvmArgs(info.jpmsAddModulesFlags) }

--- a/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklKotlinLibrary.gradle.kts
@@ -42,5 +42,8 @@ tasks.compileKotlin {
 }
 
 tasks.withType<KotlinJvmCompile>().configureEach {
-  compilerOptions { jvmTarget = JvmTarget.fromTarget(buildInfo.jvmTarget.toString()) }
+  compilerOptions {
+    jvmTarget = JvmTarget.fromTarget(buildInfo.jvmTarget.toString())
+    freeCompilerArgs.addAll("-Xjdk-release=${buildInfo.jvmTarget}")
+  }
 }


### PR DESCRIPTION
Previously, only sourceCompatibility and targetCompatibility were used, and they might cause issues like NoSuchMethodError when a newer javac compiles with -target older_release.

Note: it is good to use a new an up to date javac to avoid issues in the compiler itself, so having a proper `-release ..` configuration is vital.

See https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/