### PR TITLE
Add dependency submission

### DIFF
--- a/.github/PklProject
+++ b/.github/PklProject
@@ -2,9 +2,9 @@ amends "pkl:Project"
 
 dependencies {
   ["pkl.impl.ghactions"] {
-    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.5.0"
+    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.6.0"
   }
   ["gha"] {
-    uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.2.0"
+    uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.4.0"
   }
 }

--- a/.github/PklProject.deps.json
+++ b/.github/PklProject.deps.json
@@ -3,16 +3,16 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.3.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.4.0",
       "checksums": {
-        "sha256": "fd515da685ea126678c3ec684e84a4f992d43481cc1d75cb866cd55775f675f9"
+        "sha256": "e0b9a9f71071d6101e9d764c069b2ec4a597d5315cb6e4c265b3f0d90c2b482c"
       }
     },
     "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.5.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.6.0",
       "checksums": {
-        "sha256": "2c1e0d9efcd65b3c3207bf535c325ebc0ec2ab169187b324c4bb70821cac0e51"
+        "sha256": "fbc3c456ea468a0fe6baa9b3d30167259ac04e721a41a10fe82d2970026f0b1d"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
@@ -24,16 +24,16 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.0.3",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.0",
       "checksums": {
-        "sha256": "d368900942efb88ed51a98f9614748b06c74ba43423f045fcd6dedb5dbdc0bea"
+        "sha256": "025fac778f2c5f75c8229fa4ec0f49ebdb99a61affe9aae489fefd8fccd92faa"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.1",
       "checksums": {
-        "sha256": "02ef6f25bfca5b1d095db73ea15de79d2d2c6832ebcab61e6aba90554382abcb"
+        "sha256": "0a4fe9b0983716ec49fb060b9e5e83f8c365eb899d517123b43134416a9574b6"
       }
     }
   }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
 - package-ecosystem: github-actions
+  cooldown:
+    default-days: 7
   directory: /
   ignore:
   - dependency-name: '*'

--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -22,6 +22,8 @@ testReports {
   excludeJobs {
     "bench"
     "github-release"
+    "dependency-submission"
+    "dependency-review"
     Regex("deploy-.*")
   }
 }
@@ -114,6 +116,23 @@ local releaseJobs: PklJobs = new {
   ...buildNativeReleases
 }
 
+local dependencySubmission: Workflow.Job = new {
+  `runs-on` = "ubuntu-latest"
+  permissions {
+    contents = "write"
+  }
+  steps {
+    module.catalog.`actions/checkout@v6`
+    (module.catalog.`actions/setup-java@v5`) {
+      with {
+        `java-version` = "25"
+        distribution = "temurin"
+      }
+    }
+    module.catalog.`gradle/actions/dependency-submission@v6`
+  }
+}
+
 // By default, just run ./gradlew check on linux.
 // Trigger other checks based on GitHub PR description. Examples:
 //
@@ -153,7 +172,16 @@ prb {
       nightlyMacOS = false
     }
   }
