### PR TITLE
Adjust formatting of line comments in lets

### DIFF
--- a/pkl-formatter/src/main/kotlin/org/pkl/formatter/Builder.kt
+++ b/pkl-formatter/src/main/kotlin/org/pkl/formatter/Builder.kt
@@ -972,21 +972,21 @@ internal class Builder(sourceText: String, private val grammarVersion: GrammarVe
 
   private fun formatLetExpr(node: Node): FormatNode {
     val separator = if (node.isMultiline()) forceLine() else spaceOrLine()
+    val endsWithLet = node.children.last().type == NodeType.LET_EXPR
     val nodes =
       formatGenericWithGen(
         node.children,
         { _, next -> if (next.type == NodeType.LET_PARAMETER_DEFINITION) Space else separator },
-      ) { node, next ->
+      ) { node, _ ->
         when {
           node.type == NodeType.LET_EXPR -> {
             // unpack the lets
             val group = formatLetExpr(node) as Group
             Nodes(group.nodes)
           }
-          node.type == NodeType.LET_PARAMETER_DEFINITION ||
-            node.isTerminal("let") ||
-            next?.type == NodeType.LET_EXPR -> format(node)
-          else -> indent(format(node))
+          endsWithLet -> format(node)
+          node.type.isExpression || node.type.isAffix -> indent(format(node))
+          else -> format(node)
         }
       }
     return Group(newId(), nodes)

--- a/pkl-formatter/src/test/files/FormatterSnippetTests/input/comment-interleaved.pkl
+++ b/pkl-formatter/src/test/files/FormatterSnippetTests/input/comment-interleaved.pkl
@@ -57,3 +57,18 @@ bar6 =
 bar7 =
   let (bar = 4) /* some comment */
     bar + 5
+
+bar8 =
+  let (bar = 4)
+    // some comment
+    // another comment
+  let (foo = 5)
+    // some comment
+    // another comment
+      bar + foo
+
+bar9 =
+  let (bar = 4)
+    // some comment
+    // another comment
+    bar

--- a/pkl-formatter/src/test/files/FormatterSnippetTests/output/comment-interleaved.pkl
+++ b/pkl-formatter/src/test/files/FormatterSnippetTests/output/comment-interleaved.pkl
@@ -60,3 +60,18 @@ bar6 =
 bar7 =
   let (bar = 4) /* some comment */
     bar + 5
+
+bar8 =
+  let (bar = 4)
+  // some comment
+  // another comment
+  let (foo = 5)
+    // some comment
+    // another comment
+    bar + foo
+
+bar9 =
+  let (bar = 4)
+    // some comment
+    // another comment
+    bar


### PR DESCRIPTION
Fixes an issue where line comments preceding let bodies are not indented.

Turn this:

```pkl
bar3 =
  let (bar = new Dynamic {})
  // some coment
    (bar) {
      qux = 4
    }
```

Into this:

```pkl
bar3 =
  let (bar = new Dynamic {})
    // some coment
    (bar) {
      qux = 4
    }
```