### PR TITLE
Fix stdlib lockfile

### DIFF
--- a/stdlib/gradle.lockfile
+++ b/stdlib/gradle.lockfile
@@ -1,8 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.2.21=pklFormatter
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.2.21=pklFormatter
-org.jetbrains.kotlin:kotlin-stdlib:2.2.21=pklFormatter
-org.jetbrains:annotations:13.0=pklFormatter
-empty=signatures
+empty=pklFormatter,signatures


### PR DESCRIPTION
Kotlin isn't a dependency of pkl-formatter anymore.