### PR TITLE
Omit superfluous newline when writing formatted content to stdout

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterCommand.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliFormatterCommand.kt
@@ -49,13 +49,13 @@ constructor(
     return Formatter().format(contents, grammarVersion)
   }
 
-  private fun writeErr(error: String) {
+  private fun writeErrLine(error: String) {
     errWriter.write(error)
     errWriter.appendLine()
     errWriter.flush()
   }
 
-  private fun write(message: String) {
+  private fun writeLine(message: String) {
     if (silent) return
     consoleWriter.write(message)
     consoleWriter.appendLine()
@@ -88,7 +88,7 @@ constructor(
       }
       ERROR -> {
         if (!silent) {
-          writeErr("An error occurred during formatting.")
+          writeErrLine("An error occurred during formatting.")
         }
         throw CliTestException("", status.status)
       }
@@ -113,7 +113,7 @@ constructor(
           status.update(FORMATTING_VIOLATION)
           if (diffNameOnly || overwrite) {
             // if `--diff-name-only` or `-w` is specified, only write file names
-            write(pathStr)
+            writeLine(pathStr)
           }
 
           if (overwrite) {
@@ -122,13 +122,14 @@ constructor(
         }
 
         if (!diffNameOnly && !overwrite) {
-          write(formatted)
+          consoleWriter.write(formatted)
+          consoleWriter.flush()
         }
       } catch (pe: GenericParserError) {
-        writeErr("Could not format `$pathStr`: $pe")
+        writeErrLine("Could not format `$pathStr`: $pe")
         status.update(ERROR)
       } catch (e: IOException) {
-        writeErr("IO error while reading `$pathStr`: ${e.message}")
+        writeErrLine("IO error while reading `$pathStr`: ${e.message}")
         status.update(ERROR)
       }
     }

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliFormatterTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliFormatterTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.cli
+
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.pkl.commons.cli.CliException
+import org.pkl.core.util.StringBuilderWriter
+import org.pkl.formatter.GrammarVersion
+
+class CliFormatterTest {
+  @Test
+  fun `no double newline when writing to stdout`(@TempDir tempDir: Path) {
+    val file = tempDir.resolve("foo.pkl").also { it.writeText("foo = 1") }
+    val sb = StringBuilder()
+    val writer = StringBuilderWriter(sb)
+    val cmd =
+      CliFormatterCommand(
+        listOf(file),
+        GrammarVersion.latest(),
+        overwrite = false,
+        diffNameOnly = false,
+        silent = false,
+        consoleWriter = writer,
+      )
+    try {
+      cmd.run()
+    } catch (_: CliException) {}
+    assertThat(sb.toString()).isEqualTo("foo = 1\n")
+  }
+}


### PR DESCRIPTION
Fixes an issue where an extra newline is added when writing formatted code to stdout.

Closes https://github.com/apple/pkl/issues/1346