### PR TITLE
Add ResourceReaders#fromServiceProviders to preconfigured evaluator

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,7 @@ public final class EvaluatorBuilder {
    *   <li>{@link ResourceReaders#https}
    *   <li>{@link ResourceReaders#pkg}
    *   <li>{@link ResourceReaders#projectpackage}
+   *   <li>{@link ResourceReaders#fromServiceProviders}
    *   <li>{@link System#getProperties}
    * </ul>
    */
@@ -108,6 +109,7 @@ public final class EvaluatorBuilder {
         .addResourceReader(ResourceReaders.https())
         .addResourceReader(ResourceReaders.pkg())
         .addResourceReader(ResourceReaders.projectpackage())
+        .addResourceReaders(ResourceReaders.fromServiceProviders())
         .addModuleKeyFactory(ModuleKeyFactories.standardLibrary);
 
     if (!TruffleOptions.AOT) {

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorBuilderTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorBuilderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.pkl.core.project.Project
+import org.pkl.core.resource.TestResourceReader
 
 class EvaluatorBuilderTest {
   @Test
@@ -33,6 +34,12 @@ class EvaluatorBuilderTest {
   fun `preconfigured builder sets system properties`() {
     val builder = EvaluatorBuilder.preconfigured()
     assertThat(builder.externalProperties).isEqualTo(System.getProperties())
+  }
+
+  @Test
+  fun `preconfigured builder adds resource readers from service providers`() {
+    val builder = EvaluatorBuilder.preconfigured()
+    assertThat(builder.resourceReaders).hasAtLeastOneElementOfType(TestResourceReader::class.java)
   }
 
   @Test


### PR DESCRIPTION
The preconfigured evaluator currently adds module key factories from service providers, but not resource readers.

This means that users of pkl-spring, for example, cannot add custom resource readers.
This is also inconsistent (in the preconfigured evaluator, `import` can use custom schemes, but not `read`).