### PR TITLE
Fix cyclic dependencies bug

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
@@ -288,6 +288,10 @@ public class AstBuilder extends AbstractAstBuilder<Object> {
     isMethodReturnTypeChecked = !isStdLibModule || IoUtils.isTestMode();
   }
 
+  public ModuleInfo getModuleInfo() {
+    return moduleInfo;
+  }
+
   public static AstBuilder create(
       Source source,
       VmLanguage language,

--- a/pkl-core/src/main/java/org/pkl/core/ast/member/ClassNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/ClassNode.java
@@ -99,7 +99,10 @@ public final class ClassNode extends ExpressionNode {
       // nodes
       // via static final fields without having to fear recursive field initialization.
       prototype = module;
-      prototype.setExtraStorage(moduleInfo);
+      // Only set ModuleInfo if it hasn't been set already (to handle cyclic dependencies)
+      if (!prototype.hasExtraStorage()) {
+        prototype.setExtraStorage(moduleInfo);
+      }
       prototype.addProperties(prototypeMembers);
     } else {
       prototype =

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmLanguage.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmLanguage.java
@@ -108,6 +108,11 @@ public final class VmLanguage extends TruffleLanguage<VmContext> {
     var builder =
         AstBuilder.create(
             source, this, moduleContext, moduleKey, resolvedModuleKey, moduleResolver);
+
+    // Set the ModuleInfo on the empty module immediately to handle cyclic dependencies.
+    // This ensures it works even if the module is accessed during initialization via imports
+    emptyModule.setExtraStorage(builder.getModuleInfo());
+
     var moduleNode = builder.visitModule(moduleContext);
     moduleNode.getCallTarget().call(emptyModule, emptyModule);
     MinPklVersionChecker.check(emptyModule, importNode);


### PR DESCRIPTION
In some very specific scenarios cyclic dependencies may lead to a null pointer due to the module not being properly initialized.