### PR TITLE
Defer noproxy to settings.pkl or PklProject if not set explicitly

### DIFF
--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliMainTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliMainTest.kt
@@ -149,6 +149,14 @@ class CliMainTest {
     assertThat(ex.message).contains("Rewrite rule must end with '/', but was 'http://foo.com'")
   }
 
+  @Test
+  fun `missing --http-no-proxy flag is null`(@TempDir tempDir: Path) {
+    val inputFile = tempDir.resolve("test.pkl").writeString("").toString()
+    val command = EvalCommand()
+    command.parse(arrayOf(inputFile))
+    assertThat(command.baseOptions.noProxy).isNull()
+  }
+
   private fun makeInput(tempDir: Path, fileName: String = "test.pkl"): String {
     val code = "x = 1"
     return tempDir.resolve(fileName).writeString(code).toString()

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -321,7 +321,7 @@ class BaseOptions : OptionGroup() {
       noProject = projectOptions?.noProject ?: false,
       caCertificates = caCertificates,
       httpProxy = proxy,
-      httpNoProxy = noProxy ?: emptyList(),
+      httpNoProxy = noProxy,
       httpRewrites = httpRewrites.ifEmpty { null },
       externalModuleReaders = externalModuleReaders,
       externalResourceReaders = externalResourceReaders,


### PR DESCRIPTION
Fixes an issue where `http.noProxy` settings are ignored.

Closes #1142 