### PR TITLE
Fix NPE in VmTyped.hashCode when property is null

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmExceptionBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmExceptionBuilder.java
@@ -345,8 +345,8 @@ public final class VmExceptionBuilder {
     return this;
   }
 
-  public VmExceptionBuilder nullPropertyInHashCode(String propertyName) {
-    return evalError("nullPropertyInHashCode", propertyName);
+  public VmExceptionBuilder stackOverflowError() {
+    return evalError("stackOverflow");
   }
 
   public VmException build() {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmTyped.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmTyped.java
@@ -204,9 +204,7 @@ public final class VmTyped extends VmObject {
 
     for (var key : clazz.getAllRegularPropertyNames()) {
       var value = getCachedValue(key);
-      if (value == null) {
-        throw new VmExceptionBuilder().nullPropertyInHashCode(key.toString()).build();
-      }
+      if (value == null) throw new VmExceptionBuilder().stackOverflowError().build();
       result = 31 * result + value.hashCode();
     }
 

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -436,8 +436,6 @@ Undefined value.
 undefinedPropertyValue=\
 Tried to read property `{0}` but its value is undefined.
 
-nullPropertyInHashCode=Null property value encountered while computing hashCode for property ''{0}''
-
 cannotFindModule=\
 Cannot find module `{0}`.
 


### PR DESCRIPTION
Fixes #1167

Null properties in `VmTyped` previously caused a NPE when accessed through `hashCode()`. 
This fix adds null checks so that `containsKey` and other map operations do not crash.