### PR TITLE
Fix multi-jdk testing setup

### DIFF
--- a/buildSrc/src/main/kotlin/pklJavaExecutable.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklJavaExecutable.gradle.kts
@@ -84,6 +84,7 @@ val testStartJavaExecutable by tasks.registering { setupTestStartJavaExecutable(
 val testStartJavaExecutableOnOtherJdks =
   buildInfo.jdkTestRange.map { jdkTarget ->
     tasks.register("testStartJavaExecutableJdk${jdkTarget.asInt()}") {
+      enabled = buildInfo.isVersionEnabled(jdkTarget)
       val toolChainService: JavaToolchainService = serviceOf()
       val launcher = toolChainService.launcherFor { languageVersion = jdkTarget }
       setupTestStartJavaExecutable(launcher)
@@ -94,9 +95,7 @@ tasks.assemble { dependsOn(javaExecutable) }
 
 tasks.check {
   dependsOn(testStartJavaExecutable)
-  if (buildInfo.multiJdkTesting) {
-    dependsOn(testStartJavaExecutableOnOtherJdks)
-  }
+  dependsOn(testStartJavaExecutableOnOtherJdks)
 }
 
 publishing {

--- a/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklJavaLibrary.gradle.kts
@@ -20,6 +20,7 @@ import org.gradle.accessors.dm.LibrariesForLibs
 plugins {
   `java-library`
   `jvm-toolchains`
+  `jvm-test-suite`
   id("pklKotlinTest")
   id("com.diffplug.spotless")
 }
@@ -135,4 +136,4 @@ tasks.test { configureJdkTestTask(info.javaTestLauncher) }
 // inherits the configuration of the default `test` task (aside from an overridden launcher).
 val jdkTestTasks = info.multiJdkTestingWith(tasks.test) { (_, jdk) -> configureJdkTestTask(jdk) }
 
-if (info.multiJdkTesting) tasks.check { dependsOn(jdkTestTasks) }
+tasks.check { dependsOn(jdkTestTasks) }

--- a/pkl-cli/pkl-cli.gradle.kts
+++ b/pkl-cli/pkl-cli.gradle.kts
@@ -99,12 +99,7 @@ val testJavaExecutable by
   }
 
 // Setup `testJavaExecutable` tasks for multi-JDK testing.
-val testJavaExecutableOnOtherJdks =
-  if (buildInfo.multiJdkTesting) {
-    buildInfo.multiJdkTestingWith(testJavaExecutable)
-  } else {
-    emptyList()
-  }
+val testJavaExecutableOnOtherJdks = buildInfo.multiJdkTestingWith(testJavaExecutable)
 
 // Prepare a run of the fat JAR, optionally with a specific Java launcher.
 private fun setupJavaExecutableRun(

--- a/pkl-tools/pkl-tools.gradle.kts
+++ b/pkl-tools/pkl-tools.gradle.kts
@@ -120,6 +120,7 @@ for (jdkTarget in buildInfo.jdkTestRange) {
   } else {
     val task =
       tasks.register("testStartFatJarJdk${jdkTarget.asInt()}", Exec::class) {
+        enabled = buildInfo.isVersionEnabled(jdkTarget)
         val launcher = project.javaToolchains.launcherFor { languageVersion = jdkTarget }
         configureTestStartFatJar(launcher)
       }


### PR DESCRIPTION
This changes the Gradle build to always create multi-jdk tasks, and instead use the `enabled` property to determine whether the task is actually ran or not.

The has the following benefits:
* IntelliJ and other tools understand the task execution graph (e.g. testJdk20 shows up as a task)
* `gw updateDependencyLocks` discovers all configurations