### PR TITLE
Fix download links

### DIFF
--- a/docs/modules/ROOT/partials/component-attributes.adoc
+++ b/docs/modules/ROOT/partials/component-attributes.adoc
@@ -23,9 +23,9 @@ endif::[]
 
 :uri-maven-docsite: https://central.sonatype.com
 
-:uri-sonatype: https://s01.oss.sonatype.org/content/groups/public
+:uri-snapshot-repo: https://central.sonatype.com/repository/maven-snapshots/
 
-:uri-maven-repo: https://s01.oss.sonatype.org/content/groups/public
+:uri-maven-repo: https://central.sonatype.com/repository/maven-snapshots
 ifdef::is-release-version[]
 :uri-maven-repo: https://repo1.maven.org/maven2
 endif::[]
@@ -150,4 +150,5 @@ endif::[]
 
 :uri-pkl-roadmap: https://github.com/orgs/apple/projects/12/views/1
 
+// TODO: figure out what the correct URL should be
 :uri-sonatype-snapshot-download: https://s01.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.pkl-lang&v={pkl-artifact-version}

--- a/docs/modules/java-binding/pages/codegen.adoc
+++ b/docs/modules/java-binding/pages/codegen.adoc
@@ -5,7 +5,7 @@ include::ROOT:partial$component-attributes.adoc[]
 :uri-pkl-codegen-java-download: {uri-sonatype-snapshot-download}&a=pkl-cli-codegen-java&e=jar
 
 ifdef::is-release-version[]
-:uri-pkl-cli-codegen-java-download: {github-releases}/pkl-codegen-java
+:uri-pkl-codegen-java-download: {github-releases}/pkl-codegen-java
 endif::[]
 
 The Java source code generator takes Pkl class definitions as an input, and generates corresponding Java classes with equally named properties.
@@ -33,7 +33,7 @@ The `pkl-codegen-java` library is available {uri-pkl-codegen-java-maven-module}[
 It requires Java 17 or higher.
 
 ifndef::is-release-version[]
-NOTE: Snapshots are published to repository `{uri-sonatype}`.
+NOTE: Snapshots are published to repository `{uri-snapshot-repo}`.
 endif::[]
 
 ==== Gradle

--- a/docs/modules/pkl-doc/pages/index.adoc
+++ b/docs/modules/pkl-doc/pages/index.adoc
@@ -94,7 +94,7 @@ The `pkl-doc` library is available {uri-pkl-doc-maven}[from Maven Central].
 It requires Java 17 or higher.
 
 ifndef::is-release-version[]
-NOTE: Snapshots are published to repository `{uri-sonatype}`.
+NOTE: Snapshots are published to repository `{uri-snapshot-repo}`.
 endif::[]
 
 ==== Gradle

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -25,7 +25,7 @@ It requires Java 17 or higher and Gradle 8.1 or higher.
 Earlier Gradle versions are not supported.
 
 ifndef::is-release-version[]
-NOTE: Snapshots are published to repository `{uri-sonatype}`.
+NOTE: Snapshots are published to repository `{uri-snapshot-repo}`.
 endif::[]
 
 The plugin is applied as follows:


### PR DESCRIPTION
* Snapshot repo has changed
* Fix a bug where pkl-codegen-java download link points to Sonatype instead of GitHub

Not in the PR: we also need to fix the snapshot download location; but haven't figured out yet what the correct link is.