### PR TITLE
Add custom CodeQL query to prevent project evaluator misuse in the CLI

### DIFF
--- a/.github/codeql-queries/cli-project-evaluator-settings.ql
+++ b/.github/codeql-queries/cli-project-evaluator-settings.ql
@@ -1,0 +1,17 @@
+import java
+
+from MethodCall mc, Field f, Method m
+where
+  // find all calls to Project.getEvaluatorSettings in CliCommand
+  mc.getCompilationUnit().getFile().getBaseName() = "CliCommand.kt" and
+  mc.getMethod().getName() = "getEvaluatorSettings" and
+  mc.getMethod().getDeclaringType().getName() = "Project" and
+
+  // find CliCommand.evaluatorSettings field delegate
+  f.getFile().getBaseName() = "CliCommand.kt" and
+  f.getName() = "evaluatorSettings$delegate" and
+
+  // exclude the allowed call in CliCommand.evaluatorSettings
+  m = f.getInitializer().(MethodCall).getArgument(0).(LambdaExpr).getAnonymousClass().getAMember() and
+  m != mc.getCaller()
+select mc, "CliCommand must access project evaluator settings via this.evaluatorSettings, not via this.project"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,7 @@ jobs:
       with:
         languages: java-kotlin
         build-mode: autobuild
+        queries: +./.github/codeql-queries/cli-project-evaluator-settings.ql
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -166,7 +166,7 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
   }
 
   protected val externalProperties: Map<String, String> by lazy {
-    cliOptions.externalProperties ?: evaluatorSettings?.externalProperties ?: emptyMap()
+    cliOptions.externalProperties ?: project?.evaluatorSettings?.externalProperties ?: emptyMap()
   }
 
   protected val moduleCacheDir: Path? by lazy {


### PR DESCRIPTION
Catches the issue originally fixed by #1459 