### PR TITLE
Do not activate power assertions when a single union member containing a type constraint fails

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/EvaluatorImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/EvaluatorImpl.java
@@ -337,10 +337,10 @@ public final class EvaluatorImpl implements Evaluator {
   }
 
   // for use in tests to determine whether an evaluator ever triggered instrumentation
-  boolean wasInstrumentationUsed() {
+  boolean isInstrumentationEverUsed() {
     polyglotContext.enter();
     try {
-      return VmLanguage.get(null).localContext.get().getInstrumentationUsed();
+      return VmLanguage.get(null).localContext.get().isInstrumentationEverUsed();
     } finally {
       polyglotContext.leave();
     }

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
@@ -987,7 +987,7 @@ public abstract class TypeNode extends PklNode {
 
       // disallow power assertions from triggering in case one union member checks successfully
       var localContext = VmLanguage.get(this).localContext.get();
-      boolean wasInTypeTest = localContext.isInTypeTest();
+      var wasInTypeTest = localContext.isInTypeTest();
       localContext.setInTypeTest(true);
 
       // Do eager checks (shallow-force) if there are two listings or two mappings represented.
@@ -1039,7 +1039,7 @@ public abstract class TypeNode extends PklNode {
 
       // disallow power assertions from triggering in case one union member checks successfully
       var localContext = VmLanguage.get(this).localContext.get();
-      boolean wasInTypeTest = localContext.isInTypeTest();
+      var wasInTypeTest = localContext.isInTypeTest();
       localContext.setInTypeTest(true);
 
       for (var i = 0; i < elementTypeNodes.length; i++) {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmLocalContext.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmLocalContext.java
@@ -28,7 +28,7 @@ public class VmLocalContext {
    */
   private int activeTrackerDepth = 0;
 
-  private boolean instrumentationUsed = false;
+  private boolean instrumentationEverUsed = false;
 
   public VmLocalContext() {}
 
@@ -50,7 +50,7 @@ public class VmLocalContext {
 
   public void enterTracker() {
     activeTrackerDepth++;
-    instrumentationUsed = true;
+    instrumentationEverUsed = true;
   }
 
   public void exitTracker() {
@@ -61,7 +61,7 @@ public class VmLocalContext {
     return activeTrackerDepth > 0;
   }
 
-  public boolean getInstrumentationUsed() {
-    return instrumentationUsed;
+  public boolean isInstrumentationEverUsed() {
+    return instrumentationEverUsed;
   }
 }

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorTest.kt
@@ -586,7 +586,7 @@ class EvaluatorTest {
         )
       }
 
-    assertThat((evaluator as EvaluatorImpl).wasInstrumentationUsed()).isTrue
+    assertThat((evaluator as EvaluatorImpl).isInstrumentationEverUsed()).isTrue
   }
 
   @Test
@@ -600,13 +600,13 @@ class EvaluatorTest {
     evaluator.evaluate(
       text(
         """
-    foo: String(startsWith("a")) | String(startsWith("b")) = "boo"
+    foo: String(startsWith("a")) | String(startsWith("b")) | String(startsWith("c")) = "cool"
     """
           .trimIndent()
       )
     )
 
-    assertThat((evaluator as EvaluatorImpl).wasInstrumentationUsed()).isFalse
+    assertThat((evaluator as EvaluatorImpl).isInstrumentationEverUsed()).isFalse
   }
 
   @Test
@@ -626,7 +626,7 @@ class EvaluatorTest {
       )
     )
 
-    assertThat((evaluator as EvaluatorImpl).wasInstrumentationUsed()).isFalse
+    assertThat((evaluator as EvaluatorImpl).isInstrumentationEverUsed()).isFalse
   }
 
   private fun checkModule(module: PModule) {


### PR DESCRIPTION
Prior to this change, this code would activate powers assertions / instrumentation permanently:
```pkl
foo: String(contains("a")) | String(contains("b")) = "boo"
```

This is because the `contains("a")` constraint would fail, triggering power assertions, but the subsequent check of the union's `contains("b")` branch would succeed.
As observed in #1419, once instrumentation is enabled, all subsequent evaluation slows significantly.
As with #1419, the fix here is to disable power assertions via `VmLocalContext` until we know that all union members failed type checking; then, each member is re-executed with power assertions allowed to provide the improved user-facing error.