### PR TITLE
Enforce Pkl formatting of stdlib with spotless

### DIFF
--- a/buildSrc/src/main/kotlin/PklFormatterSpotless.kt
+++ b/buildSrc/src/main/kotlin/PklFormatterSpotless.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.diffplug.spotless.FormatterFunc
+import com.diffplug.spotless.FormatterStep
+import java.io.Serial
+import java.io.Serializable
+import java.net.URLClassLoader
+import org.gradle.api.artifacts.Configuration
+
+class PklFormatterStep(@Transient private val configuration: Configuration) : Serializable {
+  companion object {
+    @Serial private const val serialVersionUID: Long = 1L
+  }
+
+  fun create(): FormatterStep {
+    return FormatterStep.createLazy(
+      "pkl",
+      { PklFormatterStep(configuration) },
+      { PklFormatterFunc(configuration) },
+    )
+  }
+}
+
+class PklFormatterFunc(@Transient private val configuration: Configuration) :
+  FormatterFunc, Serializable {
+  companion object {
+    @Serial private const val serialVersionUID: Long = 1L
+  }
+
+  private val formatterClass by lazy {
+    val urls = configuration.files.map { it.toURI().toURL() }
+    val classLoader = URLClassLoader(urls.toTypedArray())
+    classLoader.loadClass("org.pkl.formatter.Formatter")
+  }
+
+  private val formatMethod by lazy { formatterClass.getMethod("format", String::class.java) }
+
+  private val formatterInstance by lazy { formatterClass.getConstructor().newInstance() }
+
+  override fun apply(input: String): String {
+    return formatMethod(formatterInstance, input) as String
+  }
+}

--- a/buildSrc/src/main/kotlin/pklSpotlessFormat.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklSpotlessFormat.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins { id("com.diffplug.spotless") }
+
+val pklFormatter by configurations.creating
+
+dependencies { pklFormatter(rootProject.project("pkl-formatter")) }
+
+spotless {
+  format("pkl") {
+    target("**/*.pkl")
+    addStep(PklFormatterStep(pklFormatter).create())
+    licenseHeaderFile(
+      rootProject.file("buildSrc/src/main/resources/license-header.line-comment.txt"),
+      "/// ",
+    )
+  }
+}
+
+for (taskName in
+  listOf("spotlessPkl", "spotlessPklApply", "spotlessPklCheck", "spotlessPklDiagnose")) {
+  tasks.named(taskName) { dependsOn(":pkl-formatter:assemble") }
+}

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -437,7 +437,7 @@ class RenderDirective {
   text: String
 
   /// The bytes to output as-is (without escaping or quoting).
-  /// 
+  ///
   /// Only used by [BytesRenderer], ignored by [ValueRenderer].
   @Since { version = "0.30.0" }
   bytes: Bytes = text.encodeToBytes("UTF-8")

--- a/stdlib/stdlib.gradle.kts
+++ b/stdlib/stdlib.gradle.kts
@@ -17,8 +17,8 @@ plugins {
   pklAllProjects
   base
   `maven-publish`
-  id("com.diffplug.spotless")
   pklPublishLibrary
+  pklSpotlessFormat
   signing
 }
 
@@ -51,13 +51,3 @@ publishing {
 }
 
 signing { sign(publishing.publications["stdlib"]) }
-
-spotless {
-  format("pkl") {
-    target("*.pkl")
-    licenseHeaderFile(
-      rootProject.file("buildSrc/src/main/resources/license-header.line-comment.txt"),
-      "/// ",
-    )
-  }
-}


### PR DESCRIPTION
This adds a spotless formatting step using the new pkl formatter.

This only formats Pkl sources in the stdlib, because other sources are possibly test input and not meant to be formatted.

TODO: it'd be good to also format the sources in `.circleci` (and `.github` once we migrate to GHA), but I'm running into some Gradle weirdness when trying to set that up; seeing this error:

```
A problem was found with the configuration of task ':spotlessPkl' (type 'SpotlessTaskImpl').
  - Gradle detected a problem with the following location: '/Users/danielchao/code/apple/pkl'.

    Reason: Task ':spotlessPkl' uses this output of task ':stdlib:spotlessKotlinGradle' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```
