### PR TITLE
Allow formatting multiple files/directories

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterApply.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterApply.kt
@@ -22,8 +22,8 @@ import kotlin.io.path.writeText
 import org.pkl.commons.cli.CliBaseOptions
 import org.pkl.commons.cli.CliException
 
-class CliFormatterApply(cliBaseOptions: CliBaseOptions, path: Path, private val silent: Boolean) :
-  CliFormatterCommand(cliBaseOptions, path) {
+class CliFormatterApply(cliBaseOptions: CliBaseOptions, paths: List<Path>, private val silent: Boolean) :
+  CliFormatterCommand(cliBaseOptions, paths) {
 
   override fun doRun() {
     var status = 0

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterCheck.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterCheck.kt
@@ -20,8 +20,8 @@ import java.nio.file.Path
 import org.pkl.commons.cli.CliBaseOptions
 import org.pkl.commons.cli.CliException
 
-class CliFormatterCheck(cliBaseOptions: CliBaseOptions, path: Path) :
-  CliFormatterCommand(cliBaseOptions, path) {
+class CliFormatterCheck(cliBaseOptions: CliBaseOptions, paths: List<Path>) :
+  CliFormatterCommand(cliBaseOptions, paths) {
 
   override fun doRun() {
     var status = 0

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterCommand.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterCommand.kt
@@ -31,7 +31,7 @@ abstract class CliFormatterCommand
 @JvmOverloads
 constructor(
   options: CliBaseOptions,
-  protected val path: Path,
+  protected val paths: List<Path>,
   protected val consoleWriter: Writer = System.out.writer(),
 ) : CliCommand(options) {
   protected fun format(file: Path, contents: String): Pair<String, Int> {
@@ -46,9 +46,17 @@ constructor(
   }
 
   @OptIn(ExperimentalPathApi::class)
-  protected fun paths(): Sequence<Path> {
-    return if (path.isDirectory()) {
-      path.walk().filter { it.extension == "pkl" || it.name == "PklProject" }
-    } else sequenceOf(path)
+  protected fun paths(): Set<Path> {
+    val allPaths = mutableSetOf<Path>()
+    for (path in paths) {
+      if (path.isDirectory()) {
+        allPaths.addAll(
+          path.walk().filter { it.extension == "pkl" || it.name == "PklProject" }
+        )
+      } else {
+        allPaths.add(path)
+      }
+    }
+    return allPaths
   }
 }

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/commands/FormatterCommand.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/commands/FormatterCommand.kt
@@ -19,6 +19,7 @@ import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.NoOpCliktCommand
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.path
@@ -41,12 +42,13 @@ class FormatterCheckCommand : BaseCommand(name = "check", helpLink = helpLink) {
   override val helpString: String =
     "Check if the given files are properly formatted, printing the file name to stdout in case they are not. Returns non-zero in case of failure."
 
-  val path: Path by
-    argument(name = "path", help = "File or directory to check.")
+  val paths: List<Path> by
+    argument(name = "paths", help = "Files or directory to check.")
       .path(mustExist = true, canBeDir = true)
+      .multiple()
 
   override fun run() {
-    CliFormatterCheck(baseOptions.baseOptions(emptyList()), path).run()
+    CliFormatterCheck(baseOptions.baseOptions(emptyList()), paths).run()
   }
 }
 
@@ -54,9 +56,10 @@ class FormatterApplyCommand : BaseCommand(name = "apply", helpLink = helpLink) {
   override val helpString: String =
     "Overwrite all the files in place with the formatted version. Returns non-zero in case of failure."
 
-  val path: Path by
-    argument(name = "path", help = "File or directory to format.")
+  val paths: List<Path> by
+    argument(name = "paths", help = "Files or directory to format.")
       .path(mustExist = true, canBeDir = true)
+      .multiple()
 
   val silent: Boolean by
     option(
@@ -66,6 +69,6 @@ class FormatterApplyCommand : BaseCommand(name = "apply", helpLink = helpLink) {
       .flag()
 
   override fun run() {
-    CliFormatterApply(baseOptions.baseOptions(emptyList()), path, silent).run()
+    CliFormatterApply(baseOptions.baseOptions(emptyList()), paths, silent).run()
   }
 }


### PR DESCRIPTION
This makes it easier to work with tools which return a list of file to format, e.g. to only handle files which have changed in a PR.