### PR TITLE
fix newline checks in parser

### DIFF
--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/binopDifferentLine.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/binopDifferentLine.pkl
@@ -1,0 +1,5 @@
+binop_result: Int = 1 
+
+/*comment*/- 
+  
+/*comment*/ 1

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/binopDifferentLine.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/binopDifferentLine.err
@@ -1,0 +1,6 @@
+–– Pkl Error ––
+Invalid token at position. Expected a class, typealias, method, or property.
+
+x | /*comment*/-
+               ^
+at binopDifferentLine (file:///$snippetsDir/input/errors/binopDifferentLine.pkl)

--- a/pkl-parser/src/main/java/org/pkl/parser/Parser.java
+++ b/pkl-parser/src/main/java/org/pkl/parser/Parser.java
@@ -1811,11 +1811,13 @@ public class Parser {
   private FullToken forceNext() {
     var tk = lexer.next();
     precededBySemicolon = false;
+    var newLines = lexer.newLinesBetween;
     while (tk.isAffix()) {
       precededBySemicolon = precededBySemicolon || tk == Token.SEMICOLON;
       tk = lexer.next();
+      newLines += lexer.newLinesBetween;
     }
-    return new FullToken(tk, lexer.span(), lexer.newLinesBetween);
+    return new FullToken(tk, lexer.span(), newLines);
   }
 
   // Like next, but don't ignore comments

--- a/pkl-parser/src/test/kotlin/org/pkl/parser/ParserComparisonTest.kt
+++ b/pkl-parser/src/test/kotlin/org/pkl/parser/ParserComparisonTest.kt
@@ -93,6 +93,7 @@ class ParserComparisonTest {
         "stringError1.pkl",
         "annotationIsNotExpression2.pkl",
         "amendsRequiresParens.pkl",
+        "errors/binopDifferentLine.pkl",
         "errors/parser18.pkl",
         "errors/nested1.pkl",
         "errors/invalidCharacterEscape.pkl",


### PR DESCRIPTION
In places where the parser tries to check or enforce that productions occur on the same line, 'affix' tokens present on subsequent lines, when followed by the expected/enforced production can confuse the parser. For example, this code is rejected by the old ANT parser, but accepted with the new parser in 0.28+:

```pkl
// block comments help you violate "same line" rules 
// such as for type constraints, subscription, binary expressions etc
binresult: Int = 1

/*comment*/ - 

/*comment*/ 1
```

<details><summary>Execution details</summary>

In versions <0.28:

```pkl
–– Pkl Error ––
Extraneous input: `-`. Expected one of: <EOF>, `abstract`, `class`, `const`, `external`, `fixed`, `function`, `hidden`, `local`, `open`, `typealias`, `@`, Identifier, DocComment

3 | /*comment*/-
               ^
at binopDifferentLine (file:///path/to/binopDifferentLine.pkl, line 3)
```
In pkl 0.28+ this succeeds erroneously:

```yaml
binresult: 0
```

</details>

This is because of how the lexer (re)sets `newLinesBetween`  when it encounters new tokens, including those often ignored by the parser. When those ignored tokens (specifically line comments, block comments, and semicolons) are encountered in, the count is reset and checks like `lookahead.newLinesBetween == 0` can fail to assert the necessary/intended state.


Because checks on newLinesBetween generally are for `==0` and coincide with `!precededBySemicolon` in practice, I think only block comments can cause this issue, even though semicolons and line comments also reset the count.

This _may_ also have an impact on how `expect` logically arrives at the error location in which to point.

The proposed fix modifies `forceNext` to keep track of newlines between tokens, including any newlines between tokens that are skipped, and accumulating the total into the presented `FullToken`.

This may also be needed for `forceNextComment` but not sure.