### PR TITLE
Fix snapshot publishing

### DIFF
--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -2,13 +2,13 @@ amends "@pkl.impl.ghactions/PklCI.pkl"
 
 import "@gha/Workflow.pkl"
 
+import "jobs/BuildJavaExecutableJob.pkl"
 import "jobs/BuildNativeJob.pkl"
 import "jobs/DeployJob.pkl"
 import "jobs/GithubRelease.pkl"
 import "jobs/GradleJob.pkl"
 import "jobs/PklJob.pkl"
 import "jobs/SimpleGradleJob.pkl"
-import "jobs/BuildJavaExecutableJob.pkl"
 
 triggerDocsBuild = "both"
 
@@ -132,7 +132,10 @@ prb {
           }
         }
         `if` =
-          tags.toList().map((it) -> "contains(github.event.pull_request.body, '\(it)')").join(" || ")
+          tags
+            .toList()
+            .map((it) -> "contains(github.event.pull_request.body, '\(it)')")
+            .join(" || ")
       }
     }
   }
@@ -152,7 +155,14 @@ build {
 main {
   jobs =
     (buildAndTestJobs) {
-      ["deploy-snapshot"] = (new DeployJob { command = "publishToSonatype" }) {
+      ["deploy-snapshot"] = (
+        new DeployJob {
+          extraGradleArgs {
+            "--no-parallel"
+          }
+          command = "publishToSonatype"
+        }
+      ) {
         needs = buildAndTestJobs.keys.toListing()
       }
     } |> toWorkflowJobs
@@ -163,14 +173,15 @@ releaseBranch {
 }
 
 release {
-  jobs = (releaseJobs) {
-    ["deploy-release"] = (
-      new DeployJob { command = "publishToSonatype closeAndReleaseSonatypeStagingRepository" }
-    ) {
-      needs = releaseJobs.keys.toListing()
-    }
-    ["github-release"] = (new GithubRelease {}) {
-      needs = "deploy-release"
-    }
-  } |> toWorkflowJobs
+  jobs =
+    (releaseJobs) {
+      ["deploy-release"] = (
+        new DeployJob { command = "publishToSonatype closeAndReleaseSonatypeStagingRepository" }
+      ) {
+        needs = releaseJobs.keys.toListing()
+      }
+      ["github-release"] = (new GithubRelease {}) {
+        needs = "deploy-release"
+      }
+    } |> toWorkflowJobs
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -763,7 +763,7 @@ jobs:
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
-      run: ./gradlew --info --stacktrace -DpklMultiJdkTesting=true publishToSonatype
+      run: ./gradlew --info --stacktrace -DpklMultiJdkTesting=true --no-parallel publishToSonatype
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@v5


### PR DESCRIPTION
We're publish snapshots too fast and sonatype is complaining about `too many request`.