### PR TITLE
Fix pkl-doc native test

### DIFF
--- a/pkl-doc/src/test/kotlin/org/pkl/doc/NativeExecutableTest.kt
+++ b/pkl-doc/src/test/kotlin/org/pkl/doc/NativeExecutableTest.kt
@@ -37,6 +37,10 @@ class NativeExecutableTest {
   @ParameterizedTest()
   @MethodSource("generateDocs")
   fun test(relativePath: String) {
-    DocTestUtils.testExpectedFile(helper.expectedOutputDir, helper.actualOutputDir, relativePath)
+    DocTestUtils.testExpectedFile(
+      helper.expectedOutputDir,
+      helper.baseActualOutputDir,
+      relativePath,
+    )
   }
 }


### PR DESCRIPTION
Fixes a bug in the native tests for pkl-doc, which is causing them to fail.