### PR TITLE
Change `pkl format --write` to exit 0 when formatting violations are found

### DIFF
--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -741,9 +741,9 @@ pkl shell-completion zsh
 This command formats or checks formatting of Pkl files. +
 Exit codes:
 
-* 0: No violations found.
+* 0: No violations found or files were updated.
 * 1: An unexpected error happened (ex.: IO error)
-* 11: Violations were found.
+* 11: Violations were found (when running without `--write`).
 
 If the path is a directory, recursively looks for files with a `.pkl` extension, or files named `PklProject`.
 

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterCommand.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterCommand.kt
@@ -110,7 +110,6 @@ constructor(
 
         val formatted = format(contents)
         if (contents != formatted) {
-          status.update(FORMATTING_VIOLATION)
           if (diffNameOnly || overwrite) {
             // if `--diff-name-only` or `-w` is specified, only write file names
             writeLine(pathStr)
@@ -118,6 +117,9 @@ constructor(
 
           if (overwrite) {
             path.writeText(formatted, Charsets.UTF_8)
+          } else {
+            // only exit on violation for "check" operations, not when overwriting
+            status.update(FORMATTING_VIOLATION)
           }
         }
 


### PR DESCRIPTION
Does not change the behavior of invocations without `--write`.

Resolves #1324