### PR TITLE
Add syntax highlighting of Pkl code

### DIFF
--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliRepl.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliRepl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/repl/Repl.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/repl/Repl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,9 @@ internal class Repl(workingDir: Path, private val server: ReplServer, private va
       .apply {
         history(history)
         terminal(terminal)
-        highlighter(PklHighlighter())
+        if (color) {
+          highlighter(PklHighlighter())
+        }
         completer(AggregateCompleter(CommandCompleter, FileCompleter(workingDir)))
         option(Option.DISABLE_EVENT_EXPANSION, true)
         variable(LineReader.HISTORY_FILE, (IoUtils.getPklHomeDir().resolve("repl-history")))

--- a/pkl-core/src/main/java/org/pkl/core/repl/ReplServer.java
+++ b/pkl-core/src/main/java/org/pkl/core/repl/ReplServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ public class ReplServer implements AutoCloseable {
   private final VmExceptionRenderer errorRenderer;
   private final PackageResolver packageResolver;
   private final @Nullable ProjectDependenciesManager projectDependenciesManager;
+  private final boolean color;
 
   public ReplServer(
       SecurityManager securityManager,
@@ -92,6 +93,7 @@ public class ReplServer implements AutoCloseable {
     this.securityManager = securityManager;
     this.moduleResolver = new ModuleResolver(moduleKeyFactories);
     this.errorRenderer = new VmExceptionRenderer(new StackTraceRenderer(frameTransformer), color);
+    this.color = color;
     replState = new ReplState(createEmptyReplModule(BaseModule.getModuleClass().getPrototype()));
 
     var languageRef = new MutableReference<VmLanguage>(null);
@@ -450,7 +452,7 @@ public class ReplServer implements AutoCloseable {
   }
 
   private String render(Object value) {
-    var sb = new AnsiStringBuilder(true);
+    var sb = new AnsiStringBuilder(color);
     var src = VmValueRenderer.multiLine(Integer.MAX_VALUE).render(value);
     SyntaxHighlighter.writeTo(sb, src);
     return sb.toString();

--- a/pkl-core/src/main/java/org/pkl/core/runtime/StackTraceRenderer.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/StackTraceRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkl-core/src/main/java/org/pkl/core/util/AnsiStringBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/AnsiStringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,6 +197,10 @@ public final class AnsiStringBuilder {
 
   public PrintWriter toPrintWriter() {
     return new PrintWriter(new StringBuilderWriter(builder));
+  }
+
+  public int length() {
+    return builder.length();
   }
 
   public void setLength(int length) {

--- a/pkl-core/src/main/java/org/pkl/core/util/AnsiTheme.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/AnsiTheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkl-core/src/main/java/org/pkl/core/util/SyntaxHighlighter.java
+++ b/pkl-core/src/main/java/org/pkl/core/util/SyntaxHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,12 +101,13 @@ public final class SyntaxHighlighter {
       EnumSet.of(Token.INT, Token.FLOAT, Token.BIN, Token.OCT, Token.HEX);
 
   public static void writeTo(AnsiStringBuilder out, String src) {
+    var prevLength = out.length();
     try {
       var lexer = new Lexer(src);
       doHighlightNormal(out, lexer.next(), lexer, Token.EOF);
     } catch (ParserError err) {
       // bail out and emit everything un-highlighted
-      out.setLength(0);
+      out.setLength(prevLength);
       out.append(src);
     }
   }

--- a/pkl-parser/src/main/java/org/pkl/parser/Lexer.java
+++ b/pkl-parser/src/main/java/org/pkl/parser/Lexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This adds syntax highlighting of Pkl code!

It adds highlighting for:

* Stack frames within error messages
* CLI REPL (highlights as you type, highlights error output)
* Power assertions (coming in https://github.com/apple/pkl/pull/1384)

This uses the lexer for highlighting. It will highlight strings, numbers, keywords, but doesn't understand how to highlight nodes like types, function params, etc.
The reason for this is because a single line of code by itself may not be grammatically valid.

Sample screenshots:

<img width="456" height="436" alt="Screenshot 2025-12-23 at 10 32 37 PM" src="https://github.com/user-attachments/assets/b96fc23a-2f59-4064-a6da-273d94aae8d3" />

<img width="1136" height="350" alt="Screenshot 2025-12-23 at 10 39 10 PM" src="https://github.com/user-attachments/assets/71c79396-7dc3-445e-81b4-f5011c7ef6be" />

