### PR TITLE
Fix CI build for pkldoc

### DIFF
--- a/buildSrc/src/main/kotlin/pklNativeLifecycle.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklNativeLifecycle.gradle.kts
@@ -83,6 +83,7 @@ val assembleNative by
 val testNative by
   tasks.registering {
     group = "verification"
+    dependsOn(assembleNative)
 
     if (!buildInfo.isCrossArchSupported && buildInfo.isCrossArch) {
       throw GradleException("Cross-arch builds are not supported on ${buildInfo.os.name}")
@@ -125,5 +126,5 @@ val checkNative by
 val buildNative by
   tasks.registering {
     group = "build"
-    dependsOn(assembleNative, checkNative)
+    dependsOn(checkNative)
   }


### PR DESCRIPTION
Fixes an issue where the executable is not built.

Haven't dug into why this broke; this was working just a little bit ago (see https://github.com/apple/pkl/actions/runs/19911073549/job/57079605641?pr=1342).
Nevertheless, the lifecycle job dependencies were a little wonky (test should assemble first).

[native-pkl-doc]