### PR TITLE
Remove Config.makeConfig

### DIFF
--- a/docs/modules/release-notes/pages/0.32.adoc
+++ b/docs/modules/release-notes/pages/0.32.adoc
@@ -31,6 +31,12 @@ XXX
 
 Things to watch out for when upgrading.
 
+=== Removed Java APIs
+
+The following APIs have been removed without replacement.
+
+* `org.pkl.config.java.Config#makeConfig` (pr:https://github.com/apple/pkl/pull/1531[])
+
 .XXX
 [%collapsible]
 ====

--- a/pkl-config-java/src/main/java/org/pkl/config/java/Config.java
+++ b/pkl-config-java/src/main/java/org/pkl/config/java/Config.java
@@ -19,7 +19,6 @@ import static org.pkl.config.java.ConfigUtils.makeConfig;
 
 import java.io.InputStream;
 import java.lang.reflect.Type;
-import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import org.pkl.config.java.mapper.ConversionException;
 import org.pkl.config.java.mapper.ValueMapper;

--- a/pkl-config-java/src/main/java/org/pkl/config/java/Config.java
+++ b/pkl-config-java/src/main/java/org/pkl/config/java/Config.java
@@ -15,7 +15,7 @@
  */
 package org.pkl.config.java;
 
-import static org.pkl.config.java.Utils.makeConfig;
+import static org.pkl.config.java.ConfigUtils.makeConfig;
 
 import java.io.InputStream;
 import java.lang.reflect.Type;

--- a/pkl-config-java/src/main/java/org/pkl/config/java/Config.java
+++ b/pkl-config-java/src/main/java/org/pkl/config/java/Config.java
@@ -15,13 +15,14 @@
  */
 package org.pkl.config.java;
 
+import static org.pkl.config.java.Utils.makeConfig;
+
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import org.pkl.config.java.mapper.ConversionException;
 import org.pkl.config.java.mapper.ValueMapper;
-import org.pkl.core.Composite;
 import org.pkl.core.Evaluator;
 import org.pkl.core.PklBinaryDecoder;
 
@@ -30,6 +31,7 @@ import org.pkl.core.PklBinaryDecoder;
  * using {@link #get(String)}. To consume the node's composite or scalar value, convert the value to
  * the desired Java type, using one of the provided {@link #as} methods.
  */
+@SuppressWarnings("unused")
 public interface Config {
   /**
    * The dot-separated name of this node. For example, the node reached using {@code
@@ -109,15 +111,5 @@ public interface Config {
    */
   static Config fromPklBinary(InputStream inputStream) {
     return fromPklBinary(inputStream, ValueMapper.preconfigured());
-  }
-
-  static Config makeConfig(Object decoded, ValueMapper mapper) {
-    if (decoded instanceof Composite composite) {
-      return new CompositeConfig("", mapper, composite);
-    }
-    if (decoded instanceof Map<?, ?> map) {
-      return new MapConfig("", mapper, map);
-    }
-    return new LeafConfig("", mapper, decoded);
   }
 }

--- a/pkl-config-java/src/main/java/org/pkl/config/java/ConfigEvaluatorImpl.java
+++ b/pkl-config-java/src/main/java/org/pkl/config/java/ConfigEvaluatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.pkl.config.java;
+
+import static org.pkl.config.java.Utils.makeConfig;
 
 import org.pkl.config.java.mapper.ValueMapper;
 import org.pkl.core.Evaluator;
@@ -37,13 +39,13 @@ final class ConfigEvaluatorImpl implements ConfigEvaluator {
   @Override
   public Config evaluateOutputValue(ModuleSource moduleSource) {
     var value = evaluator.evaluateOutputValue(moduleSource);
-    return Config.makeConfig(value, mapper);
+    return makeConfig(value, mapper);
   }
 
   @Override
   public Config evaluateExpression(ModuleSource moduleSource, String expression) {
     var value = evaluator.evaluateExpression(moduleSource, expression);
-    return Config.makeConfig(value, mapper);
+    return makeConfig(value, mapper);
   }
 
   @Override

--- a/pkl-config-java/src/main/java/org/pkl/config/java/ConfigEvaluatorImpl.java
+++ b/pkl-config-java/src/main/java/org/pkl/config/java/ConfigEvaluatorImpl.java
@@ -15,7 +15,7 @@
  */
 package org.pkl.config.java;
 
-import static org.pkl.config.java.Utils.makeConfig;
+import static org.pkl.config.java.ConfigUtils.makeConfig;
 
 import org.pkl.config.java.mapper.ValueMapper;
 import org.pkl.core.Evaluator;

--- a/pkl-config-java/src/main/java/org/pkl/config/java/ConfigUtils.java
+++ b/pkl-config-java/src/main/java/org/pkl/config/java/ConfigUtils.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import org.pkl.config.java.mapper.ValueMapper;
 import org.pkl.core.Composite;
 
-class Utils {
-  private Utils() {}
+class ConfigUtils {
+  private ConfigUtils() {}
 
   static Config makeConfig(Object decoded, ValueMapper mapper) {
     if (decoded instanceof Composite composite) {

--- a/pkl-config-java/src/main/java/org/pkl/config/java/Utils.java
+++ b/pkl-config-java/src/main/java/org/pkl/config/java/Utils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.config.java;
+
+import java.util.Map;
+import org.pkl.config.java.mapper.ValueMapper;
+import org.pkl.core.Composite;
+
+class Utils {
+  private Utils() {}
+
+  static Config makeConfig(Object decoded, ValueMapper mapper) {
+    if (decoded instanceof Composite composite) {
+      return new CompositeConfig("", mapper, composite);
+    }
+    if (decoded instanceof Map<?, ?> map) {
+      return new MapConfig("", mapper, map);
+    }
+    return new LeafConfig("", mapper, decoded);
+  }
+}


### PR DESCRIPTION
This doesn't really make sense as part of the `Config` API.

We can maybe make class `Utils` public, but, I don't know how useful it is anyways; it's more of an implementation detail.