### PR TITLE
Add `bytesType` to pkl:reflect

### DIFF
--- a/stdlib/reflect.pkl
+++ b/stdlib/reflect.pkl
@@ -100,6 +100,10 @@ const listingType: DeclaredType = DeclaredType(Class(Listing))
 /// A mirror for the `Mapping<unknown, unknown>` type.
 const mappingType: DeclaredType = DeclaredType(Class(Mapping))
 
+/// A mirror for the `Bytes` type.
+@Since { version = "0.29.0" }
+const bytesType: DeclaredType = DeclaredType(Class(Bytes))
+
 /// A mirror for the `module` type.
 external const moduleType: ModuleType
 


### PR DESCRIPTION
Just like other data types on the base module, the mirror for `Bytes` should be available directly on `pkl:reflect`.