### PR TITLE
Bump Gradle to 9.1.0

### DIFF
--- a/buildSrc/src/main/kotlin/MergeSourcesJars.kt
+++ b/buildSrc/src/main/kotlin/MergeSourcesJars.kt
@@ -70,7 +70,7 @@ open class MergeSourcesJars : DefaultTask() {
         val details = this
         if (details.isDirectory) return@visit
 
-        var path = details.relativePath.parent.pathString
+        var path = details.relativePath.parent!!.pathString
         val relocatedPath = relocatedPaths.keys.find { path.startsWith(it) }
         if (relocatedPath != null) {
           path = path.replace(relocatedPath, relocatedPaths.getValue(relocatedPath))
@@ -101,7 +101,7 @@ open class MergeSourcesJars : DefaultTask() {
       project.zipTree(jar).visit {
         val details = this
         if (details.isDirectory) return@visit // avoid adding empty dirs
-        result.add(details.relativePath.parent.pathString)
+        result.add(details.relativePath.parent!!.pathString)
       }
     }
     return result

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/pkl-gradle/pkl-gradle.gradle.kts
+++ b/pkl-gradle/pkl-gradle.gradle.kts
@@ -89,7 +89,7 @@ gradlePlugin {
 gradlePluginTests {
   // keep in sync with `PklPlugin.MIN_GRADLE_VERSION`
   minGradleVersion = GradleVersion.version("8.2")
-  maxGradleVersion = GradleVersion.version("8.99")
+  maxGradleVersion = GradleVersion.version("9.99")
   skippedGradleVersions = listOf()
 }
 

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/KotlinCodeGeneratorsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/KotlinCodeGeneratorsTest.kt
@@ -108,7 +108,7 @@ class KotlinCodeGeneratorsTest : AbstractTest() {
   }
 
   private fun writeBuildFile() {
-    val kotlinVersion = "1.6.0"
+    val kotlinVersion = "2.0.21"
 
     writeFile(
       "build.gradle",


### PR DESCRIPTION
Also, remove support for kotlin gradle plugin less than 1.8.x, because:

* Class `org.gradle.api.plugins.Convention ` is no longer available in the classpath in Gradle
* Continued support for legacy plugin would require heavy reflection, which is brittle and hard to verify
* Kotlin 1.7 is 3 years old and no longer updated