### PR TITLE
Fix import* and read* skipping symlinked files

### DIFF
--- a/docs/modules/release-notes/pages/changelog.adoc
+++ b/docs/modules/release-notes/pages/changelog.adoc
@@ -4,6 +4,11 @@ include::ROOT:partial$component-attributes.adoc[]
 [[release-0.32.0]]
 == 0.32.0 (UNRELEASED)
 
+=== Fixes
+
+* Fix `import*` and `read*` silently skipping symlinked files during glob expansion
+(pr:https://github.com/apple/pkl/pull/1522[]).
+
 [[release-0.31.1]]
 == 0.31.1 (2026-03-26)
 

--- a/pkl-core/src/main/java/org/pkl/core/module/FileResolver.java
+++ b/pkl-core/src/main/java/org/pkl/core/module/FileResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ public final class FileResolver {
     try (var stream = Files.newDirectoryStream(path)) {
       var ret = new ArrayList<PathElement>();
       for (var entry : stream) {
-        // skip symlinks to prevent cyclical globs
-        if (Files.isSymbolicLink(entry)) {
+        // Skip symlinks to directories to prevent cyclical globs.
+        if (Files.isSymbolicLink(entry) && Files.isDirectory(entry)) {
           continue;
         }
         ret.add(new PathElement(entry.getFileName().toString(), Files.isDirectory(entry)));

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/globtest-symlink/linked.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/globtest-symlink/linked.pkl
@@ -1,0 +1,1 @@
+real-target.pkl

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/globtest-symlink/real-target.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/globtest-symlink/real-target.pkl
@@ -1,0 +1,1 @@
+name = "real-target"

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/basic/importGlobSymlink.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/basic/importGlobSymlink.pkl
@@ -1,0 +1,15 @@
+amends ".../snippetTest.pkl"
+
+examples {
+  ["symlink to file is included"] {
+    import*("../../input-helper/globtest-symlink/*.pkl").keys.toListing()
+  }
+
+  ["symlink target content is read through symlink"] {
+    import*("../../input-helper/globtest-symlink/*.pkl")
+      .toMap()
+      .values
+      .map((it) -> it.name)
+      .toListing()
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/basic/importGlobSymlink.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/basic/importGlobSymlink.pcf
@@ -1,0 +1,14 @@
+examples {
+  ["symlink to file is included"] {
+    new {
+      "../../input-helper/globtest-symlink/linked.pkl"
+      "../../input-helper/globtest-symlink/real-target.pkl"
+    }
+  }
+  ["symlink target content is read through symlink"] {
+    new {
+      "real-target"
+      "real-target"
+    }
+  }
+}

--- a/pkl-core/src/test/kotlin/org/pkl/core/module/FileResolverTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/module/FileResolverTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.module
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectory
+import kotlin.io.path.createFile
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.pkl.commons.writeString
+
+class FileResolverTest {
+  @Test
+  fun `includes symlink whose target is a regular file outside the listed directory`(
+    @TempDir tempDir: Path
+  ) {
+    val listedDir = tempDir.resolve("listed").createDirectory()
+    val otherDir = tempDir.resolve("other").createDirectory()
+    listedDir.resolve("real.pkl").createFile().writeString("""name = "real"""")
+    val target = otherDir.resolve("target.pkl").createFile()
+    target.writeString("""name = "target"""")
+    Files.createSymbolicLink(listedDir.resolve("linked.pkl"), target)
+
+    val elements = FileResolver.listElements(listedDir)
+
+    assertThat(elements)
+      .containsExactlyInAnyOrder(PathElement("real.pkl", false), PathElement("linked.pkl", false))
+  }
+
+  @Test
+  fun `skips symlink whose target is a directory to prevent cyclical globs`(
+    @TempDir tempDir: Path
+  ) {
+    val listedDir = tempDir.resolve("listed").createDirectory()
+    val otherDir = tempDir.resolve("other").createDirectory()
+    listedDir.resolve("real.pkl").createFile()
+    Files.createSymbolicLink(listedDir.resolve("linked-dir"), otherDir)
+
+    val elements = FileResolver.listElements(listedDir)
+
+    assertThat(elements).containsExactly(PathElement("real.pkl", false))
+  }
+
+  @Test
+  fun `includes broken symlink as non-directory entry`(@TempDir tempDir: Path) {
+    tempDir.resolve("real.pkl").createFile()
+    Files.createSymbolicLink(tempDir.resolve("broken.pkl"), tempDir.resolve("missing.pkl"))
+
+    val elements = FileResolver.listElements(tempDir)
+
+    assertThat(elements)
+      .containsExactlyInAnyOrder(PathElement("real.pkl", false), PathElement("broken.pkl", false))
+  }
+}


### PR DESCRIPTION
## Problem                                                                                                             
                                                                                                                       
`import*()` and `read*()` glob expansion silently omits symlinked files from results. Regular files matching the same pattern in the same directory are returned, so the partial result is easy to miss. There's also no warning that the glob returned only some matches.                                                                                            
                                                          
## Reproduction
                                                                                                                        
```bash
mkdir -p proj/sources
echo 'name = "real"'   > proj/sources/real.pkl
echo 'name = "target"' > proj/sources/target.pkl
ln -s target.pkl proj/sources/linked.pkl
echo 'result = import*("sources/*.pkl")' > proj/main.pkl
pkl eval proj/main.pkl
# Before: result contains only sources/real.pkl and sources/target.pkl
# After:  result additionally contains sources/linked.pkl                                       
```                                                                                                                    
                                                                                                                       
## Cause                                                                                                               
                                                          
`FileResolver.listElements()` skipped every directory entry that was a symbolic link, with the comment "skip symlinks to prevent cyclical globs". The intent, preventing cycles caused by directory symlinks, was good, but the check was too broad and also excluded symlinks to regular files that don't cause cyclical globs.
                                                          
## Fix
                                                                                                                        
Narrow the skip to symlinks whose target is a directory. Symlinks to regular files are now surfaced as ordinary        `PathElement` entries. Broken symlinks are also surfaced; their failure now shows up as a clear load-time error rather than a silent omission.                                                                                                  
                                                          
`read*()` shares the same `FileResolver.listElements()` code path as `import*()`, so the same change fixes both.       
 
## Tests                                                                                                               
                                                          
- New unit test `FileResolverTest` covering: symlink to a regular file (the bug), symlink to a directory (still        
skipped, invariant preserved), and broken symlink (now surfaced).

- New language snippet test `importGlobSymlink.pkl` exercising the fix end-to-end through `import*()`. Fixture lives in a new `input-helper/globtest-symlink/` directory so existing snippet tests are untouched.
                                                                                                                       
## Future work                                            
                                                                                                                        
Following directory symlinks (with real-path cycle tracking) is intentionally out of scope for this PR. This is the minimal change to stop the silent-drop bug; full shell-glob-style symlink following can be a follow-up.