### PR TITLE
Only set `--stacktrace --info` if verbose logging is enabled

### DIFF
--- a/.github/jobs/GradleJob.pkl
+++ b/.github/jobs/GradleJob.pkl
@@ -29,8 +29,7 @@ fetchDepth: Int?
 
 fixed gradleArgs =
   new Listing {
-    "--info"
-    "--stacktrace"
+    "$DEBUG_ARGS"
     "--no-daemon"
     "-DpklMultiJdkTesting=true"
     when (isRelease) {
@@ -45,6 +44,9 @@ fixed job {
     when (os == "windows") {
       ["JAVA_HOME"] = "/jdk"
     }
+    ["DEBUG_ARGS"] =
+    // language=GithubExpressionLanguage
+      "${{ case(runner.debug == '1', '--info --stacktrace', '') }}"
   }
   when (os == "macOS") {
     `if` =

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -32,7 +33,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -51,6 +52,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -65,7 +67,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -83,6 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -96,11 +99,12 @@ jobs:
       with: {}
     - name: bench:jmh
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true bench:jmh
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true bench:jmh
   gradle-compatibility:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -115,7 +119,7 @@ jobs:
       with: {}
     - name: :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -133,6 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -150,7 +155,7 @@ jobs:
         persist-credentials: false
     - name: gradle build java executables
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:build pkl-cli:build pkl-codegen-java:build pkl-codegen-kotlin:build
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:build pkl-cli:build pkl-codegen-java:build pkl-codegen-kotlin:build
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -176,6 +181,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -189,7 +195,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -212,6 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -229,7 +236,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -257,6 +264,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -270,7 +278,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -293,6 +301,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -310,7 +319,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -335,6 +344,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -421,7 +431,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -445,6 +455,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -458,7 +469,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -484,6 +495,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -497,7 +509,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -520,6 +532,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -537,7 +550,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -565,6 +578,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -578,7 +592,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -601,6 +615,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -618,7 +633,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -643,6 +658,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -729,7 +745,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -753,6 +769,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -766,7 +783,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -30,7 +31,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -49,6 +50,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -63,7 +65,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -81,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -94,11 +97,12 @@ jobs:
       with: {}
     - name: bench:jmh
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true bench:jmh
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true bench:jmh
   gradle-compatibility:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -113,7 +117,7 @@ jobs:
       with: {}
     - name: :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -131,6 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -148,7 +153,7 @@ jobs:
         persist-credentials: false
     - name: gradle build java executables
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:build pkl-cli:build pkl-codegen-java:build pkl-codegen-kotlin:build
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:build pkl-cli:build pkl-codegen-java:build pkl-codegen-kotlin:build
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -174,6 +179,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -187,7 +193,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -210,6 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -227,7 +234,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -255,6 +262,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -268,7 +276,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -291,6 +299,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -308,7 +317,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -333,6 +342,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -419,7 +429,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -443,6 +453,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -456,7 +467,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -482,6 +493,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -495,7 +507,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -518,6 +530,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -535,7 +548,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -563,6 +576,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -576,7 +590,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -599,6 +613,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -616,7 +631,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -641,6 +656,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -727,7 +743,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -751,6 +767,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -764,7 +781,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -805,6 +822,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     environment: maven-release
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -830,7 +848,7 @@ jobs:
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true --no-parallel publishToSonatype
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true --no-parallel publishToSonatype
   dependency-submission:
     permissions:
       contents: write

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -26,7 +27,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -47,6 +48,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -61,7 +63,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -83,6 +85,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -96,7 +99,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -121,6 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -138,7 +142,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -167,6 +171,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -180,7 +185,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -205,6 +210,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -222,7 +228,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -249,6 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -335,7 +342,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -361,6 +368,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -374,7 +382,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -401,6 +409,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -414,7 +423,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -439,6 +448,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -456,7 +466,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -485,6 +495,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -498,7 +509,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -523,6 +534,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -540,7 +552,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -567,6 +579,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -653,7 +666,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -679,6 +692,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -692,7 +706,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -30,7 +31,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -49,6 +50,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -63,7 +65,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -81,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -94,11 +97,12 @@ jobs:
       with: {}
     - name: bench:jmh
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true bench:jmh
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true bench:jmh
   gradle-compatibility:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -113,7 +117,7 @@ jobs:
       with: {}
     - name: :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -131,6 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -148,7 +153,7 @@ jobs:
         persist-credentials: false
     - name: gradle build java executables
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:build pkl-cli:build pkl-codegen-java:build pkl-codegen-kotlin:build
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:build pkl-cli:build pkl-codegen-java:build pkl-codegen-kotlin:build
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -174,6 +179,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -187,7 +193,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -210,6 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -227,7 +234,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -255,6 +262,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -268,7 +276,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -291,6 +299,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -308,7 +317,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -333,6 +342,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -419,7 +429,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -443,6 +453,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -456,7 +467,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -482,6 +493,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -495,7 +507,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -518,6 +530,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -535,7 +548,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -563,6 +576,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -576,7 +590,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -599,6 +613,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -616,7 +631,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -641,6 +656,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -727,7 +743,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -Dpkl.musl=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -751,6 +767,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -764,7 +781,7 @@ jobs:
       with: {}
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -30,7 +31,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -49,6 +50,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -63,7 +65,7 @@ jobs:
       with: {}
     - name: check
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true check
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true check
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -81,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -94,11 +97,12 @@ jobs:
       with: {}
     - name: bench:jmh
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true bench:jmh
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true bench:jmh
   gradle-compatibility:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -113,7 +117,7 @@ jobs:
       with: {}
     - name: :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true :pkl-gradle:build :pkl-gradle:compatibilityTestReleases
     - name: Upload Test Result XML
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -131,6 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -149,7 +154,7 @@ jobs:
         persist-credentials: false
     - name: gradle build java executables
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:build pkl-cli:build pkl-codegen-java:build pkl-codegen-kotlin:build
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:build pkl-cli:build pkl-codegen-java:build pkl-codegen-kotlin:build
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -175,6 +180,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -189,7 +195,7 @@ jobs:
         cache-disabled: true
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -212,6 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -230,7 +237,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -258,6 +265,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -272,7 +280,7 @@ jobs:
         cache-disabled: true
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -295,6 +303,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -313,7 +322,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -338,6 +347,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -425,7 +435,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.musl=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.musl=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -449,6 +459,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -463,7 +474,7 @@ jobs:
         cache-disabled: true
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-cli:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -489,6 +500,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -503,7 +515,7 @@ jobs:
         cache-disabled: true
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.targetArch=amd64 "-Dpkl.native--native-compiler-path=${GITHUB_WORKSPACE}/.github/scripts/cc_macos_amd64.sh" pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -526,6 +538,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -544,7 +557,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -572,6 +585,7 @@ jobs:
     - macos
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -586,7 +600,7 @@ jobs:
         cache-disabled: true
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -609,6 +623,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - name: Install deps
       run: dnf install -y git binutils gcc glibc-devel zlib-devel libstdc++-static glibc-langpack-en
@@ -627,7 +642,7 @@ jobs:
       run: git status || git config --system --add safe.directory "$GITHUB_WORKSPACE"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -652,6 +667,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -739,7 +755,7 @@ jobs:
         echo "${HOME}/staticdeps/bin" >> "$GITHUB_PATH"
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.musl=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true -Dpkl.musl=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -763,6 +779,7 @@ jobs:
     env:
       LANG: en_US.UTF-8
       JAVA_HOME: /jdk
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -777,7 +794,7 @@ jobs:
         cache-disabled: true
     - name: gradle buildNative
       shell: bash
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true pkl-doc:buildNative
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
@@ -818,6 +835,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LANG: en_US.UTF-8
+      DEBUG_ARGS: ${{ case(runner.debug == '1', '--info --stacktrace', '') }}
     environment: maven-release
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -844,7 +862,7 @@ jobs:
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
-      run: ./gradlew --info --stacktrace --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true publishToSonatype closeAndReleaseSonatypeStagingRepository
+      run: ./gradlew $DEBUG_ARGS --no-daemon -DpklMultiJdkTesting=true -DreleaseBuild=true publishToSonatype closeAndReleaseSonatypeStagingRepository
   github-release:
     needs: deploy-release
     permissions:


### PR DESCRIPTION
This is a quality-of-life improvement; make our build logs more easy to read through for the default case.

If we need more information, we can click on the "Enable debug logging" checkbox when re-running a job, which then populates the `runner.debug` context variable.