### PR TITLE
Only include *runtimeClasspath and *compileClasspath dependencies

### DIFF
--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -192,7 +192,13 @@ main {
               distribution = "temurin"
             }
           }
-          module.catalog.`gradle/actions/dependency-submission@v6`
+          (module.catalog.`gradle/actions/dependency-submission@v6`) {
+            with {
+              // language=regexp
+              `dependency-graph-include-configurations` =
+                ".*[rR]untimeClasspath|.*[cC]ompileClasspath"
+            }
+          }
         }
       }
     } |> toWorkflowJobs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -844,7 +844,8 @@ jobs:
         java-version: '25'
         distribution: temurin
     - uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
-      with: {}
+      with:
+        dependency-graph-include-configurations: .*[rR]untimeClasspath|.*[cC]ompileClasspath
   publish-test-results:
     if: '!cancelled()'
     needs:


### PR DESCRIPTION
The dependencies submitted is too noisy; for example, it includes Gradle build environment dependencies.

This configures the action to only submit dependencies that are either runtime or compile time dependencies (including test configurations).