### PR TITLE
Fix deploy jobs

### DIFF
--- a/.github/jobs/DeployJob.pkl
+++ b/.github/jobs/DeployJob.pkl
@@ -18,6 +18,7 @@ steps {
   new Artifact.Download {
     with {
       pattern = "executable-**"
+      `merge-multiple` = true
     }
   }
   new Workflow.Step {

--- a/.github/jobs/GithubRelease.pkl
+++ b/.github/jobs/GithubRelease.pkl
@@ -15,6 +15,7 @@ fixed job {
     new Artifact.Download {
       with {
         pattern = "executable-**"
+        `merge-multiple` = true
       }
     }
     new {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -682,6 +682,7 @@ jobs:
     - uses: actions/download-artifact@v6
       with:
         pattern: executable-**
+        merge-multiple: true
     - env:
         ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -682,6 +682,7 @@ jobs:
     - uses: actions/download-artifact@v6
       with:
         pattern: executable-**
+        merge-multiple: true
     - env:
         ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
@@ -711,6 +712,7 @@ jobs:
     - uses: actions/download-artifact@v6
       with:
         pattern: executable-**
+        merge-multiple: true
     - name: Publish release on GitHub
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Specify `merge-multiple` to prevent new directories from being created when downloading artifacts.