### PR TITLE
Fix macOS Intel native builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
     resource_class: m4pro.large
     macos:
-      xcode: 26.0.1
+      xcode: 16.4.0
   pkl-cli-linux-amd64-release:
     steps:
     - checkout
@@ -144,7 +144,7 @@ jobs:
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
     resource_class: m4pro.large
     macos:
-      xcode: 26.0.1
+      xcode: 16.4.0
   pkl-cli-linux-aarch64-release:
     steps:
     - checkout
@@ -349,7 +349,7 @@ jobs:
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
     resource_class: m4pro.large
     macos:
-      xcode: 26.0.1
+      xcode: 16.4.0
   pkl-doc-linux-amd64-release:
     steps:
     - checkout
@@ -457,7 +457,7 @@ jobs:
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
     resource_class: m4pro.large
     macos:
-      xcode: 26.0.1
+      xcode: 16.4.0
   pkl-doc-linux-aarch64-release:
     steps:
     - checkout
@@ -662,7 +662,7 @@ jobs:
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
     resource_class: m4pro.large
     macos:
-      xcode: 26.0.1
+      xcode: 16.4.0
   pkl-cli-linux-amd64-snapshot:
     steps:
     - checkout
@@ -770,7 +770,7 @@ jobs:
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
     resource_class: m4pro.large
     macos:
-      xcode: 26.0.1
+      xcode: 16.4.0
   pkl-cli-linux-aarch64-snapshot:
     steps:
     - checkout
@@ -975,7 +975,7 @@ jobs:
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
     resource_class: m4pro.large
     macos:
-      xcode: 26.0.1
+      xcode: 16.4.0
   pkl-doc-linux-amd64-snapshot:
     steps:
     - checkout
@@ -1083,7 +1083,7 @@ jobs:
       JAVA_HOME: /Users/distiller/jdk/Contents/Home
     resource_class: m4pro.large
     macos:
-      xcode: 26.0.1
+      xcode: 16.4.0
   pkl-doc-linux-aarch64-snapshot:
     steps:
     - checkout

--- a/.circleci/jobs/BuildNativeJob.pkl
+++ b/.circleci/jobs/BuildNativeJob.pkl
@@ -172,7 +172,7 @@ steps {
 job {
   when (os == "macOS") {
     macos {
-      xcode = "26.0.1"
+      xcode = "16.4.0"
     }
     resource_class = "m4pro.large"
     environment {


### PR DESCRIPTION
Looks like there's some incompatibility between Xcode 26 (or at least CircleCI's install of it) and native-image that affects cross-compiling amd64 binaries on aarch64 systems. This PR reverts Xcode to 16.4.0 which is the next oldest release supported in CircleCI.

Successful native image jobs:
* https://app.circleci.com/pipelines/github/apple/pkl/2707/workflows/8d0053a6-e6fe-450c-866c-364ff8f4f7ed/jobs/15927
* https://app.circleci.com/pipelines/github/apple/pkl/2707/workflows/8d0053a6-e6fe-450c-866c-364ff8f4f7ed/jobs/15929