### PR TITLE
Fixed fallback certificates not working in certain classloader setups

### DIFF
--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -218,8 +218,9 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
     }
     if (!certsAdded) {
       val defaultCerts =
-        javaClass.classLoader.getResourceAsStream("org/pkl/commons/cli/PklCARoots.pem")
-          ?: throw CliException("Could not find bundled certificates")
+        this@CliCommand.javaClass.classLoader.getResourceAsStream(
+          "org/pkl/commons/cli/PklCARoots.pem"
+        ) ?: throw CliException("Could not find bundled certificates")
       addCertificates(defaultCerts.readAllBytes())
     }
   }


### PR DESCRIPTION
In the original implementation the `org/pkl/commons/cli/PklCARoots.pem` resource is resolved relatively to the classloader associated with the class returned by `javaClass`. However, since this is an extension method for `HttpClient.Builder`, it means calling `javaClass` on the builder instance, which is actually defined in the system classpath.

Because of this, if the Pkl class is loaded by a different classloader compared to the one which contains JDK classes, which is totally possible in certain scenarios (e.g. with Gradle), then this resource resolution will fail.

The solution is to resolve `javaClass` against `this@CliCommand`, to use the classloader which loaded the jar with the `CliCommand` class to find the CA resource.

Closes https://github.com/apple/pkl/issues/1199