### PR TITLE
Add support for customizing HTTP headers

### DIFF
--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
@@ -58,7 +58,7 @@ class CliEvaluatorTest {
         name = "pigeon"
         age = 20 + 10
       }
-    """
+      """
         .trimIndent()
 
     private val packageServer = PackageServer()
@@ -243,12 +243,12 @@ person:
       .resolve("test2.pkl")
       .writeString(
         """
-      amends "test.pkl"
-      
-      person {
-        name = "barn owl"
-      }
-      """
+        amends "test.pkl"
+
+        person {
+          name = "barn owl"
+        }
+        """
           .trimIndent()
       )
 
@@ -655,9 +655,9 @@ result = someLib.x
       "output.pcf",
       """
       x = 1
-      
+
       y = 2
-      
+
       z = 3
       """
         .trimIndent(),
@@ -739,7 +739,7 @@ result = someLib.x
               }
             } 
           }
-        """
+          """
             .trimIndent(),
         )
       )
@@ -815,31 +815,31 @@ result = someLib.x
         writePklFile(
           "test0.pkl",
           """
-        output {
-          files {
-            ["foo.pcf"] {
-              value = new Dynamic {
-                ["bar"] = "baz"
+          output {
+            files {
+              ["foo.pcf"] {
+                value = new Dynamic {
+                  ["bar"] = "baz"
+                }
               }
             }
           }
-        }
-        """
+          """
             .trimIndent(),
         ),
         writePklFile(
           "test1.pkl",
           """
-        output {
-          files {
-            ["bar.pcf"] {
-              value = new Dynamic {
-                ["bar"] = "baz"
+          output {
+            files {
+              ["bar.pcf"] {
+                value = new Dynamic {
+                  ["bar"] = "baz"
+                }
               }
             }
           }
-        }
-        """
+          """
             .trimIndent(),
         ),
       )
@@ -860,27 +860,27 @@ result = someLib.x
         writePklFile(
           "bar.pkl",
           """
-        output {
-          files {
-            ["foo.pcf"] {
-              text = "myBar"
+          output {
+            files {
+              ["foo.pcf"] {
+                text = "myBar"
+              }
             }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
         writePklFile(
           "foo.pkl",
           """
-        output {
-          files {
-            ["foo.pcf"] {
-              text = "myFoo"
+          output {
+            files {
+              ["foo.pcf"] {
+                text = "myFoo"
+              }
             }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
       )
@@ -918,7 +918,7 @@ result = someLib.x
             }
           }
         }
-      """
+        """
           .trimIndent(),
       )
     val options =
@@ -949,7 +949,7 @@ result = someLib.x
             }
           }
         }
-      """
+        """
           .trimIndent(),
       )
     val options =
@@ -970,23 +970,23 @@ result = someLib.x
         writePklFile(
           "test1.pkl",
           """
-        output {
-          files {
-            ["."] { text = "bar" }
+          output {
+            files {
+              ["."] { text = "bar" }
+            }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
         writePklFile(
           "test2.pkl",
           """
-        output {
-          files {
-            ["myDir"] { text = "bar" }
+          output {
+            files {
+              ["myDir"] { text = "bar" }
+            }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
       )
@@ -1009,23 +1009,23 @@ result = someLib.x
         writePklFile(
           "test1.pkl",
           """
-        output {
-          files {
-            ["foo.txt"] { text = "bar" }
+          output {
+            files {
+              ["foo.txt"] { text = "bar" }
+            }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
         writePklFile(
           "test2.pkl",
           """
-        output {
-          files {
-            ["foo.txt"] { text = "bar" }
+          output {
+            files {
+              ["foo.txt"] { text = "bar" }
+            }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
       )
@@ -1045,13 +1045,13 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      output {
-        files {
-          ["foo.txt"] { text = "bar" }
-          ["./foo.txt"] { text = "bar" }
+        output {
+          files {
+            ["foo.txt"] { text = "bar" }
+            ["./foo.txt"] { text = "bar" }
+          }
         }
-      }
-    """
+        """
           .trimIndent(),
       )
     val options =
@@ -1071,12 +1071,12 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      output {
-        files {
-          ["foo:bar"] { text = "bar" }
+        output {
+          files {
+            ["foo:bar"] { text = "bar" }
+          }
         }
-      }
-    """
+        """
           .trimIndent(),
       )
 
@@ -1096,12 +1096,12 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      output {
-        files {
-          ["foo\\bar"] { text = "bar" }
+        output {
+          files {
+            ["foo\\bar"] { text = "bar" }
+          }
         }
-      }
-    """
+        """
           .trimIndent(),
       )
 
@@ -1120,10 +1120,10 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      foo {
-        bar = 1
-      }
-    """
+        foo {
+          bar = 1
+        }
+        """
           .trimIndent(),
       )
     val options =
@@ -1136,8 +1136,8 @@ result = someLib.x
     assertThat(buffer.toString(StandardCharsets.UTF_8))
       .isEqualTo(
         """
-      new Dynamic { bar = 1 }
-    """
+        new Dynamic { bar = 1 }
+        """
           .trimIndent()
       )
   }
@@ -1148,13 +1148,13 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      class Person {
-        name: String
+        class Person {
+          name: String
 
-        function toString() = "Person(\(name))"
-      }
-      person: Person = new { name = "Frodo" }
-    """
+          function toString() = "Person(\(name))"
+        }
+        person: Person = new { name = "Frodo" }
+        """
           .trimIndent(),
       )
     val options =
@@ -1173,10 +1173,10 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      person {
-        friend { name = "Bilbo" }
-      }
-    """
+        person {
+          friend { name = "Bilbo" }
+        }
+        """
           .trimIndent(),
       )
     val options =
@@ -1196,17 +1196,17 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      res = 1
-    """
+        res = 1
+        """
           .trimIndent(),
       )
     writePklFile(
       "PklProject",
       """
       amends "pkl:Project"
-      
+
       package = throw("invalid project package")
-    """
+      """
         .trimIndent(),
     )
     val options =
@@ -1225,8 +1225,8 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      res = read*("env:**")
-    """
+        res = read*("env:**")
+        """
           .trimIndent(),
       )
     writePklFile(
@@ -1234,14 +1234,14 @@ result = someLib.x
       // language=Pkl
       """
       amends "pkl:Project"
-      
+
       evaluatorSettings {
         env {
           ["foo"] = "foo"
           ["bar"] = "bar"
         }
       }
-    """
+      """
         .trimIndent(),
     )
     val options =
@@ -1251,12 +1251,12 @@ result = someLib.x
     assertThat(buffer.toString(StandardCharsets.UTF_8))
       .isEqualTo(
         """
-      res {
-        ["env:bar"] = "bar"
-        ["env:foo"] = "foo"
-      }
-      
-    """
+        res {
+          ["env:bar"] = "bar"
+          ["env:foo"] = "foo"
+        }
+
+        """
           .trimIndent()
       )
   }
@@ -1353,10 +1353,10 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      import "package://localhost:0/birds@0.5.0#/catalog/Swallow.pkl"
-      
-      res = Swallow
-    """
+        import "package://localhost:0/birds@0.5.0#/catalog/Swallow.pkl"
+
+        res = Swallow
+        """
           .trimIndent(),
       )
     val buffer = ByteArrayOutputStream()
@@ -1375,14 +1375,14 @@ result = someLib.x
     assertThat(buffer.toString(StandardCharsets.UTF_8))
       .isEqualTo(
         """
-      res {
-        name = "Swallow"
-        favoriteFruit {
-          name = "Apple"
+        res {
+          name = "Swallow"
+          favoriteFruit {
+            name = "Apple"
+          }
         }
-      }
-      
-    """
+
+        """
           .trimIndent()
       )
     assertThat(tempDir.resolve("package-2")).doesNotExist()
@@ -1481,13 +1481,13 @@ result = someLib.x
     assertThat(output)
       .isEqualTo(
         """
-      name = "Ostrich"
+        name = "Ostrich"
 
-      favoriteFruit {
-        name = "Orange"
-      }
+        favoriteFruit {
+          name = "Orange"
+        }
 
-    """
+        """
           .trimIndent()
       )
     verify(getRequestedFor(urlEqualTo("birds@0.5.0")))
@@ -1590,13 +1590,13 @@ result = someLib.x
     homeDir.writeFile(
       "settings.pkl",
       """
-        amends "pkl:settings"
+      amends "pkl:settings"
 
-        http {
-          proxy {
-            address = "http://invalid.proxy.address"
-          }
+      http {
+        proxy {
+          address = "http://invalid.proxy.address"
         }
+      }
       """
         .trimIndent(),
     )
@@ -1677,26 +1677,26 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-          pigeon {
-            name = "Pigeon"
-            diet = "Seeds"
-          }
-          parrot {
-            name = "Parrot"
-            diet = "Seeds"
-          }
-          output {
-            files {
-              ["pigeon.json"] {
-                value = pigeon
-                renderer = new JsonRenderer {}
-              }
-              ["birds/parrot.yaml"] {
-                value = parrot
-                renderer = new YamlRenderer {}
-              }
+        pigeon {
+          name = "Pigeon"
+          diet = "Seeds"
+        }
+        parrot {
+          name = "Parrot"
+          diet = "Seeds"
+        }
+        output {
+          files {
+            ["pigeon.json"] {
+              value = pigeon
+              renderer = new JsonRenderer {}
+            }
+            ["birds/parrot.yaml"] {
+              value = parrot
+              renderer = new YamlRenderer {}
             }
           }
+        }
         """
           .trimIndent(),
       )
@@ -1713,10 +1713,10 @@ result = someLib.x
       realOutputDir.resolve("pigeon.json"),
       "pigeon.json",
       """
-        {
-          "name": "Pigeon",
-          "diet": "Seeds"
-        }
+      {
+        "name": "Pigeon",
+        "diet": "Seeds"
+      }
       """
         .trimIndent(),
     )
@@ -1725,8 +1725,8 @@ result = someLib.x
       realOutputDir.resolve("birds/parrot.yaml"),
       "parrot.yaml",
       """
-        name: Parrot
-        diet: Seeds
+      name: Parrot
+      diet: Seeds
       """
         .trimIndent(),
     )
@@ -1735,10 +1735,10 @@ result = someLib.x
       symlinkOutputDir.resolve("pigeon.json"),
       "pigeon.json",
       """
-        {
-          "name": "Pigeon",
-          "diet": "Seeds"
-        }
+      {
+        "name": "Pigeon",
+        "diet": "Seeds"
+      }
       """
         .trimIndent(),
     )
@@ -1747,8 +1747,8 @@ result = someLib.x
       symlinkOutputDir.resolve("birds/parrot.yaml"),
       "parrot.yaml",
       """
-        name: Parrot
-        diet: Seeds
+      name: Parrot
+      diet: Seeds
       """
         .trimIndent(),
     )

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
@@ -20,6 +20,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 import java.util.regex.Pattern
+import org.pkl.core.Pair
 import org.pkl.core.evaluatorSettings.Color
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings.ExternalReader
 import org.pkl.core.evaluatorSettings.TraceMode
@@ -145,7 +146,7 @@ data class CliBaseOptions(
   val httpRewrites: Map<URI, URI>? = null,
 
   /** HTTP headers to add to the request. */
-  val httpHeaders: Map<String, String>? = null,
+  val httpHeaders: Map<URI, List<Pair<String, String>>>? = null,
 
   /** External module reader process specs */
   val externalModuleReaders: Map<String, ExternalReader> = mapOf(),

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
@@ -144,6 +144,9 @@ data class CliBaseOptions(
   /** URL prefixes to rewrite. */
   val httpRewrites: Map<URI, URI>? = null,
 
+  /** HTTP headers to add to the request. */
+  val httpHeaders: Map<String, String>? = null,
+
   /** External module reader process specs */
   val externalModuleReaders: Map<String, ExternalReader> = mapOf(),
 

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
@@ -146,7 +146,7 @@ data class CliBaseOptions(
   val httpRewrites: Map<URI, URI>? = null,
 
   /** HTTP headers to add to the request. */
-  val httpHeaders: Map<URI, List<Pair<String, String>>>? = null,
+  val httpHeaders: List<Pair<Pattern, List<Pair<String, String>>>>? = null,
 
   /** External module reader process specs */
   val externalModuleReaders: Map<String, ExternalReader> = mapOf(),

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
@@ -196,10 +196,9 @@ data class CliBaseOptions(
       // sort modules to make cli output independent of source module order
       .sorted()
 
-  val normalizedSettingsModule: URI? =
-    settings?.let { uri ->
-      if (uri.isAbsolute) uri else IoUtils.resolve(normalizedWorkingDir.toUri(), uri)
-    }
+  val normalizedSettingsModule: URI? = settings?.let { uri ->
+    if (uri.isAbsolute) uri else IoUtils.resolve(normalizedWorkingDir.toUri(), uri)
+  }
 
   /** [modulePath] after normalization. */
   val normalizedModulePath: List<Path>? = modulePath?.map(normalizedWorkingDir::resolve)

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -218,6 +218,10 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
     cliOptions.httpRewrites ?: evaluatorSettings?.http?.rewrites ?: settings.http?.rewrites()
   }
 
+  private val httpHeaders: Map<String, String>? by lazy {
+    cliOptions.httpHeaders ?: project?.evaluatorSettings?.http?.headers ?: settings.http?.headers
+  }
+
   protected val externalModuleReaders: Map<String, PklEvaluatorSettings.ExternalReader> by lazy {
     (evaluatorSettings?.externalModuleReaders ?: emptyMap()) + cliOptions.externalModuleReaders
   }
@@ -277,6 +281,7 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
         setProxy(proxyAddress, noProxy ?: listOf())
       }
       httpRewrites?.let(::setRewrites)
+      httpHeaders?.let(::setHeaders)
       // Lazy building significantly reduces execution time of commands that do minimal work.
       // However, it means that HTTP client initialization errors won't surface until an HTTP
       // request is made.

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -218,7 +218,7 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
     cliOptions.httpRewrites ?: evaluatorSettings?.http?.rewrites ?: settings.http?.rewrites()
   }
 
-  private val httpHeaders: Map<String, String>? by lazy {
+  private val httpHeaders: Map<URI, List<Pair<String, String>>>? by lazy {
     cliOptions.httpHeaders ?: project?.evaluatorSettings?.http?.headers ?: settings.http?.headers
   }
 

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -218,7 +218,7 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
     cliOptions.httpRewrites ?: evaluatorSettings?.http?.rewrites ?: settings.http?.rewrites()
   }
 
-  private val httpHeaders: Map<URI, List<Pair<String, String>>>? by lazy {
+  private val httpHeaders: List<Pair<Pattern, List<Pair<String, String>>>>? by lazy {
     cliOptions.httpHeaders ?: project?.evaluatorSettings?.http?.headers ?: settings.http?.headers
   }
 

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -33,6 +33,7 @@ import org.pkl.commons.cli.CliException
 import org.pkl.commons.shlex
 import org.pkl.core.Pair as PPair
 import org.pkl.core.evaluatorSettings.Color
+import org.pkl.core.evaluatorSettings.PklEvaluatorSettings
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings.ExternalReader
 import org.pkl.core.evaluatorSettings.TraceMode
 import org.pkl.core.runtime.VmUtils
@@ -304,11 +305,19 @@ class BaseOptions : OptionGroup() {
         try {
           val uri = URI(uriStr.trim())
 
+          val headerRegex = Regex("""^(.+?):[ \t]*(.+)$""")
           val headerPairs =
             headers.split(',').map { header ->
-              val headerParts = header.split(":", limit = 2)
-              require(headerParts.size == 2) { "Header '$header' is not in 'name:value' format. " }
-              PPair(headerParts[0], headerParts[1])
+              val (headerName, headerValue) =
+                headerRegex.find(header)?.destructured
+                  ?: fail("Header '$header' is not in 'name:value' format.")
+              require(PklEvaluatorSettings.HEADER_NAME_REGEX.matcher(headerName).matches()) {
+                "HTTP header name '$headerName' has invalid syntax."
+              }
+              require(PklEvaluatorSettings.HEADER_VALUE_REGEX.matcher(headerValue).matches()) {
+                "HTTP header value '$headerValue' has invalid syntax"
+              }
+              PPair(headerName, headerValue)
             }
           uri to headerPairs
         } catch (e: IllegalArgumentException) {

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -285,6 +285,14 @@ class BaseOptions : OptionGroup() {
       .multiple()
       .toMap()
 
+  val httpHeaders: Map<String, String> by
+    option(
+        names = arrayOf("--http-headers"),
+        metavar = "key=value",
+        help = "HTTP header to add to the request.",
+      )
+      .associate()
+
   val externalModuleReaders: Map<String, ExternalReader> by
     option(
         names = arrayOf("--external-module-reader"),
@@ -351,6 +359,7 @@ class BaseOptions : OptionGroup() {
       httpProxy = proxy,
       httpNoProxy = noProxy,
       httpRewrites = httpRewrites.ifEmpty { null },
+      httpHeaders = httpHeaders.ifEmpty { null },
       externalModuleReaders = externalModuleReaders,
       externalResourceReaders = externalResourceReaders,
       traceMode = traceMode,

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -31,6 +31,7 @@ import java.util.regex.Pattern
 import org.pkl.commons.cli.CliBaseOptions
 import org.pkl.commons.cli.CliException
 import org.pkl.commons.shlex
+import org.pkl.core.Pair as PPair
 import org.pkl.core.evaluatorSettings.Color
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings.ExternalReader
 import org.pkl.core.evaluatorSettings.TraceMode
@@ -285,13 +286,49 @@ class BaseOptions : OptionGroup() {
       .multiple()
       .toMap()
 
-  val httpHeaders: Map<String, String> by
+  val httpHeaders: Map<URI, List<PPair<String, String>>> by
     option(
         names = arrayOf("--http-headers"),
-        metavar = "key=value",
+        metavar = "<uri>=<header name>:<header value>[,<header name>:<header value>...]",
         help = "HTTP header to add to the request.",
       )
-      .associate()
+      .convert { it ->
+        val (uriStr, headers) =
+          it.split("=", limit = 2).let { parts ->
+            require(parts.size == 2) {
+              "Headers must be in the form of <prefix>=<header name>:<header value>"
+            }
+            parts[0] to parts[1]
+          }
+
+        try {
+          val uri = URI(uriStr.trim())
+
+          val headerPairs =
+            headers.split(',').map { header ->
+              val headerParts = header.split(":", limit = 2)
+              require(headerParts.size == 2) { "Header '$header' is not in 'name:value' format. " }
+              PPair(headerParts[0], headerParts[1])
+            }
+          uri to headerPairs
+        } catch (e: IllegalArgumentException) {
+          fail(e.message!!)
+        } catch (e: URISyntaxException) {
+          val message = buildString {
+            append("HTTP headers target `${e.input}` has invalid syntax (${e.reason}).")
+            if (e.index > -1) {
+              append("\n\n")
+              append(e.input)
+              append("\n")
+              append(" ".repeat(e.index))
+              append("^")
+            }
+          }
+          fail(message)
+        }
+      }
+      .multiple()
+      .toMap()
 
   val externalModuleReaders: Map<String, ExternalReader> by
     option(

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -308,13 +308,9 @@ class BaseOptions : OptionGroup() {
                 ?: fail("Header '$header' is not in 'name:value' format.")
             IoUtils.validateHeaderName(headerName)
             IoUtils.validateHeaderValue(headerValue)
-            val headerPair = PPair(headerName, headerValue)
-            val headerPairList = headersMap[stringPattern]
-            if (headerPairList == null) {
-              headersMap[stringPattern] = mutableListOf(headerPair)
-            } else {
-              headerPairList.add(headerPair)
-            }
+            headersMap
+              .computeIfAbsent(stringPattern) { mutableListOf() }
+              .add(PPair(headerName, headerValue))
           }
 
           headersMap.entries.map { PPair(GlobResolver.toRegexPattern(it.key), it.value) }

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -33,10 +33,10 @@ import org.pkl.commons.cli.CliException
 import org.pkl.commons.shlex
 import org.pkl.core.Pair as PPair
 import org.pkl.core.evaluatorSettings.Color
-import org.pkl.core.evaluatorSettings.PklEvaluatorSettings
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings.ExternalReader
 import org.pkl.core.evaluatorSettings.TraceMode
 import org.pkl.core.runtime.VmUtils
+import org.pkl.core.util.GlobResolver
 import org.pkl.core.util.IoUtils
 
 @Suppress("MemberVisibilityCanBePrivate")
@@ -95,6 +95,9 @@ class BaseOptions : OptionGroup() {
         Pair(it.first, ExternalReader(cmd.first(), cmd.drop(1)))
       }
     }
+
+    val HEADER_NAME_REGEX = Pattern.compile("^[a-zA-Z0-9!#$%&'*+-.^_`|~]+$")
+    val HEADER_VALUE_REGEX = Pattern.compile("^[\\t\\u0020-\\u007E\\u0080-\\u00FF]*$")
   }
 
   private val defaults = CliBaseOptions()
@@ -287,14 +290,14 @@ class BaseOptions : OptionGroup() {
       .multiple()
       .toMap()
 
-  val httpHeaders: Map<URI, List<PPair<String, String>>> by
+  val httpHeaders: List<PPair<Pattern, List<PPair<String, String>>>> by
     option(
         names = arrayOf("--http-headers"),
-        metavar = "<uri>=<header name>:<header value>[,<header name>:<header value>...]",
+        metavar = "<url-pattern>=<header name>:<header value>[,<header name>:<header value>...]",
         help = "HTTP header to add to the request.",
       )
       .convert { it ->
-        val (uriStr, headers) =
+        val (stringPattern, headers) =
           it.split("=", limit = 2).let { parts ->
             require(parts.size == 2) {
               "Headers must be in the form of <prefix>=<header name>:<header value>"
@@ -303,7 +306,7 @@ class BaseOptions : OptionGroup() {
           }
 
         try {
-          val uri = URI(uriStr.trim())
+          var pattern = GlobResolver.toRegexPattern(stringPattern)
 
           val headerRegex = Regex("""^(.+?):[ \t]*(.+)$""")
           val headerPairs =
@@ -311,15 +314,15 @@ class BaseOptions : OptionGroup() {
               val (headerName, headerValue) =
                 headerRegex.find(header)?.destructured
                   ?: fail("Header '$header' is not in 'name:value' format.")
-              require(PklEvaluatorSettings.HEADER_NAME_REGEX.matcher(headerName).matches()) {
+              require(HEADER_NAME_REGEX.matcher(headerName).matches()) {
                 "HTTP header name '$headerName' has invalid syntax."
               }
-              require(PklEvaluatorSettings.HEADER_VALUE_REGEX.matcher(headerValue).matches()) {
+              require(HEADER_VALUE_REGEX.matcher(headerValue).matches()) {
                 "HTTP header value '$headerValue' has invalid syntax"
               }
               PPair(headerName, headerValue)
             }
-          uri to headerPairs
+          PPair(pattern, headerPairs)
         } catch (e: IllegalArgumentException) {
           fail(e.message!!)
         } catch (e: URISyntaxException) {
@@ -337,7 +340,6 @@ class BaseOptions : OptionGroup() {
         }
       }
       .multiple()
-      .toMap()
 
   val externalModuleReaders: Map<String, ExternalReader> by
     option(

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -300,28 +300,26 @@ class BaseOptions : OptionGroup() {
       .transformAll { it ->
         val headersMap = mutableMapOf<String, MutableList<PPair<String, String>>>()
 
-        for ((stringPattern, header) in it) {
-          val headerRegex = Regex("""^(.+?):[ \t]*(.+)$""")
-          val (headerName, headerValue) =
-            headerRegex.find(header)?.destructured
-              ?: fail("Header '$header' is not in 'name:value' format.")
-          require(HEADER_NAME_REGEX.matcher(headerName).matches()) {
-            "HTTP header name '$headerName' has invalid syntax."
-          }
-          require(HEADER_VALUE_REGEX.matcher(headerValue).matches()) {
-            "HTTP header value '$headerValue' has invalid syntax"
-          }
-          val headerPair = PPair(headerName, headerValue)
-          val headerPairList = headersMap[stringPattern]
-          if (headerPairList == null) {
-            headersMap[stringPattern] = mutableListOf(headerPair)
-          } else {
-            headerPairList.add(headerPair)
-          }
-        }
-
         try {
+          for ((stringPattern, header) in it) {
+            val headerRegex = Regex("""^(.+?):[ \t]*(.+)$""")
+            val (headerName, headerValue) =
+              headerRegex.find(header)?.destructured
+                ?: fail("Header '$header' is not in 'name:value' format.")
+            IoUtils.validateHeaderName(headerName)
+            IoUtils.validateHeaderValue(headerValue)
+            val headerPair = PPair(headerName, headerValue)
+            val headerPairList = headersMap[stringPattern]
+            if (headerPairList == null) {
+              headersMap[stringPattern] = mutableListOf(headerPair)
+            } else {
+              headerPairList.add(headerPair)
+            }
+          }
+
           headersMap.entries.map { PPair(GlobResolver.toRegexPattern(it.key), it.value) }
+        } catch (e: IllegalArgumentException) {
+          fail(e.message!!)
         } catch (e: GlobResolver.InvalidGlobPatternException) {
           fail(e.message!!)
         }

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -293,53 +293,39 @@ class BaseOptions : OptionGroup() {
   val httpHeaders: List<PPair<Pattern, List<PPair<String, String>>>> by
     option(
         names = arrayOf("--http-headers"),
-        metavar = "<url-pattern>=<header name>:<header value>[,<header name>:<header value>...]",
+        metavar = "<url-pattern>=<header name>:<header value>",
         help = "HTTP header to add to the request.",
       )
-      .convert { it ->
-        val (stringPattern, headers) =
-          it.split("=", limit = 2).let { parts ->
-            require(parts.size == 2) {
-              "Headers must be in the form of <prefix>=<header name>:<header value>"
-            }
-            parts[0] to parts[1]
+      .splitPair()
+      .transformAll { it ->
+        val headersMap = mutableMapOf<String, MutableList<PPair<String, String>>>()
+
+        for ((stringPattern, header) in it) {
+          val headerRegex = Regex("""^(.+?):[ \t]*(.+)$""")
+          val (headerName, headerValue) =
+            headerRegex.find(header)?.destructured
+              ?: fail("Header '$header' is not in 'name:value' format.")
+          require(HEADER_NAME_REGEX.matcher(headerName).matches()) {
+            "HTTP header name '$headerName' has invalid syntax."
           }
+          require(HEADER_VALUE_REGEX.matcher(headerValue).matches()) {
+            "HTTP header value '$headerValue' has invalid syntax"
+          }
+          val headerPair = PPair(headerName, headerValue)
+          val headerPairList = headersMap[stringPattern]
+          if (headerPairList == null) {
+            headersMap[stringPattern] = mutableListOf(headerPair)
+          } else {
+            headerPairList.add(headerPair)
+          }
+        }
 
         try {
-          var pattern = GlobResolver.toRegexPattern(stringPattern)
-
-          val headerRegex = Regex("""^(.+?):[ \t]*(.+)$""")
-          val headerPairs =
-            headers.split(',').map { header ->
-              val (headerName, headerValue) =
-                headerRegex.find(header)?.destructured
-                  ?: fail("Header '$header' is not in 'name:value' format.")
-              require(HEADER_NAME_REGEX.matcher(headerName).matches()) {
-                "HTTP header name '$headerName' has invalid syntax."
-              }
-              require(HEADER_VALUE_REGEX.matcher(headerValue).matches()) {
-                "HTTP header value '$headerValue' has invalid syntax"
-              }
-              PPair(headerName, headerValue)
-            }
-          PPair(pattern, headerPairs)
-        } catch (e: IllegalArgumentException) {
+          headersMap.entries.map { PPair(GlobResolver.toRegexPattern(it.key), it.value) }
+        } catch (e: GlobResolver.InvalidGlobPatternException) {
           fail(e.message!!)
-        } catch (e: URISyntaxException) {
-          val message = buildString {
-            append("HTTP headers target `${e.input}` has invalid syntax (${e.reason}).")
-            if (e.index > -1) {
-              append("\n\n")
-              append(e.input)
-              append("\n")
-              append(" ".repeat(e.index))
-              append("^")
-            }
-          }
-          fail(message)
         }
       }
-      .multiple()
 
   val externalModuleReaders: Map<String, ExternalReader> by
     option(

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -95,9 +95,6 @@ class BaseOptions : OptionGroup() {
         Pair(it.first, ExternalReader(cmd.first(), cmd.drop(1)))
       }
     }
-
-    val HEADER_NAME_REGEX = Pattern.compile("^[a-zA-Z0-9!#$%&'*+-.^_`|~]+$")
-    val HEADER_VALUE_REGEX = Pattern.compile("^[\\t\\u0020-\\u007E\\u0080-\\u00FF]*$")
   }
 
   private val defaults = CliBaseOptions()

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -301,8 +301,8 @@ class BaseOptions : OptionGroup() {
         val headersMap = mutableMapOf<String, MutableList<PPair<String, String>>>()
 
         try {
+          val headerRegex = Regex("""^(.+?):[ \t]*(.+)$""")
           for ((stringPattern, header) in it) {
-            val headerRegex = Regex("""^(.+?):[ \t]*(.+)$""")
             val (headerName, headerValue) =
               headerRegex.find(header)?.destructured
                 ?: fail("Header '$header' is not in 'name:value' format.")

--- a/pkl-core/src/main/java/org/pkl/core/evaluatorSettings/PklEvaluatorSettings.java
+++ b/pkl-core/src/main/java/org/pkl/core/evaluatorSettings/PklEvaluatorSettings.java
@@ -167,13 +167,12 @@ public record PklEvaluatorSettings(
             var pairs = entry.getValue();
             for (var pair : pairs) {
               if (!HEADER_NAME_REGEX.matcher(pair.getFirst()).matches()) {
-                throw new PklException(
-                  ErrorMessages.create("invalidHeaderName", pair.getFirst()));
+                throw new PklException(ErrorMessages.create("invalidHeaderName", pair.getFirst()));
               }
               if (!HEADER_VALUE_REGEX.matcher(pair.getSecond()).matches()) {
                 throw new PklException(
-                  ErrorMessages.create("invalidHeaderValue", pair.getSecond()));
-              } 
+                    ErrorMessages.create("invalidHeaderValue", pair.getSecond()));
+              }
             }
             try {
               parsedHeaders.put(new URI(uri), pairs);

--- a/pkl-core/src/main/java/org/pkl/core/evaluatorSettings/PklEvaluatorSettings.java
+++ b/pkl-core/src/main/java/org/pkl/core/evaluatorSettings/PklEvaluatorSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.pkl.core.evaluatorSettings;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.pkl.core.Duration;
 import org.pkl.core.PNull;
 import org.pkl.core.PObject;
@@ -35,6 +37,8 @@ import org.pkl.core.PklBugException;
 import org.pkl.core.PklException;
 import org.pkl.core.Value;
 import org.pkl.core.util.ErrorMessages;
+import org.pkl.core.util.GlobResolver;
+import org.pkl.core.util.GlobResolver.InvalidGlobPatternException;
 import org.pkl.core.util.Nullable;
 
 /** Java version of {@code pkl.EvaluatorSettings}. */
@@ -53,10 +57,6 @@ public record PklEvaluatorSettings(
     @Nullable Map<String, ExternalReader> externalModuleReaders,
     @Nullable Map<String, ExternalReader> externalResourceReaders,
     @Nullable TraceMode traceMode) {
-
-  public static final Pattern HEADER_NAME_REGEX = Pattern.compile("^[a-zA-Z0-9!#$%&'*+-.^_`|~]+$");
-  public static final Pattern HEADER_VALUE_REGEX =
-      Pattern.compile("^[\\t\\u0020-\\u007E\\u0080-\\u00FF]*$");
 
   /** Initializes a {@link PklEvaluatorSettings} from a raw object representation. */
   @SuppressWarnings("unchecked")
@@ -134,7 +134,7 @@ public record PklEvaluatorSettings(
   public record Http(
       @Nullable Proxy proxy,
       @Nullable Map<URI, URI> rewrites,
-      @Nullable Map<URI, List<Pair<String, String>>> headers) {
+      @Nullable List<Pair<Pattern, List<Pair<String, String>>>> headers) {
     public static final Http DEFAULT = new Http(null, Collections.emptyMap(), null);
 
     @SuppressWarnings("unchecked")
@@ -157,31 +157,36 @@ public record PklEvaluatorSettings(
             }
           }
         }
-        var headers = http.getProperty("headers");
-        HashMap<URI, List<org.pkl.core.Pair<String, String>>> parsedHeaders = null;
-        if (!(headers instanceof PNull)) {
-          parsedHeaders = new HashMap<>();
-          var headersMap = (Map<String, List<Pair<String, String>>>) headers;
-          for (var entry : headersMap.entrySet()) {
-            var uri = entry.getKey();
-            var pairs = entry.getValue();
-            for (var pair : pairs) {
-              if (!HEADER_NAME_REGEX.matcher(pair.getFirst()).matches()) {
-                throw new PklException(ErrorMessages.create("invalidHeaderName", pair.getFirst()));
-              }
-              if (!HEADER_VALUE_REGEX.matcher(pair.getSecond()).matches()) {
-                throw new PklException(
-                    ErrorMessages.create("invalidHeaderValue", pair.getSecond()));
-              }
-            }
+        var headerDefs = http.getProperty("headers");
+        List<Pair<Pattern, List<Pair<String, String>>>> parsedHeaderDefs = null;
+        if (!(headerDefs instanceof PNull)) {
+          parsedHeaderDefs = new ArrayList<>();
+          var headerDefsMap = (Map<String, Map<String, Object>>) headerDefs;
+          for (var entry : headerDefsMap.entrySet()) {
+            var stringPattern = entry.getKey();
+            var headersMap = entry.getValue();
             try {
-              parsedHeaders.put(new URI(uri), pairs);
-            } catch (URISyntaxException e) {
-              throw new PklException(ErrorMessages.create("invalidUri", e.getInput()));
+              var urlPattern = GlobResolver.toRegexPattern(stringPattern);
+              var pairs =
+                  headersMap.entrySet().stream()
+                      .flatMap(
+                          header -> {
+                            var value = header.getValue();
+                            if (value instanceof List) {
+                              return ((List<String>) value)
+                                  .stream().map(v -> new Pair(header.getKey(), v));
+                            } else {
+                              return Stream.of(new Pair(header.getKey(), value));
+                            }
+                          })
+                      .toList();
+              parsedHeaderDefs.add(new Pair(urlPattern, pairs));
+            } catch (InvalidGlobPatternException e) {
+              throw new PklException(ErrorMessages.create("invalidUri", stringPattern));
             }
           }
         }
-        return new Http(proxy, parsedRewrites, parsedHeaders);
+        return new Http(proxy, parsedRewrites, parsedHeaderDefs);
       } else {
         throw PklBugException.unreachableCode();
       }

--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClient.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import javax.net.ssl.SSLContext;
+import org.pkl.core.Pair;
 import org.pkl.core.util.Nullable;
 
 /**
@@ -156,7 +157,7 @@ public interface HttpClient extends AutoCloseable {
      * <p>This method clears all existing headers and replaces them with the contents of the
      * provided map.
      */
-    Builder setHeaders(Map<String, String> headers);
+    Builder setHeaders(Map<URI, List<Pair<String, String>>> headers);
 
     /**
      * Creates a new {@code HttpClient} from the current state of this builder.

--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClient.java
@@ -151,6 +151,14 @@ public interface HttpClient extends AutoCloseable {
     Builder addRewrite(URI sourcePrefix, URI targetPrefix);
 
     /**
+     * Sets the HTTP headers for the request, replacing any previously configured headers.
+     *
+     * <p>This method clears all existing headers and replaces them with the contents of the
+     * provided map.
+     */
+    Builder setHeaders(Map<String, String> headers);
+
+    /**
      * Creates a new {@code HttpClient} from the current state of this builder.
      *
      * @throws HttpClientInitException if an error occurs while initializing the client

--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.net.http.HttpTimeoutException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 import org.pkl.core.Pair;
 import org.pkl.core.util.Nullable;
@@ -157,7 +158,7 @@ public interface HttpClient extends AutoCloseable {
      * <p>This method clears all existing headers and replaces them with the contents of the
      * provided map.
      */
-    Builder setHeaders(Map<URI, List<Pair<String, String>>> headers);
+    Builder setHeaders(List<Pair<Pattern, List<Pair<String, String>>>> headers);
 
     /**
      * Creates a new {@code HttpClient} from the current state of this builder.

--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClientBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClientBuilder.java
@@ -39,6 +39,7 @@ final class HttpClientBuilder implements HttpClient.Builder {
   private int testPort = -1;
   private ProxySelector proxySelector;
   private Map<URI, URI> rewrites = new HashMap<>();
+  private Map<String, String> headers = new HashMap<>();
 
   HttpClientBuilder() {
     var release = Release.current();
@@ -111,6 +112,12 @@ final class HttpClientBuilder implements HttpClient.Builder {
   }
 
   @Override
+  public Builder setHeaders(Map<String, String> headers) {
+    this.headers = new HashMap<>(headers);
+    return this;
+  }
+
+  @Override
   public HttpClient build() {
     return doBuild().get();
   }
@@ -127,7 +134,8 @@ final class HttpClientBuilder implements HttpClient.Builder {
         this.proxySelector != null ? this.proxySelector : java.net.ProxySelector.getDefault();
     return () -> {
       var jdkClient =
-          new JdkHttpClient(certificateFiles, certificateBytes, connectTimeout, proxySelector);
+          new JdkHttpClient(
+              certificateFiles, certificateBytes, connectTimeout, proxySelector, headers);
       return new RequestRewritingClient(userAgent, requestTimeout, testPort, jdkClient, rewrites);
     };
   }

--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClientBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClientBuilder.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import org.pkl.core.Pair;
 import org.pkl.core.Release;
 import org.pkl.core.http.HttpClient.Builder;
 
@@ -39,7 +40,7 @@ final class HttpClientBuilder implements HttpClient.Builder {
   private int testPort = -1;
   private ProxySelector proxySelector;
   private Map<URI, URI> rewrites = new HashMap<>();
-  private Map<String, String> headers = new HashMap<>();
+  private Map<URI, List<Pair<String, String>>> headers = new HashMap<>();
 
   HttpClientBuilder() {
     var release = Release.current();
@@ -112,8 +113,8 @@ final class HttpClientBuilder implements HttpClient.Builder {
   }
 
   @Override
-  public Builder setHeaders(Map<String, String> headers) {
-    this.headers = new HashMap<>(headers);
+  public Builder setHeaders(Map<URI, List<Pair<String, String>>> headers) {
+    this.headers = headers;
     return this;
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/http/HttpClientBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/HttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import org.pkl.core.Pair;
 import org.pkl.core.Release;
 import org.pkl.core.http.HttpClient.Builder;
@@ -40,7 +41,7 @@ final class HttpClientBuilder implements HttpClient.Builder {
   private int testPort = -1;
   private ProxySelector proxySelector;
   private Map<URI, URI> rewrites = new HashMap<>();
-  private Map<URI, List<Pair<String, String>>> headers = new HashMap<>();
+  private List<Pair<Pattern, List<Pair<String, String>>>> headers = new ArrayList<>();
 
   HttpClientBuilder() {
     var release = Release.current();
@@ -113,7 +114,7 @@ final class HttpClientBuilder implements HttpClient.Builder {
   }
 
   @Override
-  public Builder setHeaders(Map<URI, List<Pair<String, String>>> headers) {
+  public Builder setHeaders(List<Pair<Pattern, List<Pair<String, String>>>> headers) {
     this.headers = headers;
     return this;
   }
@@ -135,9 +136,9 @@ final class HttpClientBuilder implements HttpClient.Builder {
         this.proxySelector != null ? this.proxySelector : java.net.ProxySelector.getDefault();
     return () -> {
       var jdkClient =
-          new JdkHttpClient(
-              certificateFiles, certificateBytes, connectTimeout, proxySelector, headers);
-      return new RequestRewritingClient(userAgent, requestTimeout, testPort, jdkClient, rewrites);
+          new JdkHttpClient(certificateFiles, certificateBytes, connectTimeout, proxySelector);
+      return new RequestRewritingClient(
+          userAgent, requestTimeout, testPort, jdkClient, rewrites, headers);
     };
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/http/JdkHttpClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/JdkHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkl-core/src/main/java/org/pkl/core/http/JdkHttpClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/JdkHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.net.ConnectException;
-import java.net.URI;
 import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -42,13 +41,11 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.TrustManagerFactory;
-import org.pkl.core.Pair;
 import org.pkl.core.util.ErrorMessages;
 import org.pkl.core.util.Exceptions;
 
@@ -57,7 +54,6 @@ import org.pkl.core.util.Exceptions;
 final class JdkHttpClient implements HttpClient {
   // non-private for testing
   final java.net.http.HttpClient underlying;
-  final Map<URI, List<Pair<String, String>>> headers;
 
   // call java.net.http.HttpClient.close() if available (JDK 21+)
   private static final MethodHandle closeMethod;
@@ -81,8 +77,7 @@ final class JdkHttpClient implements HttpClient {
       List<Path> certificateFiles,
       List<ByteBuffer> certificateBytes,
       Duration connectTimeout,
-      java.net.ProxySelector proxySelector,
-      Map<URI, List<Pair<String, String>>> headers) {
+      java.net.ProxySelector proxySelector) {
     underlying =
         java.net.http.HttpClient.newBuilder()
             .sslContext(createSslContext(certificateFiles, certificateBytes))
@@ -90,22 +85,13 @@ final class JdkHttpClient implements HttpClient {
             .proxy(proxySelector)
             .followRedirects(Redirect.NORMAL)
             .build();
-    this.headers = headers;
   }
 
   @Override
   public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> responseBodyHandler)
       throws IOException {
     try {
-      var wrappedRequestBuilder = HttpRequest.newBuilder(request, (name, value) -> true);
-      for (var entry : headers.entrySet()) {
-        if (RequestRewritingClient.matchesRewriteRule(request.uri(), entry.getKey())) {
-          for (var value : entry.getValue()) {
-            wrappedRequestBuilder.header(value.getFirst(), value.getSecond());
-          }
-        }
-      }
-      return underlying.send(wrappedRequestBuilder.build(), responseBodyHandler);
+      return underlying.send(request, responseBodyHandler);
     } catch (ConnectException e) {
       // original exception has no message
       throw new ConnectException(

--- a/pkl-core/src/main/java/org/pkl/core/http/RequestRewritingClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/RequestRewritingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import javax.annotation.concurrent.ThreadSafe;
+import org.pkl.core.Pair;
 import org.pkl.core.PklBugException;
 import org.pkl.core.util.HttpUtils;
 import org.pkl.core.util.Nullable;
@@ -54,6 +57,7 @@ final class RequestRewritingClient implements HttpClient {
   final int testPort;
   final HttpClient delegate;
   private final List<Entry<URI, URI>> rewrites;
+  private final List<Pair<Pattern, List<Pair<String, String>>>> headers;
 
   private final AtomicBoolean closed = new AtomicBoolean();
 
@@ -62,7 +66,8 @@ final class RequestRewritingClient implements HttpClient {
       Duration requestTimeout,
       int testPort,
       HttpClient delegate,
-      Map<URI, URI> rewrites) {
+      Map<URI, URI> rewrites,
+      List<Pair<Pattern, List<Pair<String, String>>>> headers) {
     this.userAgent = userAgent;
     this.requestTimeout = requestTimeout;
     this.testPort = testPort;
@@ -72,6 +77,7 @@ final class RequestRewritingClient implements HttpClient {
             .map((it) -> Map.entry(normalizeRewrite(it.getKey()), normalizeRewrite(it.getValue())))
             .sorted(Comparator.comparingInt((it) -> -it.getKey().toString().length()))
             .toList();
+    this.headers = headers;
   }
 
   @Override
@@ -112,6 +118,9 @@ final class RequestRewritingClient implements HttpClient {
         .map()
         .forEach((name, values) -> values.forEach(value -> builder.header(name, value)));
     builder.setHeader("User-Agent", userAgent);
+    for (var header : this.getHeaders(original.uri())) {
+      builder.header(header.getFirst(), header.getSecond());
+    }
 
     var method = original.method();
     original
@@ -214,6 +223,16 @@ final class RequestRewritingClient implements HttpClient {
       ret = HttpUtils.setPort(ret, testPort);
     }
     return ret;
+  }
+
+  private List<Pair<String, String>> getHeaders(URI uri) {
+    return headers.stream()
+        .flatMap(
+            rule ->
+                rule.getFirst().asPredicate().test(uri.toString())
+                    ? rule.getSecond().stream()
+                    : Stream.empty())
+        .toList();
   }
 
   private void checkNotClosed(HttpRequest request) {

--- a/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,36 @@ public final class IoUtils {
   private static final Pattern uriLike = Pattern.compile("[\\w+.-]+:[^\\\\].*");
 
   private static final Pattern windowsPathLike = Pattern.compile("\\w:\\\\.*");
+
+  private static final Pattern headerNameLike = Pattern.compile("^[a-zA-Z0-9!#$%&'*+-.^_`|~]+$");
+
+  private static final Pattern headerValueLike =
+      Pattern.compile("^[\\t\\u0020-\\u007E\\u0080-\\u00FF]*$");
+
+  private static final String[] reservedHeaderNames = {
+    "accept-charset",
+    "accept-encoding",
+    "access-control-request-headers",
+    "access-control-request-method",
+    "connection",
+    "content-length",
+    "cookie",
+    "date",
+    "dnt",
+    "expect",
+    "host",
+    "keep-alive",
+    "origin",
+    "permissions-policy",
+    "referer",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "via"
+  };
+
+  private static final String[] reservedHeaderPrefixs = {"proxy-", "sec-", "access-control-"};
 
   private IoUtils() {}
 
@@ -852,6 +882,43 @@ public final class IoUtils {
     if (!rewrite.toString().endsWith("/")) {
       throw new IllegalArgumentException(
           "Rewrite rule must end with '/', but was '%s'".formatted(rewrite));
+    }
+  }
+
+  private static boolean isReservedHeaderName(String headerName) {
+    return Arrays.stream(reservedHeaderNames).anyMatch((reserved) -> headerName.equals(reserved));
+  }
+
+  private static boolean hasReservedHeaderPrefix(String headerName) {
+    return Arrays.stream(reservedHeaderPrefixs).anyMatch((prefix) -> headerName.startsWith(prefix));
+  }
+
+  public static void validateHeaderName(String headerName) {
+    if (!headerName.equals(headerName.toLowerCase())) {
+      throw new IllegalArgumentException(
+          "HTTP header '%s' should be all lowercase".formatted(headerName));
+    }
+
+    if (isReservedHeaderName(headerName)) {
+      throw new IllegalArgumentException(
+          "HTTP header '%s' is a reserved header".formatted(headerName));
+    }
+
+    if (hasReservedHeaderPrefix(headerName)) {
+      throw new IllegalArgumentException(
+          "HTTP header '%s' starts with a reserved header prefix".formatted(headerName));
+    }
+
+    if (!headerNameLike.matcher(headerName).matches()) {
+      throw new IllegalArgumentException(
+          "HTTP header name '%s' has an invalid syntax".formatted(headerName));
+    }
+  }
+
+  public static void validateHeaderValue(String headerValue) {
+    if (headerValueLike.matcher(headerValue).matches()) {
+      throw new IllegalArgumentException(
+          "HTTP header value '%s' has an invalid syntax".formatted(headerValue));
     }
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
@@ -80,7 +80,7 @@ public final class IoUtils {
     "via"
   };
 
-  private static final String[] reservedHeaderPrefixs = {"proxy-", "sec-", "access-control-"};
+  private static final String[] reservedHeaderPrefixes = {"proxy-", "sec-", "access-control-"};
 
   private IoUtils() {}
 
@@ -576,7 +576,7 @@ public final class IoUtils {
     }
 
     // don't use ServiceLoader.load(Class)
-    // because loading services from thread context class loader doesn't work inside gradle plugins
+    // because loading services from thread context class loader doesn't work inside Gradle plugins
     return ServiceLoader.load(serviceClass, IoUtils.class.getClassLoader());
   }
 
@@ -890,7 +890,7 @@ public final class IoUtils {
   }
 
   private static boolean hasReservedHeaderPrefix(String headerName) {
-    return Arrays.stream(reservedHeaderPrefixs).anyMatch((prefix) -> headerName.startsWith(prefix));
+    return Arrays.stream(reservedHeaderPrefixes).anyMatch((prefix) -> headerName.startsWith(prefix));
   }
 
   public static void validateHeaderName(String headerName) {

--- a/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
@@ -911,7 +911,7 @@ public final class IoUtils {
   }
 
   public static void validateHeaderValue(String headerValue) {
-    if (headerValueLike.matcher(headerValue).matches()) {
+    if (!headerValueLike.matcher(headerValue).matches()) {
       throw new IllegalArgumentException(
           "HTTP header value '%s' has an invalid syntax".formatted(headerValue));
     }

--- a/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
@@ -892,10 +892,6 @@ public final class IoUtils {
   }
 
   public static void validateHeaderName(String headerName) {
-    if (!headerName.equals(headerName.toLowerCase())) {
-      throw new IllegalArgumentException(
-          "HTTP header '%s' should be all lowercase".formatted(headerName));
-    }
 
     if (isReservedHeaderName(headerName)) {
       throw new IllegalArgumentException(

--- a/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
@@ -888,7 +888,8 @@ public final class IoUtils {
   }
 
   private static boolean hasReservedHeaderPrefix(String headerName) {
-    return Arrays.stream(reservedHeaderPrefixes).anyMatch((prefix) -> headerName.startsWith(prefix));
+    return Arrays.stream(reservedHeaderPrefixes)
+        .anyMatch((prefix) -> headerName.startsWith(prefix));
   }
 
   public static void validateHeaderName(String headerName) {

--- a/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/IoUtils.java
@@ -60,8 +60,6 @@ public final class IoUtils {
   private static final String[] reservedHeaderNames = {
     "accept-charset",
     "accept-encoding",
-    "access-control-request-headers",
-    "access-control-request-method",
     "connection",
     "content-length",
     "cookie",

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -1124,3 +1124,9 @@ Option {1}s must not overlap with built-in options.
 commandFlagInvalidType=\
 Option `{0}` with annotation `@{1}` has invalid type `{2}`.\n\
 Expected type: `{3}`
+
+invalidHeaderName=\
+HTTP header name `{0}` has invalid syntax.
+
+invalidHeaderValue=\
+HTTP header value `{0}` has invalid syntax.

--- a/pkl-core/src/test/kotlin/org/pkl/core/http/RequestRewritingClientTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/http/RequestRewritingClientTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,11 @@ import java.net.http.HttpRequest
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.HttpResponse.BodyHandlers
 import java.time.Duration
+import java.util.regex.Pattern
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatList
 import org.junit.jupiter.api.Test
+import org.pkl.core.Pair as PPair
 
 class RequestRewritingClientTest {
   private val captured = RequestCapturingClient()
@@ -34,6 +36,7 @@ class RequestRewritingClientTest {
       -1,
       captured,
       mapOf(URI("https://foo/") to URI("https://bar/")),
+      listOf(),
     )
   private val exampleUri = URI("https://example.com/foo/bar.html")
   private val exampleRequest = HttpRequest.newBuilder(exampleUri).build()
@@ -121,7 +124,8 @@ class RequestRewritingClientTest {
   @Test
   fun `rewrites port 0 if test port is set`() {
     val captured = RequestCapturingClient()
-    val client = RequestRewritingClient("Pkl", Duration.ofSeconds(42), 5000, captured, mapOf())
+    val client =
+      RequestRewritingClient("Pkl", Duration.ofSeconds(42), 5000, captured, mapOf(), listOf())
     val request = HttpRequest.newBuilder(URI("https://example.com:0")).build()
 
     client.send(request, BodyHandlers.discarding())
@@ -303,9 +307,85 @@ class RequestRewritingClientTest {
 
   private fun rewrittenRequest(uri: String, rules: Map<URI, URI>): String {
     val captured = RequestCapturingClient()
-    val client = RequestRewritingClient("Pkl", Duration.ofSeconds(42), -1, captured, rules)
+    val client =
+      RequestRewritingClient("Pkl", Duration.ofSeconds(42), -1, captured, rules, listOf())
     val request = HttpRequest.newBuilder(URI(uri)).build()
     client.send(request, BodyHandlers.discarding())
     return captured.request.uri().toString()
+  }
+
+  @Test
+  fun `adds configured headers for matching URI patterns`() {
+    val captured = RequestCapturingClient()
+    val client =
+      RequestRewritingClient(
+        "Pkl",
+        Duration.ofSeconds(42),
+        -1,
+        captured,
+        mapOf(),
+        listOf(
+          PPair(Pattern.compile("^https://example\\.com/.*"), listOf(PPair("x-one", "one"))),
+          PPair(
+            Pattern.compile("^https://example\\.com/foo/.*"),
+            listOf(PPair("x-two", "two-a"), PPair("x-two", "two-b")),
+          ),
+        ),
+      )
+    val request = HttpRequest.newBuilder(URI("https://example.com/foo/bar")).build()
+
+    client.send(request, BodyHandlers.discarding())
+
+    assertThatList(captured.request.headers().allValues("x-one")).containsExactly("one")
+    assertThatList(captured.request.headers().allValues("x-two")).containsExactly("two-a", "two-b")
+  }
+
+  @Test
+  fun `does not add configured headers for non-matching URI patterns`() {
+    val captured = RequestCapturingClient()
+    val client =
+      RequestRewritingClient(
+        "Pkl",
+        Duration.ofSeconds(42),
+        -1,
+        captured,
+        mapOf(),
+        listOf(
+          PPair(Pattern.compile("^https://foo\\.com/.*"), listOf(PPair("x-foo", "foo"))),
+          PPair(Pattern.compile("^https://bar\\.com/.*"), listOf(PPair("x-bar", "bar"))),
+        ),
+      )
+    val request = HttpRequest.newBuilder(URI("https://example.com/foo/bar")).build()
+
+    client.send(request, BodyHandlers.discarding())
+
+    assertThat(captured.request.headers().firstValue("x-foo")).isEmpty
+    assertThat(captured.request.headers().firstValue("x-bar")).isEmpty
+  }
+
+  @Test
+  fun `appends configured header values to existing request headers`() {
+    val captured = RequestCapturingClient()
+    val client =
+      RequestRewritingClient(
+        "Pkl",
+        Duration.ofSeconds(42),
+        -1,
+        captured,
+        mapOf(),
+        listOf(
+          PPair(
+            Pattern.compile("^https://example\\.com/.*"),
+            listOf(PPair("x-foo", "rule-a"), PPair("x-foo", "rule-b")),
+          )
+        ),
+      )
+    val request =
+      HttpRequest.newBuilder(URI("https://example.com/foo/bar")).header("x-foo", "request").build()
+
+    client.send(request, BodyHandlers.discarding())
+
+    assertThatList(captured.request.headers().allValues("x-foo"))
+      .containsExactly("request", "rule-a", "rule-b")
   }
 }

--- a/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
@@ -26,6 +26,7 @@ import org.pkl.commons.writeString
 import org.pkl.core.Evaluator
 import org.pkl.core.ModuleSource
 import org.pkl.core.PObject
+import org.pkl.core.Pair as PPair
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings
 import org.pkl.core.settings.PklSettings.Editor
 
@@ -65,7 +66,9 @@ class PklSettingsTest {
           ["https://foo.com/"] = "https://bar.com/"
         }
         headers {
-          ["X-Foo"] = "bar"
+          ["https://foo.com/"] {
+            Pair("X-Foo", "bar")
+          }
         }
       }
       """
@@ -80,8 +83,9 @@ class PklSettingsTest {
           listOf("example.com", "pkg.pkl-lang.org"),
         ),
         mapOf(URI("https://foo.com/") to URI("https://bar.com/")),
-        mapOf("X-Foo" to "bar"),
+        mapOf(URI("https://foo.com/") to listOf(PPair("X-Foo", "bar"))),
       )
+
     assertThat(settings).isEqualTo(PklSettings(Editor.SYSTEM, expectedHttp))
   }
 

--- a/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
@@ -64,6 +64,9 @@ class PklSettingsTest {
         rewrites {
           ["https://foo.com/"] = "https://bar.com/"
         }
+        headers {
+          ["X-Foo"] = "bar"
+        }
       }
       """
         .trimIndent()
@@ -77,6 +80,7 @@ class PklSettingsTest {
           listOf("example.com", "pkg.pkl-lang.org"),
         ),
         mapOf(URI("https://foo.com/") to URI("https://bar.com/")),
+        mapOf("X-Foo" to "bar"),
       )
     assertThat(settings).isEqualTo(PklSettings(Editor.SYSTEM, expectedHttp))
   }
@@ -101,6 +105,7 @@ class PklSettingsTest {
     val expectedHttp =
       PklEvaluatorSettings.Http(
         PklEvaluatorSettings.Proxy(URI("http://localhost:8080"), listOf()),
+        null,
         null,
       )
     assertThat(settings).isEqualTo(PklSettings(Editor.SYSTEM, expectedHttp))

--- a/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.pkl.core.PObject
 import org.pkl.core.Pair as PPair
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings
 import org.pkl.core.settings.PklSettings.Editor
+import org.pkl.core.util.GlobResolver
 
 class PklSettingsTest {
   @Test
@@ -67,7 +68,7 @@ class PklSettingsTest {
         }
         headers {
           ["https://foo.com/"] {
-            Pair("X-Foo", "bar")
+            ["x-foo"] = "bar"
           }
         }
       }
@@ -83,7 +84,9 @@ class PklSettingsTest {
           listOf("example.com", "pkg.pkl-lang.org"),
         ),
         mapOf(URI("https://foo.com/") to URI("https://bar.com/")),
-        mapOf(URI("https://foo.com/") to listOf(PPair("X-Foo", "bar"))),
+        listOf(
+          PPair(GlobResolver.toRegexPattern("https://foo.com/"), listOf(PPair("x-foo", "bar")))
+        ),
       )
 
     assertThat(settings).isEqualTo(PklSettings(Editor.SYSTEM, expectedHttp))

--- a/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
@@ -140,15 +140,15 @@ class PklSettingsTest {
       evaluator.evaluate(
         ModuleSource.text(
           """
-        import "pkl:settings"
-  
-        system = settings.System
-        idea = settings.Idea
-        textMate = settings.TextMate
-        sublime = settings.Sublime
-        atom = settings.Atom
-        vsCode = settings.VsCode
-        """
+          import "pkl:settings"
+
+          system = settings.System
+          idea = settings.Idea
+          textMate = settings.TextMate
+          sublime = settings.Sublime
+          atom = settings.Atom
+          vsCode = settings.VsCode
+          """
             .trimIndent()
         )
       )

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
@@ -723,11 +723,13 @@ internal abstract class PageGenerator<out S>(
           ?.let { markdownRenderer.render(markdownParser.parse(it)).trim().ifEmpty { null } }
       }
 
-    private val deprecatedAnnotation: PObject? =
-      annotations.find { it.classInfo == PClassInfo.Deprecated }
+    private val deprecatedAnnotation: PObject? = annotations.find {
+      it.classInfo == PClassInfo.Deprecated
+    }
 
-    private val alsoKnownAsAnnotation: PObject? =
-      annotations.find { it.classInfo == PClassInfo.AlsoKnownAs }
+    private val alsoKnownAsAnnotation: PObject? = annotations.find {
+      it.classInfo == PClassInfo.AlsoKnownAs
+    }
 
     val isDeprecatedMember: Boolean = deprecatedAnnotation != null
 

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
@@ -48,6 +48,7 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.jspecify.annotations.Nullable;
 import org.pkl.commons.cli.CliBaseOptions;
+import org.pkl.core.Pair;
 import org.pkl.core.evaluatorSettings.Color;
 import org.pkl.gradle.utils.PluginUtils;
 
@@ -163,7 +164,7 @@ public abstract class BasePklTask extends DefaultTask {
 
   @Input
   @Optional
-  public abstract MapProperty<String, String> getHttpHeaders();
+  public abstract MapProperty<URI, List<Pair<String, String>>> getHttpHeaders();
 
   @Input
   @Optional

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
@@ -164,7 +164,7 @@ public abstract class BasePklTask extends DefaultTask {
 
   @Input
   @Optional
-  public abstract MapProperty<URI, List<Pair<String, String>>> getHttpHeaders();
+  public abstract ListProperty<Pair<Pattern, List<Pair<String, String>>>> getHttpHeaders();
 
   @Input
   @Optional

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
@@ -163,6 +163,10 @@ public abstract class BasePklTask extends DefaultTask {
 
   @Input
   @Optional
+  public abstract MapProperty<String, String> getHttpHeaders();
+
+  @Input
+  @Optional
   public abstract Property<Boolean> getPowerAssertions();
 
   /**
@@ -218,6 +222,7 @@ public abstract class BasePklTask extends DefaultTask {
         getHttpProxy().getOrNull(),
         getHttpNoProxy().getOrElse(List.of()),
         getHttpRewrites().getOrNull(),
+        getHttpHeaders().getOrNull(),
         Map.of(),
         Map.of(),
         null,

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
@@ -164,6 +164,7 @@ public abstract class ModulesTask extends BasePklTask {
         null,
         List.of(),
         getHttpRewrites().getOrNull(),
+        getHttpHeaders().getOrNull(),
         Map.of(),
         Map.of(),
         null,

--- a/pkl-server/src/test/kotlin/org/pkl/server/AbstractServerTest.kt
+++ b/pkl-server/src/test/kotlin/org/pkl/server/AbstractServerTest.kt
@@ -105,7 +105,7 @@ abstract class AbstractServerTest {
         foo {
           bar = "bar"
         }
-      """
+        """
           .trimIndent(),
         null,
       )
@@ -132,7 +132,7 @@ abstract class AbstractServerTest {
         URI("repl:text"),
         """
         foo = trace(1 + 2 + 3)
-      """
+        """
           .trimIndent(),
         null,
       )
@@ -159,7 +159,7 @@ abstract class AbstractServerTest {
         function foo() = 5
 
         result = foo()
-      """
+        """
           .trimIndent(),
         null,
       )
@@ -286,7 +286,7 @@ abstract class AbstractServerTest {
         URI("repl:text"),
         """
         res = read*("bird:/**.txt").keys
-      """
+        """
           .trimIndent(),
         "res",
       )
@@ -315,11 +315,11 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.result?.debugRendering)
       .isEqualTo(
         """
-      - 6
-      - 
-        - 'bird:/foo.txt'
-        - 'bird:/subdir/bar.txt'
-    """
+        - 6
+        - 
+          - 'bird:/foo.txt'
+          - 'bird:/subdir/bar.txt'
+        """
           .trimIndent()
       )
   }
@@ -335,7 +335,7 @@ abstract class AbstractServerTest {
         URI("repl:text"),
         """
         res = read*("bird:/**.txt").keys
-      """
+        """
           .trimIndent(),
         "res",
       )
@@ -371,7 +371,7 @@ abstract class AbstractServerTest {
         URI("repl:text"),
         """
         res = read*("bird:/**.txt").keys
-      """
+        """
           .trimIndent(),
         "res",
       )
@@ -390,19 +390,19 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.error)
       .isEqualTo(
         """
-      –– Pkl Error ––
-      I/O error resolving glob pattern `bird:/**.txt`.
-      IOException: didnt work
+        –– Pkl Error ––
+        I/O error resolving glob pattern `bird:/**.txt`.
+        IOException: didnt work
 
-      1 | res = read*("bird:/**.txt").keys
-                ^^^^^^^^^^^^^^^^^^^^^
-      at text#res (repl:text)
+        1 | res = read*("bird:/**.txt").keys
+                  ^^^^^^^^^^^^^^^^^^^^^
+        at text#res (repl:text)
 
-      1 | res
-          ^^^
-      at  (repl:text)
-      
-      """
+        1 | res
+            ^^^
+        at  (repl:text)
+
+        """
           .trimIndent()
       )
   }
@@ -549,14 +549,14 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.result?.debugRendering)
       .isEqualTo(
         """
-      - 6
-      - 
-        - 'bird:/Person.pkl'
-        - 'bird:/birds/parrot.pkl'
-        - 'bird:/birds/pigeon.pkl'
-        - 'bird:/majesticBirds/barnOwl.pkl'
-        - 'bird:/majesticBirds/elfOwl.pkl'
-    """
+        - 6
+        - 
+          - 'bird:/Person.pkl'
+          - 'bird:/birds/parrot.pkl'
+          - 'bird:/birds/pigeon.pkl'
+          - 'bird:/majesticBirds/barnOwl.pkl'
+          - 'bird:/majesticBirds/elfOwl.pkl'
+        """
           .trimIndent()
       )
   }
@@ -582,9 +582,9 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.result?.debugRendering)
       .isEqualTo(
         """
-      - 6
-      - []
-    """
+        - 6
+        - []
+        """
           .trimIndent()
       )
   }
@@ -612,19 +612,19 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.error)
       .isEqualTo(
         """
-      –– Pkl Error ––
-      I/O error resolving glob pattern `bird:/**.pkl`.
-      IOException: nope
+        –– Pkl Error ––
+        I/O error resolving glob pattern `bird:/**.pkl`.
+        IOException: nope
 
-      1 | res = import*("bird:/**.pkl").keys
-                ^^^^^^^^^^^^^^^^^^^^^^^
-      at text#res (repl:text)
+        1 | res = import*("bird:/**.pkl").keys
+                  ^^^^^^^^^^^^^^^^^^^^^^^
+        at text#res (repl:text)
 
-      1 | res
-          ^^^
-      at  (repl:text)
-      
-      """
+        1 | res
+            ^^^
+        at  (repl:text)
+
+        """
           .trimIndent()
       )
   }
@@ -688,9 +688,9 @@ abstract class AbstractServerTest {
         URI("bird:/foo/bar/baz.pkl"),
         """
         import ".../buz.pkl"
-        
+
         res = buz.res
-      """
+        """
           .trimIndent(),
         "res",
       )
@@ -747,9 +747,9 @@ abstract class AbstractServerTest {
         readModuleRequest.requestId,
         evaluatorId,
         """
-          firstName = "Pigeon"
-          lastName = "Bird"
-          fullName = firstName + " " + lastName
+        firstName = "Pigeon"
+        lastName = "Bird"
+        fullName = firstName + " " + lastName
         """
           .trimIndent(),
         null,
@@ -766,7 +766,7 @@ abstract class AbstractServerTest {
           lastName = "Bird"
           fullName = "Pigeon Bird"
 
-      """
+        """
           .trimIndent()
       )
   }
@@ -788,9 +788,9 @@ abstract class AbstractServerTest {
         response11.requestId,
         evaluatorId,
         """
-          firstName = "Pigeon"
-          lastName = "Bird"
-          fullName = firstName + " " + lastName
+        firstName = "Pigeon"
+        lastName = "Bird"
+        fullName = firstName + " " + lastName
         """
           .trimIndent(),
         null,
@@ -807,7 +807,7 @@ abstract class AbstractServerTest {
           lastName = "Bird"
           fullName = "Pigeon Bird"
 
-      """
+        """
           .trimIndent()
       )
 
@@ -819,9 +819,9 @@ abstract class AbstractServerTest {
         response21.requestId,
         evaluatorId,
         """
-          firstName = "Parrot"
-          lastName = "Bird"
-          fullName = firstName + " " + lastName
+        firstName = "Parrot"
+        lastName = "Bird"
+        fullName = firstName + " " + lastName
         """
           .trimIndent(),
         null,
@@ -838,7 +838,7 @@ abstract class AbstractServerTest {
           lastName = "Bird"
           fullName = "Parrot Bird"
 
-      """
+        """
           .trimIndent()
       )
   }
@@ -948,23 +948,23 @@ abstract class AbstractServerTest {
       .resolve("lib.pkl")
       .writeText(
         """
-      text = "This is from lib"
-    """
+        text = "This is from lib"
+        """
           .trimIndent()
       )
     libDir
       .resolve("PklProject")
       .writeText(
         """
-      amends "pkl:Project"
-      
-      package {
-        name = "lib"
-        baseUri = "package://localhost:0/lib"
-        version = "5.0.0"
-        packageZipUrl = "https://localhost:0/lib.zip"
-      }
-    """
+        amends "pkl:Project"
+
+        package {
+          name = "lib"
+          baseUri = "package://localhost:0/lib"
+          version = "5.0.0"
+          packageZipUrl = "https://localhost:0/lib.zip"
+        }
+        """
           .trimIndent()
       )
     val projectDir = tempDir.resolve("proj/").createDirectories()
@@ -973,14 +973,14 @@ abstract class AbstractServerTest {
       """
       import "@birds/Bird.pkl"
       import "@lib/lib.pkl"
-      
+
       res: Bird = new {
         name = "Birdie"
         favoriteFruit { name = "dragonfruit" }
       }
-      
+
       libContents = lib
-    """
+      """
         .trimIndent()
     )
     val dollar = '$'

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -170,8 +170,8 @@ class Http {
   @Since { version = "0.29.0" }
   rewrites: Mapping<HttpRewrite, HttpRewrite>?
   
-  /// HTTP headers to add to every request.
-  headers: Mapping<String, String>?
+  /// HTTP headers to add to outbound requests targeting specified URLs.
+  headers: Mapping<HttpRewrite, Listing<Pair<String, String>>>?
 }
 
 /// Settings that control how Pkl talks to HTTP proxies.

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -126,7 +126,10 @@ local const hasNonEmptyHostname = (it: String) ->
 
 /// A key or value in [Http.rewrites].
 @Since { version = "0.29.0" }
-typealias HttpRewrite = String(startsWith(Regex("https?://")), endsWith("/"), hasNonEmptyHostname)
+typealias HttpPrefix = String(startsWith(Regex("https?://")), endsWith("/"), hasNonEmptyHostname)
+
+@Deprecated { since = "0.30.0"; replaceWith = "HttpPrefix" }
+typealias HttpRewrite = HttpPrefix
 
 /// Settings that control how Pkl talks to HTTP(S) servers.
 class Http {
@@ -168,11 +171,11 @@ class Http {
   /// An rewrite target should also not contain a query string or fragment component
   /// (not schematically enforced).
   @Since { version = "0.29.0" }
-  rewrites: Mapping<HttpRewrite, HttpRewrite>?
+  rewrites: Mapping<HttpPrefix, HttpPrefix>?
   
   /// HTTP headers to add to outbound requests targeting specified URLs.
   @Since { version = "0.30.0" }
-  headers: Mapping<HttpRewrite, Listing<Pair<String, String>>>?
+  headers: Mapping<HttpPrefix, Listing<Pair<String, String>>>?
 }
 
 /// Settings that control how Pkl talks to HTTP proxies.

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -171,6 +171,7 @@ class Http {
   rewrites: Mapping<HttpRewrite, HttpRewrite>?
   
   /// HTTP headers to add to outbound requests targeting specified URLs.
+  @Since { version = "0.30.0" }
   headers: Mapping<HttpRewrite, Listing<Pair<String, String>>>?
 }
 

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -175,7 +175,7 @@ class Http {
   
   /// HTTP headers to add to outbound requests targeting specified URLs.
   @Since { version = "0.30.0" }
-  headers: Mapping<HttpPrefix, Listing<Pair<String, String>>>?
+  headers: Mapping<HttpPrefix, Mapping<HttpHeaderName, Listing<HttpHeaderValue>>>?
 }
 
 /// Settings that control how Pkl talks to HTTP proxies.
@@ -242,3 +242,55 @@ class ExternalReader {
   /// Additional command line arguments passed to the external reader process.
   arguments: Listing<String>?
 }
+
+typealias ReservedHttpHeaderName = 
+  "accept-charset"
+  | "accept-encoding"
+  | "access-control-request-headers"
+  | "access-control-request-method"
+  | "connection"
+  | "content-length"
+  | "cookie"
+  | "date"
+  | "dnt"
+  | "expect"
+  | "host"
+  | "keep-alive"
+  | "origin"
+  | "permissions-policy"
+  | "referer"
+  | "te"
+  | "trailer"
+  | "transfer-encoding"
+  | "upgrade"
+  | "via"
+
+const local ReservedHttpHeaderPrefix = new Listing {
+  "proxy-"
+  "sec-"
+  "access-control-"
+}
+
+const local hasReservedHttpHeaderPrefix = (header: String) ->
+  ReservedHttpHeaderPrefix.any((it) -> header.startsWith(it))
+ 
+const local httpHeaderNameRegex = Regex("^[a-zA-Z0-9!#\\$%&'*+-.^_`|~]+$")
+const local hasValidHttpHeaderName = (header: String) ->
+    httpHeaderNameRegex.findMatchesIn(header)
+
+@Since {version = "0.30.0" }
+typealias HttpHeaderName = String(
+  this == toLowerCase(),
+  !(this is ReservedHttpHeaderName),
+  !hasReservedHttpHeaderPrefix.apply(this),
+  hasValidHttpHeaderName
+)
+
+const local httpHeaderValueRegex = Regex("^[\\t\\u0020-\\u007E\\u0080-\\u00FF]*$")
+const local hasValidHttpHeaderValue = (value : String) ->
+    httpHeaderValueRegex.findMatchesIn(value)
+
+@Since {version = "0.30.0"}
+typealias HttpHeaderValue = String(
+  hasValidHttpHeaderValue
+)

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -169,6 +169,9 @@ class Http {
   /// (not schematically enforced).
   @Since { version = "0.29.0" }
   rewrites: Mapping<HttpRewrite, HttpRewrite>?
+  
+  /// HTTP headers to add to every request.
+  headers: Mapping<String, String>?
 }
 
 /// Settings that control how Pkl talks to HTTP proxies.

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -128,7 +128,7 @@ local const hasNonEmptyHostname = (it: String) ->
 @Since { version = "0.29.0" }
 typealias HttpRewrite = String(startsWith(Regex("https?://")), endsWith("/"), hasNonEmptyHostname)
 
-@Since { version = "0.31.0" }
+@Since { version = "0.32.0" }
 typealias UrlPattern = String(endsWith(Regex("[/*]")))
 
 /// Settings that control how Pkl talks to HTTP(S) servers.
@@ -174,7 +174,7 @@ class Http {
   rewrites: Mapping<HttpRewrite, HttpRewrite>?
 
   /// HTTP headers to add to outbound requests targeting specified URLs.
-  @Since { version = "0.31.0" }
+  @Since { version = "0.32.0" }
   headers: Mapping<UrlPattern, Mapping<HttpHeaderName, *Listing<HttpHeaderValue> | HttpHeaderValue>>?
 }
 
@@ -243,6 +243,7 @@ class ExternalReader {
   arguments: Listing<String>?
 }
 
+@Since { version = "0.32.0" }
 typealias ReservedHttpHeaderName =
   "accept-charset"
     | "accept-encoding"
@@ -278,7 +279,7 @@ local const httpHeaderNameRegex = Regex("^[a-zA-Z0-9!#\\$%&'*+-.^_`|~]+$")
 local const hasValidHttpHeaderName = (header: String) ->
   !httpHeaderNameRegex.findMatchesIn(header).isEmpty
 
-@Since { version = "0.31.0" }
+@Since { version = "0.32.0" }
 typealias HttpHeaderName =
   String(
     (it: String) -> it == toLowerCase(),
@@ -291,5 +292,5 @@ local const httpHeaderValueRegex = Regex("^[\\t\\u0020-\\u007E\\u0080-\\u00FF]*$
 local const hasValidHttpHeaderValue = (value: String) ->
   !httpHeaderValueRegex.findMatchesIn(value).isEmpty
 
-@Since { version = "0.31.0" }
+@Since { version = "0.32.0" }
 typealias HttpHeaderValue = String(hasValidHttpHeaderValue)

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -126,10 +126,10 @@ local const hasNonEmptyHostname = (it: String) ->
 
 /// A key or value in [Http.rewrites].
 @Since { version = "0.29.0" }
-typealias HttpPrefix = String(startsWith(Regex("https?://")), endsWith("/"), hasNonEmptyHostname)
+typealias HttpRewrite = String(startsWith(Regex("https?://")), endsWith("/"), hasNonEmptyHostname)
 
-@Deprecated { since = "0.30.0"; replaceWith = "HttpPrefix" }
-typealias HttpRewrite = HttpPrefix
+@Since { version = "0.31.0" }
+typealias UrlPattern = String(endsWith(Regex("[/*]")))
 
 /// Settings that control how Pkl talks to HTTP(S) servers.
 class Http {
@@ -171,11 +171,11 @@ class Http {
   /// An rewrite target should also not contain a query string or fragment component
   /// (not schematically enforced).
   @Since { version = "0.29.0" }
-  rewrites: Mapping<HttpPrefix, HttpPrefix>?
-  
+  rewrites: Mapping<HttpRewrite, HttpRewrite>?
+
   /// HTTP headers to add to outbound requests targeting specified URLs.
-  @Since { version = "0.30.0" }
-  headers: Mapping<HttpPrefix, Mapping<HttpHeaderName, Listing<HttpHeaderValue>>>?
+  @Since { version = "0.31.0" }
+  headers: Mapping<UrlPattern, Mapping<HttpHeaderName, *Listing<HttpHeaderValue> | HttpHeaderValue>>?
 }
 
 /// Settings that control how Pkl talks to HTTP proxies.
@@ -243,54 +243,53 @@ class ExternalReader {
   arguments: Listing<String>?
 }
 
-typealias ReservedHttpHeaderName = 
+typealias ReservedHttpHeaderName =
   "accept-charset"
-  | "accept-encoding"
-  | "access-control-request-headers"
-  | "access-control-request-method"
-  | "connection"
-  | "content-length"
-  | "cookie"
-  | "date"
-  | "dnt"
-  | "expect"
-  | "host"
-  | "keep-alive"
-  | "origin"
-  | "permissions-policy"
-  | "referer"
-  | "te"
-  | "trailer"
-  | "transfer-encoding"
-  | "upgrade"
-  | "via"
+    | "accept-encoding"
+    | "access-control-request-headers"
+    | "access-control-request-method"
+    | "connection"
+    | "content-length"
+    | "cookie"
+    | "date"
+    | "dnt"
+    | "expect"
+    | "host"
+    | "keep-alive"
+    | "origin"
+    | "permissions-policy"
+    | "referer"
+    | "te"
+    | "trailer"
+    | "transfer-encoding"
+    | "upgrade"
+    | "via"
 
-const local ReservedHttpHeaderPrefix = new Listing {
+local const ReservedHttpHeaderPrefix = new Listing {
   "proxy-"
   "sec-"
   "access-control-"
 }
 
-const local hasReservedHttpHeaderPrefix = (header: String) ->
+local const hasReservedHttpHeaderPrefix = (header: String) ->
   ReservedHttpHeaderPrefix.any((it) -> header.startsWith(it))
- 
-const local httpHeaderNameRegex = Regex("^[a-zA-Z0-9!#\\$%&'*+-.^_`|~]+$")
-const local hasValidHttpHeaderName = (header: String) ->
-    httpHeaderNameRegex.findMatchesIn(header)
 
-@Since {version = "0.30.0" }
-typealias HttpHeaderName = String(
-  this == toLowerCase(),
-  !(this is ReservedHttpHeaderName),
-  !hasReservedHttpHeaderPrefix.apply(this),
-  hasValidHttpHeaderName
-)
+local const httpHeaderNameRegex = Regex("^[a-zA-Z0-9!#\\$%&'*+-.^_`|~]+$")
+local const hasValidHttpHeaderName = (header: String) ->
+  !httpHeaderNameRegex.findMatchesIn(header).isEmpty
 
-const local httpHeaderValueRegex = Regex("^[\\t\\u0020-\\u007E\\u0080-\\u00FF]*$")
-const local hasValidHttpHeaderValue = (value : String) ->
-    httpHeaderValueRegex.findMatchesIn(value)
+@Since { version = "0.31.0" }
+typealias HttpHeaderName =
+  String(
+    (it: String) -> it == toLowerCase(),
+    (it: String) -> !(it is ReservedHttpHeaderName),
+    (it: String) -> !hasReservedHttpHeaderPrefix.apply(it),
+    hasValidHttpHeaderName,
+  )
 
-@Since {version = "0.30.0"}
-typealias HttpHeaderValue = String(
-  hasValidHttpHeaderValue
-)
+local const httpHeaderValueRegex = Regex("^[\\t\\u0020-\\u007E\\u0080-\\u00FF]*$")
+local const hasValidHttpHeaderValue = (value: String) ->
+  !httpHeaderValueRegex.findMatchesIn(value).isEmpty
+
+@Since { version = "0.31.0" }
+typealias HttpHeaderValue = String(hasValidHttpHeaderValue)

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -282,15 +282,13 @@ local const hasValidHttpHeaderName = (header: String) ->
 @Since { version = "0.32.0" }
 typealias HttpHeaderName =
   String(
-    (it: String) -> it == toLowerCase(),
-    (it: String) -> !(it is ReservedHttpHeaderName),
-    (it: String) -> !hasReservedHttpHeaderPrefix.apply(it),
+    this == toLowerCase(),
+    !(this is ReservedHttpHeaderName),
+    !hasReservedHttpHeaderPrefix.apply(this),
     hasValidHttpHeaderName,
   )
 
 local const httpHeaderValueRegex = Regex("^[\\t\\u0020-\\u007E\\u0080-\\u00FF]*$")
-local const hasValidHttpHeaderValue = (value: String) ->
-  !httpHeaderValueRegex.findMatchesIn(value).isEmpty
 
 @Since { version = "0.32.0" }
-typealias HttpHeaderValue = String(hasValidHttpHeaderValue)
+typealias HttpHeaderValue = String(!httpHeaderValueRegex.findMatchesIn(this).isEmpty)

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -247,8 +247,6 @@ class ExternalReader {
 typealias ReservedHttpHeaderName =
   "accept-charset"
     | "accept-encoding"
-    | "access-control-request-headers"
-    | "access-control-request-method"
     | "connection"
     | "content-length"
     | "cookie"


### PR DESCRIPTION
This PR adds support for custom HTTP headers, introducing a `--http-header` CLI flag to accept `key=value` pairs. These headers can also be specified within the `setting.pkl` file.

Closes #633

SPICE: https://github.com/apple/pkl-evolution/pull/24
