### PR TITLE
Let expression formatting changes

### DIFF
--- a/pkl-formatter/src/main/kotlin/org/pkl/formatter/Builder.kt
+++ b/pkl-formatter/src/main/kotlin/org/pkl/formatter/Builder.kt
@@ -91,7 +91,7 @@ internal class Builder(sourceText: String) {
       NodeType.CLASS_BODY_ELEMENTS -> formatClassBodyElements(node)
       NodeType.CLASS_PROPERTY,
       NodeType.OBJECT_PROPERTY,
-      NodeType.OBJECT_ENTRY -> formatClassProperty(node)
+      NodeType.OBJECT_ENTRY -> formatPropertyOrEntryOrLetBinding(node)
       NodeType.CLASS_PROPERTY_HEADER,
       NodeType.OBJECT_PROPERTY_HEADER -> formatClassPropertyHeader(node)
       NodeType.CLASS_PROPERTY_HEADER_BEGIN,
@@ -303,7 +303,7 @@ internal class Builder(sourceText: String) {
     return Indent(nodes)
   }
 
-  private fun formatClassProperty(node: Node): FormatNode {
+  private fun formatPropertyOrEntryOrLetBinding(node: Node): FormatNode {
     val sameLine =
       node.children
         .lastOrNull { it.isExpressionOrPropertyBody() }
@@ -791,13 +791,13 @@ internal class Builder(sourceText: String) {
   private fun formatLetParameterDefinition(node: Node): FormatNode {
     val nodes =
       formatGeneric(node.children) { prev, next ->
-        if (prev.isTerminal("(")) null else if (next.isTerminal(")")) Line else SpaceOrLine
+        if (prev.isTerminal("(") || (next.isTerminal(")"))) Line else SpaceOrLine
       }
     return Group(newId(), nodes)
   }
 
   private fun formatLetParameter(node: Node): FormatNode {
-    return indent(formatClassProperty(node))
+    return indent(formatPropertyOrEntryOrLetBinding(node))
   }
 
   private fun formatBinaryOpExpr(node: Node): FormatNode {

--- a/pkl-formatter/src/test/files/FormatterSnippetTests/input/expr-let-if.pkl
+++ b/pkl-formatter/src/test/files/FormatterSnippetTests/input/expr-let-if.pkl
@@ -1,0 +1,9 @@
+foo =
+  let (converted =
+    if (bar is Typed | Map | Mapping)
+      if (bar is Map) bar else bar.toMap()
+    else if (bar is List | Listing)
+      if (bar is List) bar else bar.toList()
+    else
+      bar
+  ) converted

--- a/pkl-formatter/src/test/files/FormatterSnippetTests/output/expr-let-if.pkl
+++ b/pkl-formatter/src/test/files/FormatterSnippetTests/output/expr-let-if.pkl
@@ -1,0 +1,11 @@
+foo =
+  let (
+    converted =
+      if (bar is Typed | Map | Mapping)
+        if (bar is Map) bar else bar.toMap()
+      else if (bar is List | Listing)
+        if (bar is List) bar else bar.toList()
+      else
+        bar
+  )
+    converted

--- a/pkl-formatter/src/test/files/FormatterSnippetTests/output/expr-let.pkl
+++ b/pkl-formatter/src/test/files/FormatterSnippetTests/output/expr-let.pkl
@@ -1,11 +1,13 @@
 foo =
-  let (vaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaariable =
+  let (
+    vaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaariable =
       10
   )
     1 * 1
 
 bar =
-  let (someVariable = new Listing {
+  let (
+    someVariable = new Listing {
       1
     }
   )


### PR DESCRIPTION
This add a newline after opening `(` in a let expression when multilined. As a side-effect, this also fixes an issue where let expressions are incorrectly doubly indented.