### PR TITLE
Switch publishing to sonatype central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,8 +32,8 @@ plugins {
 nexusPublishing {
   repositories {
     sonatype {
-      nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-      snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
     }
   }
 }


### PR DESCRIPTION
This configures the gradle-publish plugin to publish to sonatype central, because OSSRH is now EOL'd.

Note: we might want to switch to using jreleaser in the future. From [Sonatype's docs](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#getting-started-for-maven-api-like-plugins):

> The Portal OSSRH Staging API is a partial reimplementation of the OSSRH / Nexus Repository Manager 2 Staging APIs. The intent of this service is to enable publishers who are using existing plugins to have a smooth migration to the Central Publisher Portal. We hope that over time plugins will adopt the [Portal API](https://central.sonatype.org/publish/publish-portal-api/) rather than rely on this service.