### PR TITLE
Fix: use http.rewrites to configure the evaluator in message passing API

### DIFF
--- a/pkl-server/src/main/kotlin/org/pkl/server/ServerMessagePackDecoder.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ServerMessagePackDecoder.kt
@@ -99,8 +99,8 @@ class ServerMessagePackDecoder(unpacker: MessageUnpacker) : BaseMessagePackDecod
       getNullable(httpMap, "rewrites")
         ?.asMapValue()
         ?.map()
-        ?.mapKeys { it.key.asStringValue().asString() }
-        ?.mapValues { it.value.asStringValue().asString() }
+        ?.mapKeys { URI(it.key.asStringValue().asString()) }
+        ?.mapValues { URI(it.value.asStringValue().asString()) }
     return Http(caCertificates, proxy, rewrites)
   }
 

--- a/pkl-server/src/main/kotlin/org/pkl/server/ServerMessagePackEncoder.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ServerMessagePackEncoder.kt
@@ -48,8 +48,8 @@ class ServerMessagePackEncoder(packer: MessagePacker) : BaseMessagePackEncoder(p
       packString("rewrites")
       packMapHeader(rewrites.size)
       for ((key, value) in rewrites) {
-        packString(key)
-        packString(value)
+        packString(key.toString())
+        packString(value.toString())
       }
     }
   }

--- a/pkl-server/src/main/kotlin/org/pkl/server/ServerMessages.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ServerMessages.kt
@@ -57,7 +57,7 @@ data class Http(
   /** Proxy settings */
   val proxy: Proxy?,
   /** HTTP rewrites */
-  val rewrites: Map<String, String>?,
+  val rewrites: Map<URI, URI>?,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/pkl-server/src/test/kotlin/org/pkl/server/ServerMessagePackCodecTest.kt
+++ b/pkl-server/src/test/kotlin/org/pkl/server/ServerMessagePackCodecTest.kt
@@ -96,7 +96,7 @@ class ServerMessagePackCodecTest {
           Http(
             proxy = Proxy(URI("http://foo.com:1234"), listOf("bar", "baz")),
             caCertificates = byteArrayOf(1, 2, 3, 4),
-            rewrites = mapOf("https://foo.com" to "https://bar.com"),
+            rewrites = mapOf(URI("https://foo.com/") to URI("https://bar.com/")),
           ),
         externalModuleReaders = mapOf("external" to externalReader, "external2" to externalReader),
         externalResourceReaders = mapOf("external" to externalReader),


### PR DESCRIPTION
This is a bugfix, where the `rewrites` option is currently ignored.

Also: return any illegal argument errors from creating the evaluator as an error in the CreateEvaluatorResponse