### PR TITLE
Use gradle/actions/setup-gradle

### DIFF
--- a/.github/PklProject
+++ b/.github/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 dependencies {
   ["pkl.impl.ghactions"] {
-    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.1.6"
+    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.2.0"
   }
   ["gha"] {
     uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.2.0"

--- a/.github/PklProject.deps.json
+++ b/.github/PklProject.deps.json
@@ -10,9 +10,9 @@
     },
     "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.1.6",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.2.0",
       "checksums": {
-        "sha256": "efe36e694f45b0804c5fcc746774727c016c866478b8c1eb0ea86d00c8bd8cf2"
+        "sha256": "2f60e7167eab8728c4f60196fd5b6e9965723797528a859f36eb0ecbd2db2909"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {

--- a/.github/jobs/GradleJob.pkl
+++ b/.github/jobs/GradleJob.pkl
@@ -3,7 +3,7 @@ abstract module GradleJob
 extends "PklJob.pkl"
 
 import "@gha/Workflow.pkl"
-import "@gha/catalog.pkl"
+import "@pkl.impl.ghactions/catalog.pkl"
 
 /// Whether this is a release build or not.
 isRelease: Boolean = false
@@ -83,7 +83,6 @@ fixed job {
       with {
         `java-version` = "21"
         distribution = "temurin"
-        cache = "gradle"
         architecture =
           if (arch == "amd64")
             "x64"
@@ -91,6 +90,7 @@ fixed job {
             "aarch64"
       }
     }
+    catalog.`gradle/actions/setup-gradle@v5`
     ...module.steps
   }
 }

--- a/.github/workflows/__lockfile__.yml
+++ b/.github/workflows/__lockfile__.yml
@@ -29,3 +29,5 @@ jobs:
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     - name: dawidd6/action-download-artifact@v11
       uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
+    - name: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -59,7 +60,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -89,7 +91,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: bench:jmh
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true bench:jmh
@@ -107,7 +110,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
@@ -138,7 +142,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
         persist-credentials: false
@@ -179,7 +184,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-cli:buildNative
@@ -216,7 +222,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -258,7 +265,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
@@ -295,7 +303,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -334,7 +343,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -443,7 +453,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
@@ -481,7 +492,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-doc:buildNative
@@ -518,7 +530,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -560,7 +573,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
@@ -597,7 +611,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -636,7 +651,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -745,7 +761,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -58,7 +59,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -88,7 +90,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: bench:jmh
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true bench:jmh
@@ -106,7 +109,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
@@ -137,7 +141,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
         persist-credentials: false
@@ -178,7 +183,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-cli:buildNative
@@ -215,7 +221,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -257,7 +264,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
@@ -294,7 +302,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -333,7 +342,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -442,7 +452,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
@@ -480,7 +491,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-doc:buildNative
@@ -517,7 +529,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -559,7 +572,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
@@ -596,7 +610,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -635,7 +650,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -744,7 +760,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
@@ -798,7 +815,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
         persist-credentials: false

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -22,7 +22,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -56,7 +57,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -90,7 +92,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-cli:buildNative
@@ -129,7 +132,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -172,7 +176,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
@@ -211,7 +216,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -252,7 +258,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -363,7 +370,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
@@ -402,7 +410,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-doc:buildNative
@@ -441,7 +450,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -484,7 +494,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
@@ -523,7 +534,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -564,7 +576,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -675,7 +688,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -26,7 +26,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -58,7 +59,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -88,7 +90,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: bench:jmh
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true bench:jmh
@@ -106,7 +109,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
@@ -137,7 +141,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
         persist-credentials: false
@@ -178,7 +183,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-cli:buildNative
@@ -215,7 +221,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -257,7 +264,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
@@ -294,7 +302,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -333,7 +342,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -442,7 +452,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
@@ -480,7 +491,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-doc:buildNative
@@ -517,7 +529,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -559,7 +572,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
@@ -596,7 +610,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -635,7 +650,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -744,7 +760,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -58,7 +59,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: check
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
@@ -88,7 +90,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: bench:jmh
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true bench:jmh
@@ -106,7 +109,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
@@ -137,7 +141,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
         persist-credentials: false
@@ -178,7 +183,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-cli:buildNative
@@ -215,7 +221,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -257,7 +264,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
@@ -294,7 +302,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -333,7 +342,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -442,7 +452,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
@@ -480,7 +491,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.targetArch=amd64 -Dpkl.native--native-compiler-path=${{ github.workspace }}/.github/scripts/cc_macos_amd64.sh pkl-doc:buildNative
@@ -517,7 +529,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -559,7 +572,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
@@ -596,7 +610,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: aarch64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Fix git ownership
       run: git status || git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: gradle buildNative
@@ -635,7 +650,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: Install musl and zlib
       run: |
         set -e
@@ -744,7 +760,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - name: gradle buildNative
       shell: bash
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
@@ -798,7 +815,8 @@ jobs:
         java-version: '21'
         distribution: temurin
         architecture: x64
-        cache: gradle
+    - uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      with: {}
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       with:
         persist-credentials: false


### PR DESCRIPTION
This adds the setup-gradle action; which has the following improvements:

* Improved cacheing (compared to setup-java's Gradle cache)
* Validates the gradle wrapper jar