-  jobs = prbJobs2 |> toWorkflowJobs
+  jobs = (prbJobs2 |> toWorkflowJobs) {
+    ["dependency-review"] {
+      `runs-on` = "ubuntu-latest"
+      steps {
+        module.catalog.`actions/checkout@v6`
+        module.catalog.`actions/dependency-review-action@v4`
+      }
+    }
+    ["dependency-submission"] = dependencySubmission
+  }
 }
 
 build {
@@ -161,7 +189,7 @@ build {
 }
 
 main {
-  jobs =
+  local _jobs =
     (buildAndTestJobs) {
       ["deploy-snapshot"] = (
         new DeployJob {
@@ -174,6 +202,10 @@ main {
         needs = buildAndTestJobs.keys.toListing()
       }
     } |> toWorkflowJobs
+
+  jobs = (_jobs) {
+    ["dependency-submission"] = dependencySubmission
+  }
 }
 
 releaseBranch {

--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -116,23 +116,6 @@ local releaseJobs: PklJobs = new {
   ...buildNativeReleases
 }
 
-local dependencySubmission: Workflow.Job = new {
-  `runs-on` = "ubuntu-latest"
-  permissions {
-    contents = "write"
-  }
-  steps {
-    module.catalog.`actions/checkout@v6`
-    (module.catalog.`actions/setup-java@v5`) {
-      with {
-        `java-version` = "25"
-        distribution = "temurin"
-      }
-    }
-    module.catalog.`gradle/actions/dependency-submission@v6`
-  }
-}
-
 // By default, just run ./gradlew check on linux.
 // Trigger other checks based on GitHub PR description. Examples:
 //
@@ -172,16 +155,7 @@ prb {
       nightlyMacOS = false
     }
   }
-  jobs = (prbJobs2 |> toWorkflowJobs) {
-    ["dependency-review"] {
-      `runs-on` = "ubuntu-latest"
-      steps {
-        module.catalog.`actions/checkout@v6`
-        module.catalog.`actions/dependency-review-action@v4`
-      }
-    }
-    ["dependency-submission"] = dependencySubmission
-  }
+  jobs = prbJobs2 |> toWorkflowJobs
 }
 
 build {
@@ -204,7 +178,22 @@ main {
     } |> toWorkflowJobs
 
   jobs = (_jobs) {
-    ["dependency-submission"] = dependencySubmission
+    ["dependency-submission"] {
+      `runs-on` = "ubuntu-latest"
+      permissions {
+        contents = "write"
+      }
+      steps {
+        module.catalog.`actions/checkout@v6`
+        (module.catalog.`actions/setup-java@v5`) {
+          with {
+            `java-version` = "25"
+            distribution = "temurin"
+          }
+        }
+        module.catalog.`gradle/actions/dependency-submission@v6`
+      }
+    }
   }
 }
 

--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -42,11 +42,15 @@ local gradleCheckWindows = (baseGradleCheck) {
   os = "windows"
 }
 
-local typealias PklJobs = Mapping<String, PklJob>
+local typealias PklJobs = Mapping<String, PklJob | *Workflow.Job>
 
 local toWorkflowJobs: (PklJobs) -> Workflow.Jobs = (it) -> new Workflow.Jobs {
   for (k, v in it) {
-    [k] = v.job
+    when (v is PklJob) {
+      [k] = v.job
+    } else {
+      [k] = v
+    }
   }
 }
 
@@ -163,7 +167,7 @@ build {
 }
 
 main {
-  local _jobs =
+  jobs =
     (buildAndTestJobs) {
       ["deploy-snapshot"] = (
         new DeployJob {
@@ -175,26 +179,23 @@ main {
       ) {
         needs = buildAndTestJobs.keys.toListing()
       }
-    } |> toWorkflowJobs
-
-  jobs = (_jobs) {
-    ["dependency-submission"] {
-      `runs-on` = "ubuntu-latest"
-      permissions {
-        contents = "write"
-      }
-      steps {
-        module.catalog.`actions/checkout@v6`
-        (module.catalog.`actions/setup-java@v5`) {
-          with {
-            `java-version` = "25"
-            distribution = "temurin"
-          }
+      ["dependency-submission"] {
+        `runs-on` = "ubuntu-latest"
+        permissions {
+          contents = "write"
         }
-        module.catalog.`gradle/actions/dependency-submission@v6`
+        steps {
+          module.catalog.`actions/checkout@v6`
+          (module.catalog.`actions/setup-java@v5`) {
+            with {
+              `java-version` = "25"
+              distribution = "temurin"
+            }
+          }
+          module.catalog.`gradle/actions/dependency-submission@v6`
+        }
       }
-    }
-  }
+    } |> toWorkflowJobs
 }
 
 releaseBranch {

--- a/.github/jobs/BuildNativeJob.pkl
+++ b/.github/jobs/BuildNativeJob.pkl
@@ -23,7 +23,8 @@ preSteps {
   when (os == "linux" && !musl) {
     new {
       name = "Install deps"
-      run = "dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en"
+      run =
+        "dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en"
     }
   }
 }

--- a/.github/workflows/__lockfile__.yml
+++ b/.github/workflows/__lockfile__.yml
@@ -22,8 +22,6 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: actions/create-github-app-token@v2
       uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-    - name: actions/dependency-review-action@v4
-      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
     - name: actions/download-artifact@v6
       uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
     - name: actions/setup-java@v5

--- a/.github/workflows/__lockfile__.yml
+++ b/.github/workflows/__lockfile__.yml
@@ -22,6 +22,8 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: actions/create-github-app-token@v2
       uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+    - name: actions/dependency-review-action@v4
+      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
     - name: actions/download-artifact@v6
       uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
     - name: actions/setup-java@v5
@@ -30,5 +32,7 @@ jobs:
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     - name: dawidd6/action-download-artifact@v11
       uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
+    - name: gradle/actions/dependency-submission@v6
+      uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
     - name: gradle/actions/setup-gradle@v5
       uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -831,6 +831,20 @@ jobs:
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
       run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true --no-parallel publishToSonatype
+  dependency-submission:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      with:
+        java-version: '25'
+        distribution: temurin
+    - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+      with: {}
   publish-test-results:
     if: '!cancelled()'
     needs:
@@ -891,6 +905,7 @@ jobs:
     - pkl-doc-alpine-linux-amd64-snapshot
     - pkl-doc-windows-amd64-snapshot
     - deploy-snapshot
+    - dependency-submission
     - publish-test-results
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -712,6 +712,27 @@ jobs:
         name: test-results-html-pkl-doc-windows-amd64-snapshot
         path: '**/build/reports/tests/**/*'
         if-no-files-found: ignore
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+  dependency-submission:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      with:
+        java-version: '25'
+        distribution: temurin
+    - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+      with: {}
   upload-event-file:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -712,27 +712,6 @@ jobs:
         name: test-results-html-pkl-doc-windows-amd64-snapshot
         path: '**/build/reports/tests/**/*'
         if-no-files-found: ignore
-  dependency-review:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        persist-credentials: false
-    - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
-  dependency-submission:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        persist-credentials: false
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-      with:
-        java-version: '25'
-        distribution: temurin
-    - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
-      with: {}
   upload-event-file:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This adds jobs to add Gradle dependencies to [GitHub's dependency submission API](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/using-the-dependency-submission-api), and to review when these dependencies change.