### PR TITLE
Improve interrupt handling in `pkl repl`

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/repl/Repl.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/repl/Repl.kt
@@ -52,6 +52,7 @@ internal class Repl(workingDir: Path, private val server: ReplServer) {
 
   private var continuation = false
   private var quit = false
+  private var maybeQuit = false
   private var nextRequestId = 0
 
   fun run() {
@@ -74,11 +75,23 @@ internal class Repl(workingDir: Path, private val server: ReplServer) {
               reader.readLine("pkl$nextRequestId> ")
             }
           } catch (e: UserInterruptException) {
-            ":quit"
+            if (!continuation && reader.buffer.length() == 0) {
+              if (maybeQuit) quit()
+              else {
+                maybeQuit = true
+                println("(To exit, press ^C again or ^D or type :quit)")
+              }
+            } else {
+              maybeQuit = false
+            }
+            inputBuffer = ""
+            continuation = false
+            continue
           } catch (e: EndOfFileException) {
             ":quit"
           }
 
+        maybeQuit = false
         val input = line.trim()
         if (input.isEmpty()) continue
 


### PR DESCRIPTION
The REPL now handles interrupts (Ctrl-C) in a more user-friendly way. Instead of exiting immediately, it behaves like other REPLs:
* If the line is non-empty or in a continuation, the buffer is cleared.
* If the line is empty, print a message with instructions on exiting the REPL.
  * If another interrupt is sent immediately after, exit.

Pressing Ctrl-D immediately exits the REPL, as before.