### PR TITLE
Allow command options to have nullable types and default values

### DIFF
--- a/docs/modules/release-notes/pages/0.31.adoc
+++ b/docs/modules/release-notes/pages/0.31.adoc
@@ -99,7 +99,7 @@ To learn more about this feature, consult https://github.com/apple/pkl-evolution
 [[cli-framework]]
 === CLI Framework
 
-Pkl 0.31 introduces a new framework for implementing CLI tools in Pkl (pr:https://github.com/apple/pkl/pull/1367[], pr:https://github.com/apple/pkl/pull/1431[], pr:https://github.com/apple/pkl/pull/1432[], pr:https://github.com/apple/pkl/pull/1436[], pr:https://github.com/apple/pkl/pull/1440[]).
+Pkl 0.31 introduces a new framework for implementing CLI tools in Pkl (pr:https://github.com/apple/pkl/pull/1367[], pr:https://github.com/apple/pkl/pull/1431[], pr:https://github.com/apple/pkl/pull/1432[], pr:https://github.com/apple/pkl/pull/1436[], pr:https://github.com/apple/pkl/pull/1440[], pr:https://github.com/apple/pkl/pull/1444[]).
 
 The framework provides a way to build command line tools with user experience idioms that will be immediately familiar to users.
 CLI tools implemented in Pkl have largely the same capabilities as normal Pkl evaluation (i.e. writing to standard output and files), but this may be extended using xref:language-reference:index.adoc#external-readers[external readers].

--- a/pkl-core/src/main/java/org/pkl/core/runtime/CommandSpecParser.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/CommandSpecParser.java
@@ -513,12 +513,6 @@ public final class CommandSpecParser {
       var typeNode = resolved.getFirst();
       isNullable = resolved.getSecond();
       defaultValue = CommandSpecParser.this.getDefaultValue(prop, requireExplicitDefault);
-      if (isNullable && defaultValue != null) {
-        throw exceptionBuilder()
-            .evalError("commandOptionTypeNullableWithDefaultValue", prop.getName())
-            .withSourceSection(prop.getHeaderSection())
-            .build();
-      }
 
       resolve(prop, typeNode);
       return this;

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -1098,11 +1098,6 @@ Found both `@Flag` and `@Argument` annotations for options property `{0}`.\n\
 \n\
 Only one option type may be specified.
 
-commandOptionTypeNullableWithDefaultValue=\
-Unexpected option property `{0}` with nullable type and default value.\n\
-\n\
-Options with default values must not be nullable.
-
 commandOptionUnsupportedType=\
 Command option property `{0}` has unsupported {1}type `{2}`.
 

--- a/pkl-core/src/test/kotlin/org/pkl/core/runtime/CommandSpecParserTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/runtime/CommandSpecParserTest.kt
@@ -293,26 +293,6 @@ class CommandSpecParserTest {
   }
 
   @Test
-  fun `nullable option with default not allowed`() {
-    val moduleUri =
-      writePklFile(
-        "cmd.pkl",
-        renderOptions +
-          """
-      class Options {
-        foo: String? = "bar"
-      }
-    """
-            .trimIndent(),
-      )
-
-    val exc = assertThrows<PklException> { parse(moduleUri) }
-    assertThat(exc.message).contains("foo: String? = \"bar\"")
-    assertThat(exc.message)
-      .contains("Unexpected option property `foo` with nullable type and default value")
-  }
-
-  @Test
   fun `option with union type containing non-string-literals`() {
     val moduleUri =
       writePklFile(


### PR DESCRIPTION
Needed for `pkl-gen-go` replacement