### PR TITLE
Expose version of Pkl within native library using `pkl_version`

### DIFF
--- a/libpkl/src/main/c/pkl.c
+++ b/libpkl/src/main/c/pkl.c
@@ -31,7 +31,7 @@
 pthread_mutex_t graal_mutex;
 graal_isolatethread_t *isolatethread = NULL;
 
-int pkl_init(PklMessageResponseHandler handler, void *payload) {
+int pkl_init(PklMessageResponseHandler handler, void *userData) {
   if (isolatethread != NULL) {
     perror("pkl_init: isolatethread is already initialised");
     return -1;
@@ -47,7 +47,7 @@ int pkl_init(PklMessageResponseHandler handler, void *payload) {
   }
 
   isolatethread = pkl_internal_init();
-  pkl_internal_register_response_handler(isolatethread, handler, payload);
+  pkl_internal_register_response_handler(isolatethread, handler, userData);
   pkl_internal_server_start(isolatethread);
   pthread_mutex_unlock(&graal_mutex);
 

--- a/libpkl/src/main/c/pkl.c
+++ b/libpkl/src/main/c/pkl.c
@@ -84,3 +84,7 @@ int pkl_close() {
 
   return 0;
 };
+
+char* pkl_version() {
+  return pkl_internal_version(isolatethread);
+}

--- a/libpkl/src/main/c/pkl.h
+++ b/libpkl/src/main/c/pkl.h
@@ -50,3 +50,10 @@ int pkl_send_message(int length, char *message);
  * @return -1 on failure, 0 on success.
  */
 int pkl_close();
+
+/**
+ * Returns the version of Pkl in use.
+ *
+ * @return a string with the version information.
+ */
+char* pkl_version();

--- a/libpkl/src/main/java/org/pkl/libpkl/LibPkl.java
+++ b/libpkl/src/main/java/org/pkl/libpkl/LibPkl.java
@@ -22,7 +22,9 @@ import org.graalvm.nativeimage.c.function.CFunction.Transition;
 import org.graalvm.nativeimage.c.function.CFunctionPointer;
 import org.graalvm.nativeimage.c.function.InvokeCFunctionPointer;
 import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CTypeConversion;
 import org.graalvm.nativeimage.c.type.VoidPointer;
+import org.pkl.core.Release;
 import org.pkl.core.messaging.MessageTransports.Logger;
 import org.pkl.server.Server;
 
@@ -71,6 +73,15 @@ public class LibPkl {
   @CEntryPoint(name = "pkl_internal_server_stop")
   public static void pklInternalServerStop(IsolateThread thread) {
     server.close();
+  }
+
+  @CEntryPoint(name = "pkl_internal_version")
+  public static CCharPointer pklInternalVersion(IsolateThread thread) {
+    var version = Release.current().version();
+
+    try (var versionInfoCCharHolder = CTypeConversion.toCString(version.toString())) {
+      return versionInfoCCharHolder.get();
+    }
   }
 
   public static void handleSendMessageToNative(byte[] bytes) {

--- a/libpkl/src/nativeTest/kotlin/org/pkl/libpkl/LibPklJNA.kt
+++ b/libpkl/src/nativeTest/kotlin/org/pkl/libpkl/LibPklJNA.kt
@@ -35,4 +35,6 @@ interface LibPklJNA : Library {
   fun pkl_send_message(length: Int, message: ByteArray): Int
 
   fun pkl_close(): Int
+
+  fun pkl_version(): String
 }

--- a/libpkl/src/nativeTest/kotlin/org/pkl/libpkl/LibPklTest.kt
+++ b/libpkl/src/nativeTest/kotlin/org/pkl/libpkl/LibPklTest.kt
@@ -15,10 +15,13 @@
  */
 package org.pkl.libpkl
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.pkl.commons.test.server.AbstractServerTest
 import org.pkl.commons.test.server.TestTransport
+import org.pkl.core.Release
 
 /**
  * Tests libpkl bindings by using JNA (see [LibPklJNA] and [LibPklMessageTransport]).
@@ -42,5 +45,10 @@ class LibPklTest : AbstractServerTest() {
   @AfterEach
   fun afterEach() {
     client.close()
+  }
+
+  @Test
+  fun testVersionString() {
+    assertThat(LibPklJNA.INSTANCE.pkl_version()).isEqualTo(Release.current().version.toString())
   }
 }


### PR DESCRIPTION
This allows consumers of the native library to know which version of Pkl they're using, e.g. to build version-specific gates around newer functionality.