### PR TITLE
fix: resolve intermittent NullPointerException in LetExprNode during concurrent execution

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/binary/LetExprNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/binary/LetExprNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -50,14 +50,10 @@ public final class LetExprNode extends ExpressionNode {
 
   @Override
   public Object executeGeneric(VirtualFrame frame) {
-    if (functionNode == null) {
-      CompilerDirectives.transferToInterpreterAndInvalidate();
-      functionNode = unresolvedFunctionNode.execute(frame);
-      callNode = insert(DirectCallNode.create(functionNode.getCallTarget()));
-      if (isCustomThisScope) {
-        // deferred until execution time s.t. nodes of inlined type aliases get the right frame slot
-        customThisSlot = VmUtils.findCustomThisSlot(frame);
-      }
+    // Usamos callNode como flag de inicialização para garantir que
+    // todos os campos dependentes estejam prontos antes de prosseguir.
+    if (callNode == null) {
+      initialize(frame);
     }
 
     var function =
@@ -71,5 +67,30 @@ public final class LetExprNode extends ExpressionNode {
     var value = valueNode.executeGeneric(frame);
 
     return callNode.call(function.getThisValue(), function, value);
+  }
+
+  /**
+   * Inicializa o nó de chamada e resolve a função de forma thread-safe.
+   */
+  private synchronized void initialize(VirtualFrame frame) {
+    if (callNode != null) {
+      return;
+    }
+
+    CompilerDirectives.transferToInterpreterAndInvalidate();
+    
+    // Resolvemos a função primeiro
+    var resolvedFunction = unresolvedFunctionNode.execute(frame);
+    
+    if (isCustomThisScope) {
+      customThisSlot = VmUtils.findCustomThisSlot(frame);
+    }
+    
+    // Atribuímos functionNode antes do callNode
+    this.functionNode = resolvedFunction;
+    
+    // Inserimos o callNode por último. 
+    // Quando este campo deixar de ser nulo, os outros já estarão visíveis.
+    this.callNode = insert(DirectCallNode.create(resolvedFunction.getCallTarget()));
   }
 }


### PR DESCRIPTION
This PR fixes an intermittent NullPointerException occurring in LetExprNode.java when running Gradle tasks with high parallelism (e.g., :load:configClassesGatherImports).

The root cause was a race condition in the lazy initialization of Truffle nodes. Specifically, the functionNode was being assigned before the callNode was fully initialized and inserted into the AST. In a multi-threaded environment, a second thread could pass the functionNode == null check while callNode was still null, leading to a crash during the .call() invocation.

Changes
Thread-safe Initialization: Added a synchronized block to the initialization logic in LetExprNode.

Atomic Assignment Pattern: Refactored the code to use callNode as the primary initialization flag.

Guaranteed Visibility: Ensured that functionNode and customThisSlot are fully assigned before callNode is inserted, preventing other threads from accessing a partially initialized state.

Fixes #1470 