### PR TITLE
Make the build work on jdk 25

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ clikt = "5.+"
 commonMark = "0.+"
 downloadTaskPlugin = "5.6.0"
 geantyref = "1.+"
-googleJavaFormat = "1.25.2"
+googleJavaFormat = "1.35.0"
 # must not use `+` because used in download URL
 # 23.1.x requires JDK 20+
 graalVm = "25.0.0"


### PR DESCRIPTION
The old version of googleJavaFormat we were using called some deprecated function.