### PR TITLE
Disable spotless ratcheting of Pkl sources

### DIFF
--- a/buildSrc/src/main/kotlin/pklSpotlessFormat.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklSpotlessFormat.gradle.kts
@@ -27,6 +27,9 @@ spotless {
       rootProject.file("buildSrc/src/main/resources/license-header.line-comment.txt"),
       "/// ",
     )
+    // disable ratcheting for Pkl sources
+    // make any change to pkl-formatter reformat the stdlib
+    ratchetFrom = null
   }
 }
 


### PR DESCRIPTION
This causes spotless to _always_ format Pkl files, instead of only formatting them if there's a diff between the file and what's in main.

This means that formatting changes in pkl-formatter will be propagated to the standard library.