### PR TITLE
Normalize mutli-line string indentation

### DIFF
--- a/pkl-formatter/src/test/files/FormatterSnippetTests/input/multi-line-strings.pkl
+++ b/pkl-formatter/src/test/files/FormatterSnippetTests/input/multi-line-strings.pkl
@@ -27,3 +27,23 @@ qux = """
     
   \(foo)
   """
+
+// mixed tabs and spaces
+quux {
+  // space tab
+  """
+ 	bar
+
+ 	baz
+ 	\(1)
+
+ 	"""
+  // tab tab
+  """
+		bar
+
+		baz
+		\(1)
+
+		"""
+}

--- a/pkl-formatter/src/test/files/FormatterSnippetTests/output/multi-line-strings.pkl
+++ b/pkl-formatter/src/test/files/FormatterSnippetTests/output/multi-line-strings.pkl
@@ -29,3 +29,23 @@ qux =
     
   \(foo)
   """
+
+// mixed tabs and spaces
+quux {
+  // space tab
+  """
+  bar
+
+  baz
+  \(1)
+
+  """
+  // tab tab
+  """
+  bar
+
+  baz
+  \(1)
+
+  """
+}


### PR DESCRIPTION
The formatter previously assumed all indentation was spaces and failed to normalize leading indentation in multi-line strings to be spaces only.