### PR TITLE
Fix building of pkl-doc

### DIFF
--- a/pkl-doc/pkl-doc.gradle.kts
+++ b/pkl-doc/pkl-doc.gradle.kts
@@ -69,6 +69,7 @@ publishing {
 
 val testNativeExecutable by
   tasks.registering(Test::class) {
+    dependsOn(tasks.assembleNative)
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 


### PR DESCRIPTION
Ensure that `assembleNative` is called before testing the native executable