### PR TITLE
Fix release builds

### DIFF
--- a/.github/PklProject
+++ b/.github/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 dependencies {
   ["pkl.impl.ghactions"] {
-    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@0.6.1"
+    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@0.7.1"
   }
   ["gha"] {
     uri = "package://pkg.pkl-lang.org/github.com/stefma/pkl-gha/com.github.action@0.0.6"

--- a/.github/PklProject.deps.json
+++ b/.github/PklProject.deps.json
@@ -10,9 +10,9 @@
     },
     "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@0": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@0.6.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@0.7.1",
       "checksums": {
-        "sha256": "8a1e36a92f2fd779b1439ad04dae4a088c787141ff9d4d11031e570a807170a2"
+        "sha256": "f8efc4b174855a2fafdab8ed792de4b0cb89b0516d688c8540eea13af20e0f80"
       }
     }
   }

--- a/.github/jobs/BuildNativeJob.pkl
+++ b/.github/jobs/BuildNativeJob.pkl
@@ -17,7 +17,6 @@ extraGradleArgs {
   }
 }
 
-
 steps {
   when (musl) {
     new {
@@ -28,10 +27,7 @@ steps {
   new {
     name = "gradle buildNative"
     shell = "bash"
-    run =
-      """
-      ./gradlew \(module.gradleArgs) \(project):buildNative
-      """
+    run = "./gradlew \(module.gradleArgs) \(project):buildNative"
   }
   new Artifact.Upload {
     name = "Upload executable artifacts"
@@ -41,7 +37,9 @@ steps {
           "executable-\(project)-alpine-\(module.os)-\(module.arch)"
         else
           "executable-\(project)-\(module.os)-\(module.arch)"
-      path = "\(project)/build/executable/**/*"
+      // Need to insert a wildcard to make actions/upload-artifact preserve the folder hierarchy.
+      // See https://github.com/actions/upload-artifact/issues/206
+      path = "\(project)*/build/executable/**/*"
     }
   }
 }

--- a/.github/jobs/PklJob.pkl
+++ b/.github/jobs/PklJob.pkl
@@ -1,6 +1,6 @@
 abstract module PklJob
 
-import "@gha/Workflow.pkl"
+extends "@pkl.impl.ghactions/jobs/PklJob.pkl"
 
 /// Identify any jobs that must complete successfully before this job will run.
 ///
@@ -23,7 +23,7 @@ needs: (String | *Listing<String>)?
 `if`: String?
 
 /// The underlying workflow job
-fixed job: Workflow.Job = new {
+fixed job {
   `if` = module.`if`
   needs = module.needs
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -221,7 +221,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-macOS-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -254,7 +254,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -360,7 +360,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-alpine-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -394,7 +394,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-windows-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -427,7 +427,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -463,7 +463,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-macOS-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -496,7 +496,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -602,7 +602,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-alpine-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -636,7 +636,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-windows-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -651,6 +651,7 @@ jobs:
         path: '**/build/reports/tests/**/*'
         if-no-files-found: ignore
   publish-test-results:
+    if: '!failure() && !cancelled()'
     needs:
     - gradle-check
     - gradle-check-windows
@@ -679,7 +680,7 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
         comment_mode: 'off'
-        files: '**/build/test-results/**/*.xml'
+        files: test-results-xml-*/**/*.xml
     - name: Upload Test Result HTML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,7 +184,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -220,7 +220,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-macOS-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -253,7 +253,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -359,7 +359,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-alpine-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -393,7 +393,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-windows-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -426,7 +426,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -462,7 +462,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-macOS-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -495,7 +495,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -601,7 +601,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-alpine-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -635,7 +635,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-windows-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -703,6 +703,7 @@ jobs:
         path: '**/build/reports/tests/**/*'
         if-no-files-found: ignore
   publish-test-results:
+    if: '!failure() && !cancelled()'
     needs:
     - gradle-check
     - gradle-check-windows
@@ -732,7 +733,7 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
         comment_mode: 'off'
-        files: '**/build/test-results/**/*.xml'
+        files: test-results-xml-*/**/*.xml
     - name: Upload Test Result HTML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -94,7 +94,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -131,7 +131,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-macOS-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -166,7 +166,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -274,7 +274,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-alpine-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -310,7 +310,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-windows-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -345,7 +345,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -382,7 +382,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-macOS-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -417,7 +417,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -525,7 +525,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-alpine-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -561,7 +561,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-windows-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -585,3 +585,31 @@ jobs:
       with:
         name: test-results-event-file
         path: ${{ github.event_path }}
+  check-pkl-github-actions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: Setup Pkl
+      id: setup-pkl
+      env:
+        PKL_VERSION: 0.30.0
+        PKL_FILENAME: pkl
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.30.0/pkl-linux-amd64
+      shell: bash
+      run: |-
+        DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
+        PKL_EXEC="$DIR/$PKL_FILENAME"
+        curl -sfL -o $PKL_EXEC "$PKL_DOWNLOAD_URL"
+        chmod +x $PKL_EXEC
+        echo "$DIR" >> "$GITHUB_PATH"
+        echo "pkl_exec=$PKL_EXEC" >> "$GITHUB_OUTPUT"
+    - shell: bash
+      run: pkl eval -m .github/ --project-dir .github/ .github/index.pkl
+    - name: check git status
+      shell: bash
+      run: |-
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "Running pkl resulted in a diff! You likely need to run 'pkl eval' and commit the changes."
+          git diff --name-only
+          exit 1
+        fi

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -184,7 +184,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -220,7 +220,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-macOS-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -253,7 +253,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -359,7 +359,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-alpine-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -393,7 +393,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-windows-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -426,7 +426,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -462,7 +462,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-macOS-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -495,7 +495,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -601,7 +601,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-alpine-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -635,7 +635,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-windows-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -650,6 +650,7 @@ jobs:
         path: '**/build/reports/tests/**/*'
         if-no-files-found: ignore
   publish-test-results:
+    if: '!failure() && !cancelled()'
     needs:
     - gradle-check
     - gradle-check-windows
@@ -678,7 +679,7 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
         comment_mode: 'off'
-        files: '**/build/test-results/**/*.xml'
+        files: test-results-xml-*/**/*.xml
     - name: Upload Test Result HTML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -220,7 +220,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-macOS-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -253,7 +253,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-linux-aarch64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -359,7 +359,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-alpine-linux-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -393,7 +393,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-cli-windows-amd64
-        path: pkl-cli/build/executable/**/*
+        path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -426,7 +426,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -462,7 +462,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-macOS-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -495,7 +495,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-linux-aarch64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -601,7 +601,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-alpine-linux-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -635,7 +635,7 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: executable-pkl-doc-windows-amd64
-        path: pkl-doc/build/executable/**/*
+        path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5
@@ -741,6 +741,7 @@ jobs:
         path: '**/build/reports/tests/**/*'
         if-no-files-found: ignore
   publish-test-results:
+    if: '!failure() && !cancelled()'
     needs:
     - gradle-check
     - gradle-check-windows
@@ -771,7 +772,7 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
         comment_mode: 'off'
-        files: '**/build/test-results/**/*.xml'
+        files: test-results-xml-*/**/*.xml
     - name: Upload Test Result HTML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5


### PR DESCRIPTION
In order to preserve the folder hierarchy in our uploaded artifact, we need to insert a wildcard in the root path.

Also, fix fan-in of tasks that lead to the publish test result task.