### PR TITLE
Allow command `transformAll` functions to perform imports

### DIFF
--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -1070,10 +1070,10 @@ A property may be annotated with any type if its `@Flag` or `@Argument` annotati
 The `convert` property is a xref:language-reference:index.adoc#anonymous-functions[function] that overrides how _each_ raw option value is interpreted.
 The `transformAll` property is a function that overrides how _all_ parsed option values become the final property value.
 
-The `convert` function may return an link:{uri-stdlib-Command-Import}[`Import`] value that is replaced during option parsing with the actual value of the module specified by its `uri` property.
+The `convert` and `transformAll` functions may return an pkldoc:Import[pkl:Command] value that is replaced during option parsing with the actual value of the module specified by its `uri` property.
 If `glob` is `true`, the replacement value is a `Mapping`; its keys are the _absolute_ URIs of the matched modules and its values are the actual module values.
 When specifying glob import options on the command line, it is often necessary to quote the value to avoid it being interpreted by the shell.
-If the return value of `convert` is a `List`, `Set`, `Map`, or `Pair`, each contained value (elements and entry keys/values) that are `Import` values are also replaced.
+If the return value of `convert` or `transformAll` is a `List`, `Set`, `Map`, or `Pair`, each contained value (elements and entry keys/values) that are `Import` values are also replaced.
 
 [IMPORTANT]
 ====

--- a/docs/modules/release-notes/pages/0.31.adoc
+++ b/docs/modules/release-notes/pages/0.31.adoc
@@ -99,7 +99,7 @@ To learn more about this feature, consult https://github.com/apple/pkl-evolution
 [[cli-framework]]
 === CLI Framework
 
-Pkl 0.31 introduces a new framework for implementing CLI tools in Pkl (pr:https://github.com/apple/pkl/pull/1367[], pr:https://github.com/apple/pkl/pull/1431[], pr:https://github.com/apple/pkl/pull/1432[], pr:https://github.com/apple/pkl/pull/1436[]).
+Pkl 0.31 introduces a new framework for implementing CLI tools in Pkl (pr:https://github.com/apple/pkl/pull/1367[], pr:https://github.com/apple/pkl/pull/1431[], pr:https://github.com/apple/pkl/pull/1432[], pr:https://github.com/apple/pkl/pull/1436[], pr:https://github.com/apple/pkl/pull/1440[]).
 
 The framework provides a way to build command line tools with user experience idioms that will be immediately familiar to users.
 CLI tools implemented in Pkl have largely the same capabilities as normal Pkl evaluation (i.e. writing to standard output and files), but this may be extended using xref:language-reference:index.adoc#external-readers[external readers].

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliCommandRunner.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliCommandRunner.kt
@@ -22,6 +22,7 @@ import com.github.ajalt.clikt.parameters.arguments.*
 import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.int
 import java.io.OutputStream
+import java.net.URI
 import java.nio.file.Path
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.exists
@@ -159,7 +160,7 @@ constructor(
                 )
                 .convert {
                   try {
-                    opt.transformEach.apply(it, runner.options.normalizedWorkingDir.toUri())
+                    opt.transformEach.apply(it, workingDirUri)
                   } catch (e: CommandSpec.Option.BadValue) {
                     fail(e.message!!)
                   } catch (_: CommandSpec.Option.MissingOption) {
@@ -168,7 +169,7 @@ constructor(
                 }
                 .transformAll(opt.defaultValue, opt.showAsRequired) {
                   try {
-                    opt.transformAll.apply(it)
+                    opt.transformAll.apply(it, workingDirUri)
                   } catch (e: CommandSpec.Option.BadValue) {
                     fail(e.message!!)
                   } catch (_: CommandSpec.Option.MissingOption) {
@@ -201,7 +202,7 @@ constructor(
                 )
                 .convert {
                   try {
-                    opt.transformEach.apply(it, runner.options.normalizedWorkingDir.toUri())
+                    opt.transformEach.apply(it, workingDirUri)
                   } catch (e: CommandSpec.Option.BadValue) {
                     fail(e.message!!)
                   } catch (_: CommandSpec.Option.MissingOption) {
@@ -210,7 +211,7 @@ constructor(
                 }
                 .transformAll(if (opt.repeated) -1 else 1, !opt.repeated) {
                   try {
-                    opt.transformAll.apply(it)
+                    opt.transformAll.apply(it, workingDirUri)
                   } catch (e: CommandSpec.Option.BadValue) {
                     fail(e.message!!)
                   } catch (_: CommandSpec.Option.MissingOption) {
@@ -222,6 +223,8 @@ constructor(
       }
       spec.subcommands.forEach { subcommands(SynthesizedRunCommand(it, runner)) }
     }
+
+    val workingDirUri: URI by lazy { runner.options.normalizedWorkingDir.toUri() }
 
     override val invokeWithoutSubcommand = true
 

--- a/pkl-core/src/main/java/org/pkl/core/CommandSpec.java
+++ b/pkl-core/src/main/java/org/pkl/core/CommandSpec.java
@@ -89,7 +89,7 @@ public record CommandSpec(
       @Nullable String helpText,
       boolean showAsRequired,
       BiFunction<String, URI, Object> transformEach,
-      Function<List<Object>, Object> transformAll,
+      BiFunction<List<Object>, URI, Object> transformAll,
       @Nullable CompletionCandidates completionCandidates,
       @Nullable String shortName,
       String metavar,
@@ -134,7 +134,7 @@ public record CommandSpec(
       String name,
       @Nullable String helpText,
       BiFunction<String, URI, Object> transformEach,
-      Function<List<Object>, Object> transformAll,
+      BiFunction<List<Object>, URI, Object> transformAll,
       @Nullable CompletionCandidates completionCandidates,
       boolean repeated)
       implements Option {

--- a/stdlib/Command.pkl
+++ b/stdlib/Command.pkl
@@ -176,6 +176,10 @@ class Flag extends BaseFlag {
 
   /// Customize the behavior of turning all parsed flag values into the final option value.
   ///
+  /// When the return value is an [Import] value or a [Pair] member, [List] or [Set] element
+  /// containing an [Import], the URI or glob URI specified by the value is imported and the value
+  /// is replaced with the value of the imported module(s).
+  ///
   /// If no value is provided, all flag values are transformed according to the option's type:
   ///
   /// | Type              | Behavior |
@@ -234,6 +238,10 @@ class Argument extends Annotation {
   multiple: Boolean?
 
   /// Customize the behavior of turning all parsed flag values into the final option value.
+  ///
+  /// When the return value is an [Import] value or a [Pair] member, [List] or [Set] element
+  /// containing an [Import], the URI or glob URI specified by the value is imported and the value
+  /// is replaced with the value of the imported module(s).
   ///
   /// If no value is provided, all option values are transformed using the same rules as
   /// [Flag.transformAll].


### PR DESCRIPTION
This is important for CLI use cases where a settings file should be imported from the current working directory, like with `pkl-gen-swift`/`pkl-gen-go` importing `generator-settings.pkl` if no explicit settings file path is passed.