### PR TITLE
Fix `pkl.h` header include path for `Exec.configureCompile`

### DIFF
--- a/libpkl/libpkl.gradle.kts
+++ b/libpkl/libpkl.gradle.kts
@@ -164,7 +164,7 @@ fun Exec.configureCompile(target: Target) {
 
   doLast {
     copy {
-      from(file("src/c/pkl.h"))
+      from(file("src/main/c/pkl.h"))
       into(target.outputDir)
     }
   }


### PR DESCRIPTION
Otherwise the main interface `pkl.h` won't be present in the generated library directory.