### PR TITLE
Fix dependency scopes

### DIFF
--- a/pkl-codegen-java/pkl-codegen-java.gradle.kts
+++ b/pkl-codegen-java/pkl-codegen-java.gradle.kts
@@ -21,11 +21,11 @@ plugins {
 }
 
 dependencies {
-  // CliJavaCodeGeneratorOptions exposes CliBaseOptions
+  // CliJavaCodeGeneratorOptions exposes pkl-commons-cli and pkl-base
   api(projects.pklCommonsCli)
+  api(projects.pklCore)
 
   implementation(projects.pklCommons)
-  implementation(projects.pklCore)
   implementation(libs.javaPoet)
 
   testImplementation(projects.pklConfigJava)

--- a/pkl-config-kotlin/pkl-config-kotlin.gradle.kts
+++ b/pkl-config-kotlin/pkl-config-kotlin.gradle.kts
@@ -101,7 +101,7 @@ publishing {
             appendNode("groupId", "org.pkl-lang")
             appendNode("artifactId", "pkl-config-java-all")
             appendNode("version", project.version)
-            appendNode("scope", "runtime")
+            appendNode("scope", "compile")
           }
         }
       }

--- a/pkl-doc/pkl-doc.gradle.kts
+++ b/pkl-doc/pkl-doc.gradle.kts
@@ -33,8 +33,10 @@ executable {
 }
 
 dependencies {
-  implementation(projects.pklCore)
-  implementation(projects.pklCommonsCli)
+  // CliDocGeneratorOptions exposes pkl-commons-cli and pkl-base
+  api(projects.pklCore)
+  api(projects.pklCommonsCli)
+
   implementation(projects.pklCommons)
   implementation(projects.pklParser)
   implementation(libs.commonMark)


### PR DESCRIPTION
Fixes the following pom.xml issues:

1. pkl-doc and pkl-codegen-java sets the wrong dependency scopes for pkl-commons-cli/pkl-base
2. pkl-config-kotlin sets the wrong dependency scope for pkl-config-java-all

Closes #1293
Closes #1517