### PR TITLE
Fix IDEA gradle project sync on Windows Aarch64

### DIFF
--- a/buildSrc/src/main/kotlin/pklNativeLifecycle.gradle.kts
+++ b/buildSrc/src/main/kotlin/pklNativeLifecycle.gradle.kts
@@ -69,6 +69,9 @@ val assembleNative by
       buildInfo.os.isWindows && buildInfo.targetArch == "amd64" -> {
         wraps(assembleNativeWindowsAmd64)
       }
+      buildInfo.os.isWindows && buildInfo.targetArch == "aarch64" -> {
+        logger.warn("Windows Aarch64 is not supported by GraalVM, skipping assembleNative")
+      }
       buildInfo.musl -> {
         throw GradleException("Building musl on ${buildInfo.os} is not supported")
       }
@@ -105,6 +108,9 @@ val testNative by
       }
       buildInfo.os.isWindows && buildInfo.targetArch == "amd64" -> {
         dependsOn(testNativeWindowsAmd64)
+      }
+      buildInfo.os.isWindows && buildInfo.targetArch == "aarch64" -> {
+        logger.warn("Windows Aarch64 is not supported by GraalVM, skipping testNative")
       }
       buildInfo.musl -> {
         throw GradleException("Building musl on ${buildInfo.os} is not supported")


### PR DESCRIPTION
Without this change, project sync errors:
```
Could not create task ':pkl-cli:testNative'.
Unsupported os/arch pair: Windows 11/aarch64
```

Adding these allows IDEA gradle project sync to complete on Windows 11 Aarch64. Tested with Temurin JDK 21 Aarch64.

GraalVM itself doesn't support Windows Aarch64, so this just prints a warning instead.

Please test on [windows]!