### PR TITLE
Disable publishing native executables to Maven Central

### DIFF
--- a/buildSrc/src/main/kotlin/pklNativeExecutable.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklNativeExecutable.gradle.kts
@@ -20,7 +20,8 @@ plugins {
   id("pklGraalVm")
   id("pklJavaLibrary")
   id("pklNativeLifecycle")
-  id("pklPublishLibrary")
+// TODO: re-enable maven publishing
+//  id("pklPublishLibrary")
   id("com.github.johnrengelman.shadow")
 }
 
@@ -170,122 +171,122 @@ val assembleNativeAlpineLinuxAmd64 by tasks.existing { wraps(alpineExecutableAmd
 
 val assembleNativeWindowsAmd64 by tasks.existing { wraps(windowsExecutableAmd64) }
 
-publishing {
-  publications {
-    // need to put in `afterEvaluate` because `artifactId` cannot be set lazily.
-    project.afterEvaluate {
-      create<MavenPublication>("macExecutableAmd64") {
-        artifactId = "${executableSpec.publicationName.get()}-macos-amd64"
-        artifact(stagedMacAmd64Executable.singleFile) {
-          classifier = null
-          extension = "bin"
-          builtBy(stagedMacAmd64Executable)
-        }
-        pom {
-          name = "${executableSpec.publicationName.get()}-macos-amd64"
-          url = executableSpec.website
-          description =
-            executableSpec.documentationName.map { name ->
-              "Native $name executable for macOS/amd64."
-            }
-        }
-      }
-
-      create<MavenPublication>("macExecutableAarch64") {
-        artifactId = "${executableSpec.publicationName.get()}-macos-aarch64"
-        artifact(stagedMacAarch64Executable.singleFile) {
-          classifier = null
-          extension = "bin"
-          builtBy(stagedMacAarch64Executable)
-        }
-        pom {
-          name = "${executableSpec.publicationName.get()}-macos-aarch64"
-          url = executableSpec.website
-          description =
-            executableSpec.documentationName.map { name ->
-              "Native $name executable for macOS/aarch64."
-            }
-        }
-      }
-
-      create<MavenPublication>("linuxExecutableAmd64") {
-        artifactId = "${executableSpec.publicationName.get()}-linux-amd64"
-        artifact(stagedLinuxAmd64Executable.singleFile) {
-          classifier = null
-          extension = "bin"
-          builtBy(stagedLinuxAmd64Executable)
-        }
-        pom {
-          name = "${executableSpec.publicationName.get()}-linux-amd64"
-          url = executableSpec.website
-          description =
-            executableSpec.documentationName.map { name ->
-              "Native $name executable for linux/amd64."
-            }
-        }
-      }
-
-      create<MavenPublication>("linuxExecutableAarch64") {
-        artifactId = "${executableSpec.publicationName.get()}-linux-aarch64"
-        artifact(stagedLinuxAarch64Executable.singleFile) {
-          classifier = null
-          extension = "bin"
-          builtBy(stagedLinuxAarch64Executable)
-        }
-        pom {
-          name = "${executableSpec.publicationName.get()}-linux-aarch64"
-          url = executableSpec.website
-          description =
-            executableSpec.documentationName.map { name ->
-              "Native $name executable for linux/aarch64."
-            }
-        }
-      }
-
-      create<MavenPublication>("alpineLinuxExecutableAmd64") {
-        artifactId = "${executableSpec.publicationName.get()}-alpine-linux-amd64"
-        artifact(stagedAlpineLinuxAmd64Executable.singleFile) {
-          classifier = null
-          extension = "bin"
-          builtBy(stagedAlpineLinuxAmd64Executable)
-        }
-        pom {
-          name = "${executableSpec.publicationName.get()}-alpine-linux-amd64"
-          url = executableSpec.website
-          description =
-            executableSpec.documentationName.map { name ->
-              "Native $name executable for linux/amd64 and statically linked to musl."
-            }
-        }
-      }
-
-      create<MavenPublication>("windowsExecutableAmd64") {
-        artifactId = "${executableSpec.publicationName.get()}-windows-amd64"
-        artifact(stagedWindowsAmd64Executable.singleFile) {
-          classifier = null
-          extension = "exe"
-          builtBy(stagedWindowsAmd64Executable)
-        }
-        pom {
-          name = "${executableSpec.publicationName.get()}-windows-amd64"
-          url = executableSpec.website
-          description =
-            executableSpec.documentationName.map { name ->
-              "Native $name executable for windows/amd64."
-            }
-        }
-      }
-    }
-  }
-}
-
-signing {
-  project.afterEvaluate {
-    sign(publishing.publications["linuxExecutableAarch64"])
-    sign(publishing.publications["linuxExecutableAmd64"])
-    sign(publishing.publications["macExecutableAarch64"])
-    sign(publishing.publications["macExecutableAmd64"])
-    sign(publishing.publications["alpineLinuxExecutableAmd64"])
-    sign(publishing.publications["windowsExecutableAmd64"])
-  }
-}
+//publishing {
+//  publications {
+//    // need to put in `afterEvaluate` because `artifactId` cannot be set lazily.
+//    project.afterEvaluate {
+//      create<MavenPublication>("macExecutableAmd64") {
+//        artifactId = "${executableSpec.publicationName.get()}-macos-amd64"
+//        artifact(stagedMacAmd64Executable.singleFile) {
+//          classifier = null
+//          extension = "bin"
+//          builtBy(stagedMacAmd64Executable)
+//        }
+//        pom {
+//          name = "${executableSpec.publicationName.get()}-macos-amd64"
+//          url = executableSpec.website
+//          description =
+//            executableSpec.documentationName.map { name ->
+//              "Native $name executable for macOS/amd64."
+//            }
+//        }
+//      }
+//
+//      create<MavenPublication>("macExecutableAarch64") {
+//        artifactId = "${executableSpec.publicationName.get()}-macos-aarch64"
+//        artifact(stagedMacAarch64Executable.singleFile) {
+//          classifier = null
+//          extension = "bin"
+//          builtBy(stagedMacAarch64Executable)
+//        }
+//        pom {
+//          name = "${executableSpec.publicationName.get()}-macos-aarch64"
+//          url = executableSpec.website
+//          description =
+//            executableSpec.documentationName.map { name ->
+//              "Native $name executable for macOS/aarch64."
+//            }
+//        }
+//      }
+//
+//      create<MavenPublication>("linuxExecutableAmd64") {
+//        artifactId = "${executableSpec.publicationName.get()}-linux-amd64"
+//        artifact(stagedLinuxAmd64Executable.singleFile) {
+//          classifier = null
+//          extension = "bin"
+//          builtBy(stagedLinuxAmd64Executable)
+//        }
+//        pom {
+//          name = "${executableSpec.publicationName.get()}-linux-amd64"
+//          url = executableSpec.website
+//          description =
+//            executableSpec.documentationName.map { name ->
+//              "Native $name executable for linux/amd64."
+//            }
+//        }
+//      }
+//
+//      create<MavenPublication>("linuxExecutableAarch64") {
+//        artifactId = "${executableSpec.publicationName.get()}-linux-aarch64"
+//        artifact(stagedLinuxAarch64Executable.singleFile) {
+//          classifier = null
+//          extension = "bin"
+//          builtBy(stagedLinuxAarch64Executable)
+//        }
+//        pom {
+//          name = "${executableSpec.publicationName.get()}-linux-aarch64"
+//          url = executableSpec.website
+//          description =
+//            executableSpec.documentationName.map { name ->
+//              "Native $name executable for linux/aarch64."
+//            }
+//        }
+//      }
+//
+//      create<MavenPublication>("alpineLinuxExecutableAmd64") {
+//        artifactId = "${executableSpec.publicationName.get()}-alpine-linux-amd64"
+//        artifact(stagedAlpineLinuxAmd64Executable.singleFile) {
+//          classifier = null
+//          extension = "bin"
+//          builtBy(stagedAlpineLinuxAmd64Executable)
+//        }
+//        pom {
+//          name = "${executableSpec.publicationName.get()}-alpine-linux-amd64"
+//          url = executableSpec.website
+//          description =
+//            executableSpec.documentationName.map { name ->
+//              "Native $name executable for linux/amd64 and statically linked to musl."
+//            }
+//        }
+//      }
+//
+//      create<MavenPublication>("windowsExecutableAmd64") {
+//        artifactId = "${executableSpec.publicationName.get()}-windows-amd64"
+//        artifact(stagedWindowsAmd64Executable.singleFile) {
+//          classifier = null
+//          extension = "exe"
+//          builtBy(stagedWindowsAmd64Executable)
+//        }
+//        pom {
+//          name = "${executableSpec.publicationName.get()}-windows-amd64"
+//          url = executableSpec.website
+//          description =
+//            executableSpec.documentationName.map { name ->
+//              "Native $name executable for windows/amd64."
+//            }
+//        }
+//      }
+//    }
+//  }
+//}
+//
+//signing {
+//  project.afterEvaluate {
+//    sign(publishing.publications["linuxExecutableAarch64"])
+//    sign(publishing.publications["linuxExecutableAmd64"])
+//    sign(publishing.publications["macExecutableAarch64"])
+//    sign(publishing.publications["macExecutableAmd64"])
+//    sign(publishing.publications["alpineLinuxExecutableAmd64"])
+//    sign(publishing.publications["windowsExecutableAmd64"])
+//  }
+//}

--- a/buildSrc/src/main/kotlin/pklNativeExecutable.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklNativeExecutable.gradle.kts
@@ -20,8 +20,8 @@ plugins {
   id("pklGraalVm")
   id("pklJavaLibrary")
   id("pklNativeLifecycle")
-// TODO: re-enable maven publishing
-//  id("pklPublishLibrary")
+  // TODO: re-enable maven publishing
+  //  id("pklPublishLibrary")
   id("com.github.johnrengelman.shadow")
 }
 
@@ -171,7 +171,7 @@ val assembleNativeAlpineLinuxAmd64 by tasks.existing { wraps(alpineExecutableAmd
 
 val assembleNativeWindowsAmd64 by tasks.existing { wraps(windowsExecutableAmd64) }
 
-//publishing {
+// publishing {
 //  publications {
 //    // need to put in `afterEvaluate` because `artifactId` cannot be set lazily.
 //    project.afterEvaluate {
@@ -278,9 +278,9 @@ val assembleNativeWindowsAmd64 by tasks.existing { wraps(windowsExecutableAmd64)
 //      }
 //    }
 //  }
-//}
+// }
 //
-//signing {
+// signing {
 //  project.afterEvaluate {
 //    sign(publishing.publications["linuxExecutableAarch64"])
 //    sign(publishing.publications["linuxExecutableAmd64"])
@@ -289,4 +289,4 @@ val assembleNativeWindowsAmd64 by tasks.existing { wraps(windowsExecutableAmd64)
 //    sign(publishing.publications["alpineLinuxExecutableAmd64"])
 //    sign(publishing.publications["windowsExecutableAmd64"])
 //  }
-//}
+// }

--- a/docs/modules/release-notes/pages/0.29.adoc
+++ b/docs/modules/release-notes/pages/0.29.adoc
@@ -381,6 +381,10 @@ Code that references the name from the lexical scope will continue to work as-is
 
 To learn more about name resolution, consult the xref:language-reference:index.adoc#name-resolution[language reference].
 
+=== Native executables are not published to Maven Central
+
+Due to a breakage in release pipeline, the `pkl` native executables are no longer published to Maven Central (https://github.com/apple/pkl/pull/1146[#1146]).
+
 == Miscellaneous [small]#🐸#
 
 * Documentation improvements (https://github.com/apple/pkl/pull/1065[#1065], https://github.com/apple/pkl/pull/1127[#1127]).


### PR DESCRIPTION
Attempts to publish these artifacts is resulting in errors like "No Archiver found for the stream signature"