### PR TITLE
Fix native build

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/literal/BytesLiteralNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/literal/BytesLiteralNode.java
@@ -58,6 +58,7 @@ public final class BytesLiteralNode extends ExpressionNode {
         var result = (Long) typeNode.execute(frame, elem.executeGeneric(frame));
         bytes[i] = result.byteValue();
       } catch (VmTypeMismatchException err) {
+        CompilerDirectives.transferToInterpreter();
         // optimization: don't create a new stack frame to check the type, but pretend that one
         // exists.
         err.putInsertedStackFrame(

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/BytesNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/BytesNodes.java
@@ -16,6 +16,7 @@
 package org.pkl.core.stdlib.base;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -106,12 +107,17 @@ public final class BytesNodes {
   }
 
   public abstract static class decodeToString extends ExternalMethod1Node {
+    @TruffleBoundary
+    private String doDecode(VmBytes self, String charset) throws CharacterCodingException {
+    var byteBuffer = ByteBuffer.wrap(self.getBytes());
+      var decoder = Charset.forName(charset).newDecoder();
+      return decoder.decode(byteBuffer).toString();
+    }
+
     @Specialization
     protected String eval(VmBytes self, String charset) {
       try {
-        var byteBuffer = ByteBuffer.wrap(self.getBytes());
-        var decoder = Charset.forName(charset).newDecoder();
-        return decoder.decode(byteBuffer).toString();
+        return doDecode(self, charset);
       } catch (CharacterCodingException e) {
         CompilerDirectives.transferToInterpreter();
         throw exceptionBuilder().evalError("characterCodingException", charset).build();

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/BytesNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/BytesNodes.java
@@ -109,7 +109,7 @@ public final class BytesNodes {
   public abstract static class decodeToString extends ExternalMethod1Node {
     @TruffleBoundary
     private String doDecode(VmBytes self, String charset) throws CharacterCodingException {
-    var byteBuffer = ByteBuffer.wrap(self.getBytes());
+      var byteBuffer = ByteBuffer.wrap(self.getBytes());
       var decoder = Charset.forName(charset).newDecoder();
       return decoder.decode(byteBuffer).toString();
     }

--- a/pkl-core/src/main/java/org/pkl/core/util/ByteArrayUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/ByteArrayUtils.java
@@ -15,6 +15,7 @@
  */
 package org.pkl.core.util;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
@@ -23,22 +24,28 @@ import org.pkl.core.runtime.VmExceptionBuilder;
 public final class ByteArrayUtils {
   private ByteArrayUtils() {}
 
+  // TODO: implement this directly so we don't need a truffle boundary here.
+  @TruffleBoundary
   public static String base64(byte[] input) {
     return Base64.getEncoder().encodeToString(input);
   }
 
+  @TruffleBoundary
   public static String md5(byte[] input) {
     return hash(input, "MD5");
   }
 
+  @TruffleBoundary
   public static String sha1(byte[] input) {
     return hash(input, "SHA-1");
   }
 
+  @TruffleBoundary
   public static String sha256(byte[] input) {
     return hash(input, "SHA-256");
   }
 
+  @TruffleBoundary
   public static long sha256Int(byte[] input) {
     return hashInt(input, "SHA-256");
   }

--- a/pkl-core/src/main/java/org/pkl/core/util/ByteArrayUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/ByteArrayUtils.java
@@ -55,7 +55,6 @@ public final class ByteArrayUtils {
    * this and do not need a Truffle boundary.
    */
   public static String toHex(byte[] hash) {
-    //    return new BigInteger(hash).toString(16);
     var hexDigitTable =
         new char[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/jsonRenderer8.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/jsonRenderer8.err
@@ -11,3 +11,7 @@ Consider adding a converter to `output.converters`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/jsonnetRenderer7.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/jsonnetRenderer7.err
@@ -11,3 +11,7 @@ Consider adding a converter to `output.converters`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/pListRenderer7.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/pListRenderer7.err
@@ -11,3 +11,7 @@ Consider adding a converter to `output.converters`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/pcfRenderer8.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/pcfRenderer8.err
@@ -11,3 +11,7 @@ Consider adding a converter to `output.converters`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/propertiesRenderer10.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/propertiesRenderer10.err
@@ -11,3 +11,7 @@ Consider adding a converter to `output.converters`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/propertiesRenderer11.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/propertiesRenderer11.err
@@ -11,3 +11,7 @@ Consider adding a converter to `output.converters`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/xmlRenderer8.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/xmlRenderer8.err
@@ -11,3 +11,7 @@ Consider adding a converter to `output.converters`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/yamlRenderer7.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/yamlRenderer7.err
@@ -11,3 +11,7 @@ Consider adding a converter to `output.converters`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/basic/exceptions.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/basic/exceptions.err
@@ -8,3 +8,7 @@ at exceptions#foo.bar (file:///$snippetsDir/input/basic/exceptions.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/class3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/class3.err
@@ -11,3 +11,7 @@ address
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/constraints5.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/constraints5.err
@@ -13,3 +13,7 @@ at constraints5#res2.max (file:///$snippetsDir/input/classes/constraints5.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/inheritanceError1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/inheritanceError1.err
@@ -11,3 +11,7 @@ To make a class extensible, add an `open` modifier: `open class MyClass { ... }`
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/invalidInstantiation1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/invalidInstantiation1.err
@@ -13,3 +13,7 @@ Examples:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/invalidInstantiation2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/invalidInstantiation2.err
@@ -11,3 +11,7 @@ Instead, instantiate a concrete subclass.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorAlias.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorAlias.err
@@ -12,3 +12,7 @@ at unionTypesErrorAlias#res1.a (file:///$snippetsDir/input/classes/unionTypesErr
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorDifferent1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorDifferent1.err
@@ -17,3 +17,7 @@ at unionTypesErrorDifferent1#res1.a (file:///$snippetsDir/input/classes/unionTyp
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorDifferent2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorDifferent2.err
@@ -17,3 +17,7 @@ at unionTypesErrorDifferent2#res1.a (file:///$snippetsDir/input/classes/unionTyp
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorMultipleAliases.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorMultipleAliases.err
@@ -21,3 +21,7 @@ at unionTypesErrorMultipleAliases#res1 (file:///$snippetsDir/input/classes/union
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorNested.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorNested.err
@@ -21,3 +21,7 @@ at unionTypesErrorNested#res1.a (file:///$snippetsDir/input/classes/unionTypesEr
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorSimple.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorSimple.err
@@ -13,3 +13,7 @@ at unionTypesErrorSimple#res1.a (file:///$snippetsDir/input/classes/unionTypesEr
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorString1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorString1.err
@@ -12,3 +12,7 @@ at unionTypesErrorString1#res1.a (file:///$snippetsDir/input/classes/unionTypesE
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorString2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/unionTypesErrorString2.err
@@ -12,3 +12,7 @@ at unionTypesErrorString2#res1.a (file:///$snippetsDir/input/classes/unionTypesE
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType1.err
@@ -13,3 +13,7 @@ at wrongType1#pigeon.name (file:///$snippetsDir/input/classes/wrongType1.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType2.err
@@ -13,3 +13,7 @@ at wrongType2#pigeon.age (file:///$snippetsDir/input/classes/wrongType2.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType3.err
@@ -13,3 +13,7 @@ at wrongType3#person.address (file:///$snippetsDir/input/classes/wrongType3.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType4.err
@@ -13,3 +13,7 @@ at wrongType4#person.address.street (file:///$snippetsDir/input/classes/wrongTyp
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType6.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/classes/wrongType6.err
@@ -13,3 +13,7 @@ at wrongType6#Person.names (file:///$snippetsDir/input/classes/wrongType6.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeImportsCannotFindModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeImportsCannotFindModule.err
@@ -12,3 +12,7 @@ at analyzeImportsCannotFindModule#res (file:///$snippetsDir/input/errors/analyze
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeImportsInvalidGlob.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeImportsInvalidGlob.err
@@ -12,3 +12,7 @@ at analyzeImportsInvalidGlob#res (file:///$snippetsDir/input/errors/analyzeImpor
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeInvalidHttpModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeInvalidHttpModule.err
@@ -8,3 +8,7 @@ at analyzeInvalidHttpModule#result (file:///$snippetsDir/input/errors/analyzeInv
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeInvalidModuleUri.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeInvalidModuleUri.err
@@ -10,3 +10,7 @@ Illegal character in path at index 3: foo <>
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeRelativeModuleUri.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/analyzeRelativeModuleUri.err
@@ -8,3 +8,7 @@ at analyzeRelativeModuleUri#result (file:///$snippetsDir/input/errors/analyzeRel
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/anyConverterError.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/anyConverterError.err
@@ -7,3 +7,7 @@ xxx | text = renderer.renderDocument(value)
 at pkl.base#Module.output.text (pkl:base)
 
 This value was converted during rendering. Previous: new ModuleClass {}. After: "anyConverterError".
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAmendFixedProperty1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAmendFixedProperty1.err
@@ -8,3 +8,7 @@ at cannotAmendFixedProperty1#n (file:///$snippetsDir/input/errors/cannotAmendFix
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAssignFixedProperty1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAssignFixedProperty1.err
@@ -8,3 +8,7 @@ at cannotAssignFixedProperty1#p (file:///$snippetsDir/input/errors/cannotAssignF
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAssignFixedProperty3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAssignFixedProperty3.err
@@ -12,3 +12,7 @@ at cannotAssignFixedProperty3#p.name (file:///$snippetsDir/input/errors/cannotAs
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAssignToNothing.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotAssignToNothing.err
@@ -15,3 +15,7 @@ at cannotAssignToNothing#value (file:///$snippetsDir/input/errors/cannotAssignTo
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotChangeFixed1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotChangeFixed1.err
@@ -10,3 +10,7 @@ Property `name` must be declared fixed, because it overrides a fixed property on
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotChangeFixed2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotChangeFixed2.err
@@ -10,3 +10,7 @@ Property `name` cannot be declared fixed, because it overrides a non-fixed prope
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotFindMapKey.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotFindMapKey.err
@@ -13,3 +13,7 @@ Did you mean any of the following?
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotFindStdLibModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotFindStdLibModule.err
@@ -34,3 +34,7 @@ at cannotFindStdLibModule#res1 (file:///$snippetsDir/input/errors/cannotFindStdL
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotInstantiateAbstractModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotInstantiateAbstractModule.err
@@ -11,3 +11,7 @@ Instead, instantiate a concrete subclass.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotRenderMixin.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/cannotRenderMixin.err
@@ -11,3 +11,7 @@ Consider adding a converter to `output.converters`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constAnnotation.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constAnnotation.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constAnnotation2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constAnnotation2.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constClassBody.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constClassBody.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constExplicitThis.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constExplicitThis.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constExplicitThisMethod.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constExplicitThisMethod.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constFunctionCallingNonConst.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constFunctionCallingNonConst.err
@@ -16,3 +16,7 @@ at constFunctionCallingNonConst#res (file:///$snippetsDir/input/errors/const/con
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constImplicitThis.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constImplicitThis.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constImplicitThisMethod.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constImplicitThisMethod.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constLexicalScope.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constLexicalScope.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constLocalMethod.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constLocalMethod.err
@@ -16,3 +16,7 @@ at constLocalMethod#obj.res (file:///$snippetsDir/input/errors/const/constLocalM
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constLocalProperty.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constLocalProperty.err
@@ -16,3 +16,7 @@ at constLocalProperty#foo.res2 (file:///$snippetsDir/input/errors/const/constLoc
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constMethod.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constMethod.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constMethod2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constMethod2.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constModule.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constOuter.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constOuter.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constOuter2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constOuter2.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constQualified.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constQualified.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constSubclass.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constSubclass.err
@@ -10,3 +10,7 @@ Property `x` must be declared const, because it overrides a const property on pa
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constSubclass2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constSubclass2.err
@@ -10,3 +10,7 @@ Property `x` cannot be declared const, because it overrides a non-const property
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constSuper.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constSuper.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constSuperMethod.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constSuperMethod.err
@@ -12,3 +12,7 @@ To fix, do either of:
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constTypeAliasConstraint.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/const/constTypeAliasConstraint.err
@@ -16,3 +16,7 @@ at constTypeAliasConstraint#myValue (file:///$snippetsDir/input/errors/const/con
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails1.err
@@ -13,3 +13,7 @@ at constraintDetails1#birds (file:///$snippetsDir/input/errors/constraintDetails
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails2.err
@@ -14,3 +14,7 @@ at constraintDetails2#birds (file:///$snippetsDir/input/errors/constraintDetails
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/constraintDetails3.err
@@ -13,3 +13,7 @@ at constraintDetails3#foo (file:///$snippetsDir/input/errors/constraintDetails3.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/decodingException.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/decodingException.err
@@ -8,3 +8,7 @@ at decodingException#res (file:///$snippetsDir/input/errors/decodingException.pk
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/extendExternalClass.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/extendExternalClass.err
@@ -10,3 +10,7 @@ External classes can only be extended by standard library classes.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/extendTypeAlias.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/extendTypeAlias.err
@@ -8,3 +8,7 @@ at extendTypeAlias#Baz (file:///$snippetsDir/input/errors/extendTypeAlias.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/forGeneratorCannotIterateOverThisValue.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/forGeneratorCannotIterateOverThisValue.err
@@ -9,3 +9,7 @@ at forGeneratorCannotIterateOverThisValue#foo (file:///$snippetsDir/input/errors
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/forGeneratorCannotIterateOverTyped.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/forGeneratorCannotIterateOverTyped.err
@@ -9,3 +9,7 @@ at forGeneratorCannotIterateOverTyped#foo (file:///$snippetsDir/input/errors/for
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/forGeneratorWrongVariableName.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/forGeneratorWrongVariableName.err
@@ -8,3 +8,7 @@ at forGeneratorWrongVariableName#res[#2] (file:///$snippetsDir/input/errors/forG
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/fullStackTraces.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/fullStackTraces.err
@@ -24,3 +24,7 @@ at fullStackTraces#Foo.foo (file:///$snippetsDir/input/errors/fullStackTraces.pk
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/fullStackTraces2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/fullStackTraces2.err
@@ -25,3 +25,7 @@ at fullStackTraces2#Foo.foo (file:///$snippetsDir/input/errors/fullStackTraces2.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundInClass.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundInClass.err
@@ -11,3 +11,7 @@ bar(x)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundInModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundInModule.err
@@ -11,3 +11,7 @@ bar(x)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundInScope.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundInScope.err
@@ -13,3 +13,7 @@ foob(x)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundMaybeLambda.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundMaybeLambda.err
@@ -12,3 +12,7 @@ Listing
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundMaybeProperty.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/functionNotFoundMaybeProperty.err
@@ -11,3 +11,7 @@ prop
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/intrinsifiedTypeAlias1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/intrinsifiedTypeAlias1.err
@@ -13,3 +13,7 @@ at intrinsifiedTypeAlias1#res1 (file:///$snippetsDir/input/errors/intrinsifiedTy
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/intrinsifiedTypeAlias2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/intrinsifiedTypeAlias2.err
@@ -13,3 +13,7 @@ at intrinsifiedTypeAlias2#res1 (file:///$snippetsDir/input/errors/intrinsifiedTy
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/intrinsifiedTypeAlias3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/intrinsifiedTypeAlias3.err
@@ -13,3 +13,7 @@ at intrinsifiedTypeAlias3#res1 (file:///$snippetsDir/input/errors/intrinsifiedTy
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/intrinsifiedTypeAlias4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/intrinsifiedTypeAlias4.err
@@ -13,3 +13,7 @@ at intrinsifiedTypeAlias4#res1 (file:///$snippetsDir/input/errors/intrinsifiedTy
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidBytes1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidBytes1.err
@@ -13,3 +13,7 @@ at invalidBytes1#foo (file:///$snippetsDir/input/errors/invalidBytes1.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidBytes2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidBytes2.err
@@ -13,3 +13,7 @@ at invalidBytes2#res (file:///$snippetsDir/input/errors/invalidBytes2.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidBytes3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidBytes3.err
@@ -13,3 +13,7 @@ at invalidBytes3#bytes (file:///$snippetsDir/input/errors/invalidBytes3.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidBytes4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidBytes4.err
@@ -13,3 +13,7 @@ at invalidBytes4#res (file:///$snippetsDir/input/errors/invalidBytes4.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidFileUri1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidFileUri1.err
@@ -11,3 +11,7 @@ To resolve relative paths, remove the scheme prefix (remove "file:").
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidFileUri2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidFileUri2.err
@@ -10,3 +10,7 @@ Scheme `file` requires a hierarchical path (there must be a `/` after the first 
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidFileUri3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidFileUri3.err
@@ -11,3 +11,7 @@ To resolve relative paths, remove the scheme prefix (remove "file:").
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidFileUri4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidFileUri4.err
@@ -11,3 +11,7 @@ To resolve relative paths, remove the scheme prefix (remove "file:").
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport1.err
@@ -14,3 +14,7 @@ at invalidGlobImport1#res (file:///$snippetsDir/input/errors/invalidGlobImport1.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport2.err
@@ -14,3 +14,7 @@ at invalidGlobImport2#res (file:///$snippetsDir/input/errors/invalidGlobImport2.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport3.err
@@ -14,3 +14,7 @@ at invalidGlobImport3#res (file:///$snippetsDir/input/errors/invalidGlobImport3.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport5.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport5.err
@@ -12,3 +12,7 @@ at invalidGlobImport5#res (file:///$snippetsDir/input/errors/invalidGlobImport5.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport6.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobImport6.err
@@ -10,3 +10,7 @@ The glob pattern is too complex.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobRead1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobRead1.err
@@ -10,3 +10,7 @@ Sub-patterns cannot be nested. To fix, remove or escape the inner `{` character.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobRead2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobRead2.err
@@ -8,3 +8,7 @@ at invalidGlobRead2#res (file:///$snippetsDir/input/errors/invalidGlobRead2.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobRead3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidGlobRead3.err
@@ -8,3 +8,7 @@ at invalidGlobRead3#res (file:///$snippetsDir/input/errors/invalidGlobRead3.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidImportBackslashSep.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidImportBackslashSep.err
@@ -10,3 +10,7 @@ To resolve modules in nested directories, use `/` as the directory separator.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidTypeName1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidTypeName1.err
@@ -8,3 +8,7 @@ at invalidTypeName1#listing (file:///$snippetsDir/input/errors/invalidTypeName1.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidTypeName3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidTypeName3.err
@@ -8,3 +8,7 @@ at invalidTypeName3#bar (file:///$snippetsDir/input/errors/invalidTypeName3.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidTypeName4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/invalidTypeName4.err
@@ -8,3 +8,7 @@ at invalidTypeName4#foo2 (file:///$snippetsDir/input/errors/invalidTypeName4.pkl
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/letExpressionError1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/letExpressionError1.err
@@ -16,3 +16,7 @@ at letExpressionError1#res1 (file:///$snippetsDir/input/errors/letExpressionErro
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/letExpressionError2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/letExpressionError2.err
@@ -12,3 +12,7 @@ at letExpressionError2#res1 (file:///$snippetsDir/input/errors/letExpressionErro
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/letExpressionErrorTyped.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/letExpressionErrorTyped.err
@@ -13,3 +13,7 @@ at letExpressionErrorTyped#res1 (file:///$snippetsDir/input/errors/letExpression
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError1.err
@@ -13,3 +13,7 @@ at listingTypeCheckError1#res[#1] (file:///$snippetsDir/input/errors/listingType
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError2.err
@@ -13,3 +13,7 @@ at listingTypeCheckError2#res[#1] (file:///$snippetsDir/input/errors/listingType
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError3.err
@@ -13,3 +13,7 @@ at listingTypeCheckError3#res[#1] (file:///$snippetsDir/input/errors/listingType
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError4.err
@@ -13,3 +13,7 @@ at listingTypeCheckError4#res[#1] (file:///$snippetsDir/input/errors/listingType
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError5.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError5.err
@@ -17,3 +17,7 @@ at listingTypeCheckError5#res (file:///$snippetsDir/input/errors/listingTypeChec
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError6.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError6.err
@@ -17,3 +17,7 @@ at listingTypeCheckError6#first (file:///$snippetsDir/input/errors/listingTypeCh
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError7.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError7.err
@@ -13,3 +13,7 @@ at listingTypeCheckError7#foo[#1] (file:///$snippetsDir/input/errors/listingType
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError8.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError8.err
@@ -13,3 +13,7 @@ at listingTypeCheckError8#a[#1][#1] (file:///$snippetsDir/input/errors/listingTy
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError9.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/listingTypeCheckError9.err
@@ -13,3 +13,7 @@ at listingTypeCheckError9#a[#1] (file:///$snippetsDir/input/errors/listingTypeCh
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError1.err
@@ -13,3 +13,7 @@ at mappingTypeCheckError1#res["foo"] (file:///$snippetsDir/input/errors/mappingT
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError10.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError10.err
@@ -13,3 +13,7 @@ at mappingTypeCheckError10#foo["foo"] (file:///$snippetsDir/input/errors/mapping
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError11.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError11.err
@@ -13,3 +13,7 @@ at mappingTypeCheckError11#a[0] (file:///$snippetsDir/input/errors/mappingTypeCh
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError2.err
@@ -13,3 +13,7 @@ at mappingTypeCheckError2#res["foo"] (file:///$snippetsDir/input/errors/mappingT
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError3.err
@@ -17,3 +17,7 @@ at mappingTypeCheckError3#res (file:///$snippetsDir/input/errors/mappingTypeChec
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError4.err
@@ -17,3 +17,7 @@ at mappingTypeCheckError4#res (file:///$snippetsDir/input/errors/mappingTypeChec
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError5.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError5.err
@@ -17,3 +17,7 @@ at mappingTypeCheckError5#res (file:///$snippetsDir/input/errors/mappingTypeChec
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError6.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError6.err
@@ -17,3 +17,7 @@ at mappingTypeCheckError6#res (file:///$snippetsDir/input/errors/mappingTypeChec
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError7.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError7.err
@@ -13,3 +13,7 @@ at mappingTypeCheckError7#res[#1] (file:///$snippetsDir/input/errors/mappingType
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError8.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError8.err
@@ -9,3 +9,7 @@ at mappingTypeCheckError8#res (file:///$snippetsDir/input/errors/mappingTypeChec
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError9.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/mappingTypeCheckError9.err
@@ -17,3 +17,7 @@ at mappingTypeCheckError9#first (file:///$snippetsDir/input/errors/mappingTypeCh
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/moduleExpected.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/moduleExpected.err
@@ -12,3 +12,7 @@ at moduleExpected#result (file:///$snippetsDir/input/errors/moduleExpected.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/moduleImportVersionCheck.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/moduleImportVersionCheck.err
@@ -12,3 +12,7 @@ at moduleImportVersionCheck#res1 (file:///$snippetsDir/input/errors/moduleImport
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/noDefault.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/noDefault.err
@@ -10,3 +10,7 @@ The above error occurred when rendering path `foo` of module `file:///$snippetsD
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/noDefault2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/noDefault2.err
@@ -10,3 +10,7 @@ The above error occurred when rendering path `foo` of module `file:///$snippetsD
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/objectCannotHaveElement.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/objectCannotHaveElement.err
@@ -10,3 +10,7 @@ Only objects of type `Listing` and `Dynamic` can have elements. If you did not m
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/objectCannotHaveElement2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/objectCannotHaveElement2.err
@@ -10,3 +10,7 @@ Only objects of type `Listing` and `Dynamic` can have elements. If you did not m
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/objectCannotHavePredicateMember.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/objectCannotHavePredicateMember.err
@@ -8,3 +8,7 @@ at objectCannotHavePredicateMember#res1 (file:///$snippetsDir/input/errors/objec
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/outOfRange1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/outOfRange1.err
@@ -9,3 +9,7 @@ at outOfRange1#res1 (file:///$snippetsDir/input/errors/outOfRange1.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/outOfRange2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/outOfRange2.err
@@ -9,3 +9,7 @@ at outOfRange2#res1 (file:///$snippetsDir/input/errors/outOfRange2.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/outOfRange3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/outOfRange3.err
@@ -9,3 +9,7 @@ at outOfRange3#res1 (file:///$snippetsDir/input/errors/outOfRange3.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/propertyNotFound1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/propertyNotFound1.err
@@ -12,3 +12,7 @@ xbar
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/propertyNotFound2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/propertyNotFound2.err
@@ -14,3 +14,7 @@ value
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotHaveElement.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotHaveElement.err
@@ -12,3 +12,7 @@ at spreadSyntaxCannotHaveElement#source[#1] (file:///$snippetsDir/input/errors/s
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotHaveEntry.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotHaveEntry.err
@@ -12,3 +12,7 @@ at spreadSyntaxCannotHaveEntry#source["foo"] (file:///$snippetsDir/input/errors/
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotHaveProperty.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotHaveProperty.err
@@ -12,3 +12,7 @@ at spreadSyntaxCannotHaveProperty#source.foo (file:///$snippetsDir/input/errors/
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotIterateOverTyped.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotIterateOverTyped.err
@@ -11,3 +11,7 @@ at spreadSyntaxCannotIterateOverTyped#result (file:///$snippetsDir/input/errors/
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotSpreadListIntoMapping.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxCannotSpreadListIntoMapping.err
@@ -11,3 +11,7 @@ at spreadSyntaxCannotSpreadListIntoMapping#m (file:///$snippetsDir/input/errors/
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxDuplicateEntry1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxDuplicateEntry1.err
@@ -8,3 +8,7 @@ at spreadSyntaxDuplicateEntry1#res (file:///$snippetsDir/input/errors/spreadSynt
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxDuplicateEntry2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxDuplicateEntry2.err
@@ -12,3 +12,7 @@ at spreadSyntaxDuplicateEntry2#source["foo"] (file:///$snippetsDir/input/errors/
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxDuplicateProperty1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxDuplicateProperty1.err
@@ -8,3 +8,7 @@ at spreadSyntaxDuplicateProperty1#res (file:///$snippetsDir/input/errors/spreadS
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxDuplicateProperty2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxDuplicateProperty2.err
@@ -12,3 +12,7 @@ at spreadSyntaxDuplicateProperty2#source.foo (file:///$snippetsDir/input/errors/
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxNullValue.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxNullValue.err
@@ -11,3 +11,7 @@ Try: `...?source`
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxUnknownTypedProperty.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/spreadSyntaxUnknownTypedProperty.err
@@ -15,3 +15,7 @@ at spreadSyntaxUnknownTypedProperty#personDynamic.age (file:///$snippetsDir/inpu
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/stackTraceWithQuotedMemberName.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/stackTraceWithQuotedMemberName.err
@@ -8,3 +8,7 @@ at stackTraceWithQuotedMemberName#one.`two three`.four (file:///$snippetsDir/inp
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/typeMismatchWithSameQualifiedClassName.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/typeMismatchWithSameQualifiedClassName.err
@@ -13,3 +13,7 @@ at foo.bar#baz (file:///$snippetsDir/input/errors/typeMismatchWithSameQualifiedC
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/typeMismatchWithSameQualifiedModuleName.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/typeMismatchWithSameQualifiedModuleName.err
@@ -13,3 +13,7 @@ at foo.bar#mod (file:///$snippetsDir/input/errors/typeMismatchWithSameQualifiedM
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedOp1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedOp1.err
@@ -9,3 +9,7 @@ at undefinedOp1#res1 (file:///$snippetsDir/input/errors/undefinedOp1.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedOp2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedOp2.err
@@ -10,3 +10,7 @@ at undefinedOp2#res1 (file:///$snippetsDir/input/errors/undefinedOp2.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedOp3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedOp3.err
@@ -10,3 +10,7 @@ at undefinedOp3#res1 (file:///$snippetsDir/input/errors/undefinedOp3.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty1.err
@@ -10,3 +10,7 @@ The above error occurred when rendering path `res1.name` of module `file:///$sni
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty2.err
@@ -10,3 +10,7 @@ The above error occurred when rendering path `name` of module `file:///$snippets
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty3.err
@@ -10,3 +10,7 @@ The above error occurred when rendering path `a.b[new D { dProperty = "dProperty
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty4.err
@@ -8,3 +8,7 @@ at undefinedProperty4#Bar.num (file:///$snippetsDir/input/errors/undefinedProper
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty5.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty5.err
@@ -8,3 +8,7 @@ at undefinedProperty5#Charlie.delta (file:///$snippetsDir/input/errors/undefined
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty6.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty6.err
@@ -12,3 +12,7 @@ at undefinedProperty6#res1 (file:///$snippetsDir/input/errors/undefinedProperty6
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty7.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty7.err
@@ -8,3 +8,7 @@ at undefinedProperty7#Person.name (file:///$snippetsDir/input/errors/undefinedPr
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty8.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/undefinedProperty8.err
@@ -10,3 +10,7 @@ The above error occurred when rendering path `name`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/underscoreLambda.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/underscoreLambda.err
@@ -12,3 +12,7 @@ at underscoreLambda#res (file:///$snippetsDir/input/errors/underscoreLambda.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/underscoreLet.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/underscoreLet.err
@@ -8,3 +8,7 @@ at underscoreLet#foo (file:///$snippetsDir/input/errors/underscoreLet.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/wrongForGeneratorType1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/wrongForGeneratorType1.err
@@ -9,3 +9,7 @@ at wrongForGeneratorType1#res1 (file:///$snippetsDir/input/errors/wrongForGenera
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/wrongForGeneratorType2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/wrongForGeneratorType2.err
@@ -9,3 +9,7 @@ at wrongForGeneratorType2#res1 (file:///$snippetsDir/input/errors/wrongForGenera
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/generators/duplicateDefinition1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/generators/duplicateDefinition1.err
@@ -8,3 +8,7 @@ at duplicateDefinition1#x (file:///$snippetsDir/input/generators/duplicateDefini
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/generators/duplicateDefinition2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/generators/duplicateDefinition2.err
@@ -8,3 +8,7 @@ at duplicateDefinition2#x (file:///$snippetsDir/input/generators/duplicateDefini
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/generators/duplicateDefinition3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/generators/duplicateDefinition3.err
@@ -8,3 +8,7 @@ at duplicateDefinition3#x (file:///$snippetsDir/input/generators/duplicateDefini
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/amendLambdaExternalClassError.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/amendLambdaExternalClassError.err
@@ -17,3 +17,7 @@ at amendLambdaExternalClassError#res1 (file:///$snippetsDir/input/lambdas/amendL
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/amendLambdaTooFewArgsError.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/amendLambdaTooFewArgsError.err
@@ -16,3 +16,7 @@ at amendLambdaTooFewArgsError#res1 (file:///$snippetsDir/input/lambdas/amendLamb
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/amendLambdaTooManyArgsError.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/amendLambdaTooManyArgsError.err
@@ -16,3 +16,7 @@ at amendLambdaTooManyArgsError#res1 (file:///$snippetsDir/input/lambdas/amendLam
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/lambdaStackTrace1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/lambdaStackTrace1.err
@@ -14,3 +14,7 @@ at lambdaStackTrace1#res1 (file:///$snippetsDir/input/lambdas/lambdaStackTrace1.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/lambdaStackTrace2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/lambdaStackTrace2.err
@@ -20,3 +20,7 @@ at lambdaStackTrace2#res1 (file:///$snippetsDir/input/lambdas/lambdaStackTrace2.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/lambdaStackTrace3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/lambdaStackTrace3.err
@@ -12,3 +12,7 @@ at lambdaStackTrace3#res1 (file:///$snippetsDir/input/lambdas/lambdaStackTrace3.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/wrongArgumentListLength.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/lambdas/wrongArgumentListLength.err
@@ -12,3 +12,7 @@ at wrongArgumentListLength#res (file:///$snippetsDir/input/lambdas/wrongArgument
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/mappings/stringKeyNotFound.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/mappings/stringKeyNotFound.err
@@ -13,3 +13,7 @@ Did you mean any of the following?
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/mappings2/duplicateConstantKey.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/mappings2/duplicateConstantKey.err
@@ -8,3 +8,7 @@ at duplicateConstantKey#res1 (file:///$snippetsDir/input/mappings2/duplicateCons
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/mappings2/stringKeyNotFound.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/mappings2/stringKeyNotFound.err
@@ -13,3 +13,7 @@ Did you mean any of the following?
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/modules/invalidAmend1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/modules/invalidAmend1.err
@@ -13,3 +13,7 @@ at invalidAmend1#name (file:///$snippetsDir/input/modules/invalidAmend1.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/modules/invalidAmend6.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/modules/invalidAmend6.err
@@ -18,3 +18,7 @@ uri
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/modules/invalidExtend1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/modules/invalidExtend1.err
@@ -13,3 +13,7 @@ at invalidExtend1#name (file:///$snippetsDir/input/modules/invalidExtend1.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/modules/typedModuleProperties2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/modules/typedModuleProperties2.err
@@ -13,3 +13,7 @@ at typedModuleProperties2#res1 (file:///$snippetsDir/input/modules/typedModulePr
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/modules/typedModuleProperties3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/modules/typedModuleProperties3.err
@@ -13,3 +13,7 @@ at typedModuleProperties3#res1 (file:///$snippetsDir/input/modules/typedModulePr
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/modules/日本語_error.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/modules/日本語_error.err
@@ -8,3 +8,7 @@ at 日本語_error#日本語 (file:///$snippetsDir/input/modules/%E6%97%A5%E6%9C
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/objects/implicitReceiver4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/objects/implicitReceiver4.err
@@ -8,3 +8,7 @@ at implicitReceiver4#foo.bar.y (file:///$snippetsDir/input/objects/implicitRecei
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/objects/outer2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/objects/outer2.err
@@ -12,3 +12,7 @@ x
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport1.err
@@ -12,3 +12,7 @@ A package URI must have its path suffixed by its version (e.g. `package://exampl
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport10.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport10.err
@@ -12,3 +12,7 @@ The only supported checksum algorithm is sha256.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport11.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport11.err
@@ -12,3 +12,7 @@ Checksums in package uris must have form `sha256:<checksum>`.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport2.err
@@ -10,3 +10,7 @@ at badImport2.error#res (file:///$snippetsDir/input/packages/badImport2.error.pk
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport3.err
@@ -12,3 +12,7 @@ The URI must end in `#`, followed by a path string. For example: `package://exam
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport4.err
@@ -12,3 +12,7 @@ The fragment of this URI is interpreted as a path, and it must be absolute (it s
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport7.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport7.err
@@ -13,3 +13,7 @@ at badImport7.error#res (file:///$snippetsDir/input/packages/badImport7.error.pk
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport8.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport8.err
@@ -8,3 +8,7 @@ at badImport8.error#res (package://localhost:0/badImportsWithinPackage@1.0.0#/un
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport9.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badImport9.err
@@ -8,3 +8,7 @@ at invalidPath#res (package://localhost:0/badImportsWithinPackage@1.0.0#/invalid
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead1.err
@@ -12,3 +12,7 @@ A package URI must have its path suffixed by its version (e.g. `package://exampl
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead2.err
@@ -10,3 +10,7 @@ at badRead2.error#res (file:///$snippetsDir/input/packages/badRead2.error.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead3.err
@@ -12,3 +12,7 @@ The URI must end in `#`, followed by a path string. For example: `package://exam
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead4.err
@@ -12,3 +12,7 @@ The fragment of this URI is interpreted as a path, and it must be absolute (it s
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead8.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead8.err
@@ -8,3 +8,7 @@ at unknownDependencyRead#res (package://localhost:0/badImportsWithinPackage@1.0.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead9.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/packages/badRead9.err
@@ -8,3 +8,7 @@ at invalidPathRead#res (package://localhost:0/badImportsWithinPackage@1.0.0#/inv
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/badImport3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/badImport3.err
@@ -8,3 +8,7 @@ at badImport3.error#res (projectpackage://localhost:0/badImportsWithinPackage@1.
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/badRead1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/badRead1.err
@@ -10,3 +10,7 @@ at badRead1.error#res (file:///$snippetsDir/input/projects/project1/badRead1.err
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/directPackageImport.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/directPackageImport.err
@@ -9,3 +9,7 @@ at directPackageImport.error#res (file:///$snippetsDir/input/projects/project1/d
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/cyclicTypeAlias1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/cyclicTypeAlias1.err
@@ -8,3 +8,7 @@ at cyclicTypeAlias1#Foo (file:///$snippetsDir/input/types/cyclicTypeAlias1.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/cyclicTypeAlias2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/cyclicTypeAlias2.err
@@ -16,3 +16,7 @@ at cyclicTypeAlias2#Foo (file:///$snippetsDir/input/types/cyclicTypeAlias2.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/nothingType.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/nothingType.err
@@ -12,3 +12,7 @@ at nothingType#myValue (file:///$snippetsDir/input/types/nothingType.pkl)
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAliasContext.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAliasContext.err
@@ -13,3 +13,7 @@ at typeAliasContext#res[#1] (file:///$snippetsDir/input/types/typeAliasContext.p
 xxx | text = renderer.renderDocument(value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.base#Module.output.text (pkl:base)
+
+xxx | bytes = text.encodeToBytes("UTF-8")
+              ^^^^
+at pkl.base#Module.output.bytes (pkl:base)

--- a/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt
@@ -17,6 +17,7 @@ package org.pkl.core
 
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
@@ -191,7 +192,10 @@ class LanguageSnippetTestsEngine : AbstractLanguageSnippetTestsEngine() {
               }
             }
             .build()
-        evaluator.use { true to it.evaluateOutputText(ModuleSource.path(inputFile)) }
+        evaluator.use { ev ->
+          true to
+            ev.evaluateOutputBytes(ModuleSource.path(inputFile)).toString(StandardCharsets.UTF_8)
+        }
       } catch (e: PklBugException) {
         false to e.stackTraceToString()
       } catch (e: PklException) {


### PR DESCRIPTION
* Add missing truffle boundaries
* Make Java snippet tests eval `output.bytes`, just like the CLI does
* Overwrite language snippet output files
