### PR TITLE
Added `pkg` module key factory and resource reader to project loading

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/project/Project.java
+++ b/pkl-core/src/main/java/org/pkl/core/project/Project.java
@@ -89,8 +89,10 @@ public final class Project {
             .setStackFrameTransformer(stackFrameTransformer)
             .addModuleKeyFactory(ModuleKeyFactories.standardLibrary)
             .addModuleKeyFactory(ModuleKeyFactories.file)
+            .addModuleKeyFactory(ModuleKeyFactories.pkg)
             .addResourceReader(ResourceReaders.environmentVariable())
             .addResourceReader(ResourceReaders.file())
+            .addResourceReader(ResourceReaders.pkg())
             .addEnvironmentVariables(envVars)
             .setTimeout(timeout)
             .setPowerAssertionsEnabled(powerAssertionsEnabled)
@@ -238,9 +240,11 @@ public final class Project {
         .setStackFrameTransformer(StackFrameTransformers.defaultTransformer)
         .addModuleKeyFactory(ModuleKeyFactories.standardLibrary)
         .addModuleKeyFactory(ModuleKeyFactories.file)
+        .addModuleKeyFactory(ModuleKeyFactories.pkg)
         .addModuleKeyFactory(ModuleKeyFactories.classPath(Project.class.getClassLoader()))
         .addResourceReader(ResourceReaders.environmentVariable())
-        .addResourceReader(ResourceReaders.file());
+        .addResourceReader(ResourceReaders.file())
+        .addResourceReader(ResourceReaders.pkg());
   }
 
   private static DeclaredDependencies parseDependencies(


### PR DESCRIPTION
This change allows `PklProject` files, usually loaded via the `Project` static methods, to have references to external packages via `package://` URIs.

This is helpful for centralizing and sharing common package configuration via packages.

I don't think there is an infrastructure in tests to test `package:` URIs since they require HTTP calls, and this PR doesn't seem like a good place to add it, but if you think it would make sense to do it, I can try to come up with something.