### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
 - package-ecosystem: gradle
   cooldown:
     default-days: 7
+  directory: /
   schedule:
     interval: weekly
 - package-ecosystem: github-actions

--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -235,6 +235,7 @@ dependabot {
       cooldown {
         `default-days` = 7
       }
+      directory = "/"
     }
   }
 }


### PR DESCRIPTION
Looks like `directory` is a required property; we should also fix our schema but that's orthogonal to this actual fix.