### PR TITLE
Reformat Kotlin code

### DIFF
--- a/docs/src/test/kotlin/DocSnippetTests.kt
+++ b/docs/src/test/kotlin/DocSnippetTests.kt
@@ -1,3 +1,22 @@
+/*
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Files
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.useDirectoryEntries
 import org.junit.platform.commons.annotation.Testable
 import org.junit.platform.engine.*
 import org.junit.platform.engine.TestDescriptor.Type
@@ -16,23 +35,18 @@ import org.pkl.core.Loggers
 import org.pkl.core.SecurityManagers
 import org.pkl.core.StackFrameTransformers
 import org.pkl.core.evaluatorSettings.TraceMode
+import org.pkl.core.http.HttpClient
 import org.pkl.core.module.ModuleKeyFactories
 import org.pkl.core.repl.ReplRequest
 import org.pkl.core.repl.ReplResponse
 import org.pkl.core.repl.ReplServer
+import org.pkl.core.resource.ResourceReaders
 import org.pkl.core.util.IoUtils
-import org.pkl.core.http.HttpClient
 import org.pkl.parser.Parser
 import org.pkl.parser.ParserError
 import org.pkl.parser.syntax.ClassProperty
-import org.pkl.core.resource.ResourceReaders
-import java.nio.file.Files
-import kotlin.io.path.isDirectory
-import kotlin.io.path.isRegularFile
-import kotlin.io.path.useDirectoryEntries
 
-@Testable
-class DocSnippetTests
+@Testable class DocSnippetTests
 
 class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.ExecutionContext>() {
   private val projectDir = rootProjectDir.resolve("docs")
@@ -41,7 +55,8 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
   private companion object {
     val headingRegex = Regex("""(?u)^\s*(=++)\s*(.+)""")
     val collapsibleBlockRegex = Regex("""(?u)^\s*\[%collapsible""")
-    val codeBlockRegex = Regex("""(?u)^\s*\[source(?:%(tested|parsed)(%error)?)?(?:,\{?([a-zA-Z-_]+)}?)?""")
+    val codeBlockRegex =
+      Regex("""(?u)^\s*\[source(?:%(tested|parsed)(%error)?)?(?:,\{?([a-zA-Z-_]+)}?)?""")
     val codeBlockNameRegex = Regex("""(?u)^\s*\.(.+)""")
     val codeBlockDelimiterRegex = Regex("""(?u)^\s*----""")
     val graphicsRegex = Regex("\\[small]#.+#")
@@ -51,7 +66,7 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
 
   override fun discover(
     discoveryRequest: EngineDiscoveryRequest,
-    uniqueId: UniqueId
+    uniqueId: UniqueId,
   ): TestDescriptor {
     val packageSelectors = discoveryRequest.getSelectorsByType(PackageSelector::class.java)
     val classSelectors = discoveryRequest.getSelectorsByType(ClassSelector::class.java)
@@ -62,12 +77,14 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
     val packageName = testClass.`package`.name
     val className = testClass.name
 
-    if (methodSelectors.isEmpty()
-      && (packageSelectors.isEmpty() || packageSelectors.any { it.packageName == packageName })
-      && (classSelectors.isEmpty() || classSelectors.any { it.className == className })
+    if (
+      methodSelectors.isEmpty() &&
+        (packageSelectors.isEmpty() || packageSelectors.any { it.packageName == packageName }) &&
+        (classSelectors.isEmpty() || classSelectors.any { it.className == className })
     ) {
 
-      val rootDescriptor = Descriptor.Path(uniqueId, docsDir.fileName.toString(), ClassSource.from(testClass), docsDir)
+      val rootDescriptor =
+        Descriptor.Path(uniqueId, docsDir.fileName.toString(), ClassSource.from(testClass), docsDir)
       doDiscover(rootDescriptor, uniqueIdSelectors)
       return rootDescriptor
     }
@@ -77,36 +94,34 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
   }
 
   override fun createExecutionContext(request: ExecutionRequest): ExecutionContext {
-    val replServer = ReplServer(
-      SecurityManagers.defaultManager,
-      HttpClient.dummyClient(),
-      Loggers.stdErr(),
-      listOf(
-        ModuleKeyFactories.standardLibrary,
-        ModuleKeyFactories.classPath(DocSnippetTests::class.java.classLoader),
-        ModuleKeyFactories.file
-      ),
-      listOf(
-        ResourceReaders.environmentVariable(),
-        ResourceReaders.externalProperty()
-      ),
-      System.getenv(),
-      emptyMap(),
-      null,
-      null,
-      null,
-      IoUtils.getCurrentWorkingDir(),
-      StackFrameTransformers.defaultTransformer,
-      false,
-      TraceMode.COMPACT,
-    )
+    val replServer =
+      ReplServer(
+        SecurityManagers.defaultManager,
+        HttpClient.dummyClient(),
+        Loggers.stdErr(),
+        listOf(
+          ModuleKeyFactories.standardLibrary,
+          ModuleKeyFactories.classPath(DocSnippetTests::class.java.classLoader),
+          ModuleKeyFactories.file,
+        ),
+        listOf(ResourceReaders.environmentVariable(), ResourceReaders.externalProperty()),
+        System.getenv(),
+        emptyMap(),
+        null,
+        null,
+        null,
+        IoUtils.getCurrentWorkingDir(),
+        StackFrameTransformers.defaultTransformer,
+        false,
+        TraceMode.COMPACT,
+      )
     return ExecutionContext(replServer)
   }
 
   private fun doDiscover(rootDescriptor: TestDescriptor, selectors: List<UniqueIdSelector>) {
-    fun isMatch(other: UniqueId) = selectors.isEmpty() || selectors.any {
-      it.uniqueId.hasPrefix(other) || other.hasPrefix(it.uniqueId)
-    }
+    fun isMatch(other: UniqueId) =
+      selectors.isEmpty() ||
+        selectors.any { it.uniqueId.hasPrefix(other) || other.hasPrefix(it.uniqueId) }
 
     docsDir.useDirectoryEntries { docsDirEntries ->
       for (docsDirEntry in docsDirEntries) {
@@ -116,12 +131,13 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
         val docsDirEntryId = rootDescriptor.uniqueId.append("dir", docsDirEntryName)
         if (!isMatch(docsDirEntryId)) continue
 
-        val docsDirEntryDescriptor = Descriptor.Path(
-          docsDirEntryId,
-          docsDirEntryName,
-          DirectorySource.from(docsDirEntry.toFile()),
-          docsDirEntry
-        )
+        val docsDirEntryDescriptor =
+          Descriptor.Path(
+            docsDirEntryId,
+            docsDirEntryName,
+            DirectorySource.from(docsDirEntry.toFile()),
+            docsDirEntry,
+          )
         rootDescriptor.addChild(docsDirEntryDescriptor)
 
         val pagesDir = docsDirEntry.resolve("pages")
@@ -131,17 +147,20 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
           for (pagesDirEntry in pagesDirEntries) {
             val pagesDirEntryName = pagesDirEntry.fileName.toString()
             val pagesDirEntryId = docsDirEntryId.append("file", pagesDirEntryName)
-            if (!pagesDirEntry.isRegularFile() ||
-              !pagesDirEntryName.endsWith(".adoc") ||
-              !isMatch(pagesDirEntryId)
-            ) continue
-
-            val pagesDirEntryDescriptor = Descriptor.Path(
-              pagesDirEntryId,
-              pagesDirEntryName,
-              FileSource.from(pagesDirEntry.toFile()),
-              pagesDirEntry
+            if (
+              !pagesDirEntry.isRegularFile() ||
+                !pagesDirEntryName.endsWith(".adoc") ||
+                !isMatch(pagesDirEntryId)
             )
+              continue
+
+            val pagesDirEntryDescriptor =
+              Descriptor.Path(
+                pagesDirEntryId,
+                pagesDirEntryName,
+                FileSource.from(pagesDirEntry.toFile()),
+                pagesDirEntry,
+              )
             docsDirEntryDescriptor.addChild(pagesDirEntryDescriptor)
 
             parseAsciidoc(pagesDirEntryDescriptor, selectors)
@@ -174,17 +193,15 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
         }
 
         val parent = sections.firstOrNull() ?: docDescriptor
-        val normalizedTitle = title
-          .replace("<code>", "")
-          .replace("</code>", "")
-          .replace(graphicsRegex, "")
-          .trim()
-        val childSection = Descriptor.Section(
-          parent.uniqueId.append("section", normalizedTitle),
-          normalizedTitle,
-          FileSource.from(docDescriptor.path.toFile(), FilePosition.from(lineNum)),
-          newLevel
-        )
+        val normalizedTitle =
+          title.replace("<code>", "").replace("</code>", "").replace(graphicsRegex, "").trim()
+        val childSection =
+          Descriptor.Section(
+            parent.uniqueId.append("section", normalizedTitle),
+            normalizedTitle,
+            FileSource.from(docDescriptor.path.toFile(), FilePosition.from(lineNum)),
+            newLevel,
+          )
 
         sections.addFirst(childSection)
         parent.addChild(childSection)
@@ -217,7 +234,8 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
           codeBlockNum += 1
           val (testMode, error, language) = codeBlockMatch.destructured
           if (testMode.isNotEmpty()) {
-            val blockName = codeBlockNameRegex.find(prevLine)?.groupValues?.get(1) ?: "snippet$codeBlockNum"
+            val blockName =
+              codeBlockNameRegex.find(prevLine)?.groupValues?.get(1) ?: "snippet$codeBlockNum"
             while (linesIterator.hasNext()) {
               advance()
               val startDelimiterMatch = codeBlockDelimiterRegex.find(line)
@@ -236,10 +254,13 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
                           snippetId,
                           blockName,
                           language,
-                          FileSource.from(docDescriptor.path.toFile(), FilePosition.from(jumpToLineNum)),
+                          FileSource.from(
+                            docDescriptor.path.toFile(),
+                            FilePosition.from(jumpToLineNum),
+                          ),
                           builder.toString(),
                           testMode == "parsed",
-                          error.isNotEmpty()
+                          error.isNotEmpty(),
                         )
                       )
                     }
@@ -261,28 +282,21 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
     }
   }
 
-  private sealed class Descriptor(
-    uniqueId: UniqueId,
-    displayName: String,
-    source: TestSource
-  ) : AbstractTestDescriptor(uniqueId, displayName, source), Node<ExecutionContext> {
+  private sealed class Descriptor(uniqueId: UniqueId, displayName: String, source: TestSource) :
+    AbstractTestDescriptor(uniqueId, displayName, source), Node<ExecutionContext> {
 
     class Path(
       uniqueId: UniqueId,
       displayName: String,
       source: TestSource,
-      val path: java.nio.file.Path
+      val path: java.nio.file.Path,
     ) : Descriptor(uniqueId, displayName, source) {
 
       override fun getType() = Type.CONTAINER
     }
 
-    class Section(
-      uniqueId: UniqueId,
-      displayName: String,
-      source: TestSource,
-      val level: Int
-    ) : Descriptor(uniqueId, displayName, source) {
+    class Section(uniqueId: UniqueId, displayName: String, source: TestSource, val level: Int) :
+      Descriptor(uniqueId, displayName, source) {
 
       override fun getType() = Type.CONTAINER
 
@@ -299,7 +313,7 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
       source: TestSource,
       private val code: String,
       private val parseOnly: Boolean,
-      private val expectError: Boolean
+      private val expectError: Boolean,
     ) : Descriptor(uniqueId, displayName, source) {
 
       override fun getType() = Type.TEST
@@ -308,11 +322,14 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
         when (language) {
           "pkl" -> Parser().parseModule(code)
           "pkl-expr" -> Parser().parseExpressionInput(code)
-          else -> throw(Exception("Unrecognized language: $language"))
+          else -> throw (Exception("Unrecognized language: $language"))
         }
       }
 
-      override fun execute(context: ExecutionContext, executor: DynamicTestExecutor): ExecutionContext {
+      override fun execute(
+        context: ExecutionContext,
+        executor: DynamicTestExecutor,
+      ): ExecutionContext {
         if (parseOnly) {
           try {
             parsed
@@ -328,12 +345,7 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
         }
 
         context.replServer.handleRequest(
-          ReplRequest.Eval(
-            "snippet",
-            code,
-            !expectError,
-            !expectError
-          )
+          ReplRequest.Eval("snippet", code, !expectError, !expectError)
         )
 
         val properties = parsed.children()?.filterIsInstance<ClassProperty>() ?: emptyList()
@@ -342,21 +354,21 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
 
         // force each property
         for (prop in properties) {
-          responses.addAll(context.replServer.handleRequest(
-            ReplRequest.Eval(
-              "snippet",
-              prop.name.value,
-              false,
-              true
+          responses.addAll(
+            context.replServer.handleRequest(
+              ReplRequest.Eval("snippet", prop.name.value, false, true)
             )
-          ))
+          )
         }
         if (expectError) {
-          if (responses.dropLast(1).any { it !is ReplResponse.EvalSuccess } ||
-            responses.last() !is ReplResponse.EvalError) {
+          if (
+            responses.dropLast(1).any { it !is ReplResponse.EvalSuccess } ||
+              responses.last() !is ReplResponse.EvalError
+          ) {
             throw AssertionError(
               "Expected %error snippet to fail at the end, but got the following REPL responses:\n\n" +
-                  responses.joinToString("\n\n") { it.message })
+                responses.joinToString("\n\n") { it.message }
+            )
           }
 
           return context

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzer.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliImportAnalyzer.kt
@@ -44,19 +44,19 @@ constructor(
   private val sourceModule =
     ModuleSource.text(
       """
-        import "pkl:analyze"
+      import "pkl:analyze"
 
-        local importStrings = read*("prop:pkl.analyzeImports.**").toMap().values.toSet()
+      local importStrings = read*("prop:pkl.analyzeImports.**").toMap().values.toSet()
 
-        output {
-          value = analyze.importGraph(importStrings)
-          renderer {
-            converters {
-              [Map] = (it) -> it.toMapping()
-              [Set] = (it) -> it.toListing()
-            }
+      output {
+        value = analyze.importGraph(importStrings)
+        renderer {
+          converters {
+            [Map] = (it) -> it.toMapping()
+            [Set] = (it) -> it.toListing()
           }
         }
+      }
       """
         .trimIndent()
     )

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliTestRunner.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliTestRunner.kt
@@ -53,9 +53,9 @@ constructor(
         throw CliException(
           """
           Usage: pkl test [<options>] <modules>...
-          
+
           Error: missing argument <modules>
-        """
+          """
             .trimIndent()
         )
 

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/repl/ReplMessages.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/repl/ReplMessages.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ internal object ReplMessages {
     * Incomplete input will be continued on the next line.
     * Multi-line programs can be copy-pasted into the REPL.
 
-  """
+    """
       .trimIndent()
 
   val examples: String =

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliCommandRunnerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliCommandRunnerTest.kt
@@ -44,14 +44,14 @@ import org.pkl.commons.writeString
 class CliCommandRunnerTest {
   private val renderOptions =
     """
-      extends "pkl:Command"
-      
-      options: Options
-      
-      output {
-        value = options
-      }
-      
+    extends "pkl:Command"
+
+    options: Options
+
+    output {
+      value = options
+    }
+
     """
       .trimIndent()
 
@@ -104,10 +104,10 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: String
-      }
-    """
+          class Options {
+            foo: String
+          }
+          """
             .trimIndent(),
       )
 
@@ -125,48 +125,48 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        `number-as-int`: Number
-        `number-as-float`: Number
-        `number-nullable`: Number?
-        `number-default`: Number = 100.0
-        `number-default-overridden`: Number = 100.0
-        
-        float: Float
-        `float-without-decimals`: Float
-        `float-nullable`: Float?
-        `float-default`: Float = 100.0
-        `float-default-overridden`: Float = 100.0
-        
-        int: Int
-        `int-nullable`: Int?
-        `int-default`: Int = 100
-        `int-default-overridden`: Int = 100
-        
-        int8: Int8
-        int16: Int16
-        int32: Int32
-        uint: UInt
-        uint8: UInt8
-        uint16: UInt16
-        uint32: UInt32
-        
-        boolean: Boolean
-        `boolean-nullable`: Boolean?
-        `boolean-default`: Boolean = true
-        `boolean-default-overridden`: Boolean = false
-        
-        string: String
-        `string-nullable`: String?
-        `string-default`: String = "default"
-        `string-default-overridden`: String = "default"
-        
-        char: Char
-        `char-nullable`: Char?
-        `char-default`: Char = "a"
-        `char-default-overridden`: Char = "b"
-      }
-    """
+          class Options {
+            `number-as-int`: Number
+            `number-as-float`: Number
+            `number-nullable`: Number?
+            `number-default`: Number = 100.0
+            `number-default-overridden`: Number = 100.0
+            
+            float: Float
+            `float-without-decimals`: Float
+            `float-nullable`: Float?
+            `float-default`: Float = 100.0
+            `float-default-overridden`: Float = 100.0
+            
+            int: Int
+            `int-nullable`: Int?
+            `int-default`: Int = 100
+            `int-default-overridden`: Int = 100
+            
+            int8: Int8
+            int16: Int16
+            int32: Int32
+            uint: UInt
+            uint8: UInt8
+            uint16: UInt16
+            uint32: UInt32
+            
+            boolean: Boolean
+            `boolean-nullable`: Boolean?
+            `boolean-default`: Boolean = true
+            `boolean-default-overridden`: Boolean = false
+            
+            string: String
+            `string-nullable`: String?
+            `string-default`: String = "default"
+            `string-default-overridden`: String = "default"
+            
+            char: Char
+            `char-nullable`: Char?
+            `char-default`: Char = "a"
+            `char-default-overridden`: Char = "b"
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -232,7 +232,7 @@ class CliCommandRunnerTest {
         `char-nullable` = null
         `char-default` = "a"
         `char-default-overridden` = "c"
-        
+
         """
           .trimIndent()
       )
@@ -245,45 +245,45 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        `number-as-int`: Number
-        @Argument
-        `number-as-float`: Number
-        
-        @Argument
-        float: Float
-        @Argument
-        `float-without-decimals`: Float
-        
-        @Argument
-        int: Int
-        
-        @Argument
-        int8: Int8
-        @Argument
-        int16: Int16
-        @Argument
-        int32: Int32
-        @Argument
-        uint: UInt
-        @Argument
-        uint8: UInt8
-        @Argument
-        uint16: UInt16
-        @Argument
-        uint32: UInt32
-        
-        @Argument
-        boolean: Boolean
-        
-        @Argument
-        string: String
-        
-        @Argument
-        char: Char
-      }
-    """
+          class Options {
+            @Argument
+            `number-as-int`: Number
+            @Argument
+            `number-as-float`: Number
+            
+            @Argument
+            float: Float
+            @Argument
+            `float-without-decimals`: Float
+            
+            @Argument
+            int: Int
+            
+            @Argument
+            int8: Int8
+            @Argument
+            int16: Int16
+            @Argument
+            int32: Int32
+            @Argument
+            uint: UInt
+            @Argument
+            uint8: UInt8
+            @Argument
+            uint16: UInt16
+            @Argument
+            uint32: UInt32
+            
+            @Argument
+            boolean: Boolean
+            
+            @Argument
+            string: String
+            
+            @Argument
+            char: Char
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -325,7 +325,7 @@ class CliCommandRunnerTest {
         boolean = false
         string = "foobar"
         char = "X"
-        
+
         """
           .trimIndent()
       )
@@ -338,21 +338,21 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      typealias MyEnum = "d" | "e" | *"f"
-      class Options {
-        enum: "a" | "b" | "c"
-        `enum-default`: "a" | *"b" | "c"
-        `enum-explicit-default`: "a" | "b" | "c" = "c"
-        `enum-alias-default`: MyEnum
-        `enum-alias-explicit-default`: MyEnum = "e"
-        `enum-alias-default-overridden`: MyEnum
-        
-        `enum-single`: "x"
-        `enum-single-nullable`: "x"?
-        `enum-single-explicit-default`: "x" = "x"
-        `enum-single-overridden`: "x"
-      }
-    """
+          typealias MyEnum = "d" | "e" | *"f"
+          class Options {
+            enum: "a" | "b" | "c"
+            `enum-default`: "a" | *"b" | "c"
+            `enum-explicit-default`: "a" | "b" | "c" = "c"
+            `enum-alias-default`: MyEnum
+            `enum-alias-explicit-default`: MyEnum = "e"
+            `enum-alias-default-overridden`: MyEnum
+            
+            `enum-single`: "x"
+            `enum-single-nullable`: "x"?
+            `enum-single-explicit-default`: "x" = "x"
+            `enum-single-overridden`: "x"
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -386,16 +386,16 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      typealias MyEnum = "d" | "e" | *"f"
-      class Options {
-        @Argument
-        enum: "a" | "b" | "c"
-        @Argument
-        `enum-default`: "a" | *"b" | "c"
-        @Argument
-        `enum-alias-default`: MyEnum
-      }
-    """
+          typealias MyEnum = "d" | "e" | *"f"
+          class Options {
+            @Argument
+            enum: "a" | "b" | "c"
+            @Argument
+            `enum-default`: "a" | *"b" | "c"
+            @Argument
+            `enum-alias-default`: MyEnum
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -406,7 +406,7 @@ class CliCommandRunnerTest {
         enum = "a"
         `enum-default` = "c"
         `enum-alias-default` = "d"
-        
+
         """
           .trimIndent()
       )
@@ -419,18 +419,18 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        list: List<Number>
-        `list-nullable`: List<Number>?
-        `list-default`: List<Number> = List(1, 2, 300.0)
-        set: Set<Number>
-        `set-nullable`: Set<Number>?
-        `set-default`: Set<Number> = Set(1, 2, 300.0, 2)
-        
-        `enum-list`: List<"a" | "b" | *"c">
-        `enum-set`: Set<"a" | "b" | *"c">
-      }
-    """
+          class Options {
+            list: List<Number>
+            `list-nullable`: List<Number>?
+            `list-default`: List<Number> = List(1, 2, 300.0)
+            set: Set<Number>
+            `set-nullable`: Set<Number>?
+            `set-default`: Set<Number> = Set(1, 2, 300.0, 2)
+            
+            `enum-list`: List<"a" | "b" | *"c">
+            `enum-set`: Set<"a" | "b" | *"c">
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -464,7 +464,7 @@ class CliCommandRunnerTest {
         `set-default` = Set(1, 2, 300.0)
         `enum-list` = List("a", "a", "b")
         `enum-set` = Set("a", "b")
-        
+
         """
           .trimIndent()
       )
@@ -477,11 +477,11 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        list: List<Number>
-      }
-    """
+          class Options {
+            @Argument
+            list: List<Number>
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -490,7 +490,7 @@ class CliCommandRunnerTest {
       .isEqualTo(
         """
         list = List(1, 0, 0.0, 1)
-        
+
         """
           .trimIndent()
       )
@@ -500,11 +500,11 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        set: Set<Number>
-      }
-    """
+          class Options {
+            @Argument
+            set: Set<Number>
+          }
+          """
             .trimIndent(),
       )
     val output2 =
@@ -513,7 +513,7 @@ class CliCommandRunnerTest {
       .isEqualTo(
         """
         set = Set(1, 0, 0.0)
-        
+
         """
           .trimIndent()
       )
@@ -523,11 +523,11 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        listing: Listing<Number>
-      }
-    """
+          class Options {
+            @Argument
+            listing: Listing<Number>
+          }
+          """
             .trimIndent(),
       )
     val output3 =
@@ -541,7 +541,7 @@ class CliCommandRunnerTest {
           0.0
           1
         }
-        
+
         """
           .trimIndent()
       )
@@ -554,11 +554,11 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        map: Map<Number, Number>
-      }
-    """
+          class Options {
+            @Argument
+            map: Map<Number, Number>
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -567,7 +567,7 @@ class CliCommandRunnerTest {
       .isEqualTo(
         """
         map = Map(1, 0, 0.0, 1)
-        
+
         """
           .trimIndent()
       )
@@ -577,11 +577,11 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        mapping: Mapping<Number, Number>
-      }
-    """
+          class Options {
+            @Argument
+            mapping: Mapping<Number, Number>
+          }
+          """
             .trimIndent(),
       )
     val output2 =
@@ -593,7 +593,7 @@ class CliCommandRunnerTest {
           [1] = 0
           [0.0] = 1
         }
-        
+
         """
           .trimIndent()
       )
@@ -603,11 +603,11 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        pair: Pair<Number, Number>
-      }
-    """
+          class Options {
+            @Argument
+            pair: Pair<Number, Number>
+          }
+          """
             .trimIndent(),
       )
     val output3 = runToStdout(CliBaseOptions(sourceModules = listOf(moduleUri3)), listOf("1=0.0"))
@@ -615,7 +615,7 @@ class CliCommandRunnerTest {
       .isEqualTo(
         """
         pair = Pair(1, 0.0)
-        
+
         """
           .trimIndent()
       )
@@ -628,15 +628,15 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      typealias MyEnum = "a" | "b" | *"c"
-      class Options {
-        map: Map<Char, Number>
-        `map-nullable`: Map<Char, Number>?
-        `map-default`: Map<Char, Number> = Map("x", 123, "y", 456.789)
-        
-        `enum-map`: Map<MyEnum, MyEnum>
-      }
-    """
+          typealias MyEnum = "a" | "b" | *"c"
+          class Options {
+            map: Map<Char, Number>
+            `map-nullable`: Map<Char, Number>?
+            `map-default`: Map<Char, Number> = Map("x", 123, "y", 456.789)
+            
+            `enum-map`: Map<MyEnum, MyEnum>
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -651,7 +651,7 @@ class CliCommandRunnerTest {
         `map-nullable` = null
         `map-default` = Map("x", 123, "y", 456.789)
         `enum-map` = Map("a", "b", "b", "c")
-        
+
         """
           .trimIndent()
       )
@@ -664,15 +664,15 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      typealias MyEnum = "a" | "b" | *"c"
-      class Options {
-        mapping: Mapping<Char, Number>
-        `mapping-nullable`: Mapping<Char, Number>?
-        `mapping-default`: Mapping<Char, Number> = new { ["x"] = 123; ["y"] = 456.789 }
-        
-        `enum-mapping`: Mapping<MyEnum, MyEnum>
-      }
-    """
+          typealias MyEnum = "a" | "b" | *"c"
+          class Options {
+            mapping: Mapping<Char, Number>
+            `mapping-nullable`: Mapping<Char, Number>?
+            `mapping-default`: Mapping<Char, Number> = new { ["x"] = 123; ["y"] = 456.789 }
+            
+            `enum-mapping`: Mapping<MyEnum, MyEnum>
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -696,7 +696,7 @@ class CliCommandRunnerTest {
           ["a"] = "b"
           ["b"] = "c"
         }
-        
+
         """
           .trimIndent()
       )
@@ -709,15 +709,15 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      typealias MyEnum = "a" | "b" | *"c"
-      class Options {
-        pair: Pair<Char, Number>
-        `pair-nullable`: Pair<Char, Number>?
-        `pair-default`: Pair<Char, Number> = Pair("x", 123)
-        
-        `enum-pair`: Pair<MyEnum, MyEnum>
-      }
-    """
+          typealias MyEnum = "a" | "b" | *"c"
+          class Options {
+            pair: Pair<Char, Number>
+            `pair-nullable`: Pair<Char, Number>?
+            `pair-default`: Pair<Char, Number> = Pair("x", 123)
+            
+            `enum-pair`: Pair<MyEnum, MyEnum>
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -732,7 +732,7 @@ class CliCommandRunnerTest {
         `pair-nullable` = null
         `pair-default` = Pair("x", 123)
         `enum-pair` = Pair("a", "b")
-        
+
         """
           .trimIndent()
       )
@@ -745,17 +745,17 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument { convert = module.convertDuration }
-        a: Duration
-        @Argument { convert = module.convertDuration }
-        b: Duration
-        @Argument { convert = module.convertDuration }
-        c: Duration
-        @Argument { convert = module.convertDuration }
-        d: Duration
-      }
-    """
+          class Options {
+            @Argument { convert = module.convertDuration }
+            a: Duration
+            @Argument { convert = module.convertDuration }
+            b: Duration
+            @Argument { convert = module.convertDuration }
+            c: Duration
+            @Argument { convert = module.convertDuration }
+            d: Duration
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -770,7 +770,7 @@ class CliCommandRunnerTest {
         b = 10.h
         c = 10.5.ms
         d = 10.5.d
-        
+
         """
           .trimIndent()
       )
@@ -783,17 +783,17 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument { convert = module.convertDataSize }
-        a: DataSize
-        @Argument { convert = module.convertDataSize }
-        b: DataSize
-        @Argument { convert = module.convertDataSize }
-        c: DataSize
-        @Argument { convert = module.convertDataSize }
-        d: DataSize
-      }
-    """
+          class Options {
+            @Argument { convert = module.convertDataSize }
+            a: DataSize
+            @Argument { convert = module.convertDataSize }
+            b: DataSize
+            @Argument { convert = module.convertDataSize }
+            c: DataSize
+            @Argument { convert = module.convertDataSize }
+            d: DataSize
+          }
+          """
             .trimIndent(),
       )
     val output =
@@ -808,7 +808,7 @@ class CliCommandRunnerTest {
         b = 10.gb
         c = 10.5.mb
         d = 10.5.tib
-        
+
         """
           .trimIndent()
       )
@@ -820,23 +820,23 @@ class CliCommandRunnerTest {
       writePklFile(
         "cmd.pkl",
         """
-      extends "pkl:Command"
-      
-      options: Options
-      
-      output {
-        value = (options) {
-          fromImport {
-           baz = true // assert that imported modules are not forced
+        extends "pkl:Command"
+
+        options: Options
+
+        output {
+          value = (options) {
+            fromImport {
+             baz = true // assert that imported modules are not forced
+            }
           }
         }
-      }
-      
-      class Options {
-        @Argument { convert = (it) -> new Import{ uri = it } }
-        fromImport: Module
-      }
-    """
+
+        class Options {
+          @Argument { convert = (it) -> new Import{ uri = it } }
+          fromImport: Module
+        }
+        """
           .trimIndent(),
       )
 
@@ -844,10 +844,10 @@ class CliCommandRunnerTest {
       writePklFile(
         "import.pkl",
         """
-      foo = 1
-      bar = "baz"
-      baz: Boolean
-    """
+        foo = 1
+        bar = "baz"
+        baz: Boolean
+        """
           .trimIndent(),
       )
 
@@ -861,7 +861,7 @@ class CliCommandRunnerTest {
           bar = "baz"
           baz = true
         }
-        
+
         """
           .trimIndent()
       )
@@ -873,26 +873,26 @@ class CliCommandRunnerTest {
       writePklFile(
         "cmd.pkl",
         """
-      extends "pkl:Command"
-      
-      options: Options
-      
-      output {
-        value = (options) {
-          fromImport {
-           baz = true // assert that imported modules are not forced
+        extends "pkl:Command"
+
+        options: Options
+
+        output {
+          value = (options) {
+            fromImport {
+             baz = true // assert that imported modules are not forced
+            }
           }
         }
-      }
-      
-      class Options {
-        @Flag {
-          convert = (it) -> new Import{ uri = it }
-          transformAll = (values) -> values.firstOrNull ?? new Import { uri = "./default.pkl" }
+
+        class Options {
+          @Flag {
+            convert = (it) -> new Import{ uri = it }
+            transformAll = (values) -> values.firstOrNull ?? new Import { uri = "./default.pkl" }
+          }
+          fromImport: Module
         }
-        fromImport: Module
-      }
-    """
+        """
           .trimIndent(),
       )
 
@@ -900,10 +900,10 @@ class CliCommandRunnerTest {
       writePklFile(
         "default.pkl",
         """
-      foo = 1
-      bar = "baz"
-      baz: Boolean
-    """
+        foo = 1
+        bar = "baz"
+        baz: Boolean
+        """
           .trimIndent(),
       )
 
@@ -920,7 +920,7 @@ class CliCommandRunnerTest {
           bar = "baz"
           baz = true
         }
-        
+
         """
           .trimIndent()
       )
@@ -932,26 +932,26 @@ class CliCommandRunnerTest {
       writePklFile(
         "cmd.pkl",
         """
-      extends "pkl:Command"
-      import "base.pkl"
-      
-      options: Options
-      
-      output {
-        value = (options) {
-          fromGlobImport {
-            [[true]] {
-              baz = true // assert that imported modules are not forced
+        extends "pkl:Command"
+        import "base.pkl"
+
+        options: Options
+
+        output {
+          value = (options) {
+            fromGlobImport {
+              [[true]] {
+                baz = true // assert that imported modules are not forced
+              }
             }
           }
         }
-      }
-      
-      class Options {
-        @Argument { convert = (it) -> new Import { uri = it; glob = true }; multiple = false }
-        fromGlobImport: Mapping<String, base>
-      }
-    """
+
+        class Options {
+          @Argument { convert = (it) -> new Import { uri = it; glob = true }; multiple = false }
+          fromGlobImport: Mapping<String, base>
+        }
+        """
           .trimIndent(),
       )
 
@@ -959,10 +959,10 @@ class CliCommandRunnerTest {
       writePklFile(
         "base.pkl",
         """
-      foo: Int
-      bar: String
-      baz: Boolean
-    """
+        foo: Int
+        bar: String
+        baz: Boolean
+        """
           .trimIndent(),
       )
     writePklFile(
@@ -971,7 +971,7 @@ class CliCommandRunnerTest {
       amends "base.pkl"
       foo = 1
       bar = "baz"
-    """
+      """
         .trimIndent(),
     )
     writePklFile(
@@ -980,7 +980,7 @@ class CliCommandRunnerTest {
       amends "base.pkl"
       foo = 2
       bar = "qux"
-    """
+      """
         .trimIndent(),
     )
 
@@ -1006,7 +1006,7 @@ class CliCommandRunnerTest {
             baz = true
           }
         }
-        
+
         """
           .trimIndent()
       )
@@ -1019,11 +1019,11 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument { convert = (it) -> throw("oops!") }
-        foo: String
-      }
-    """
+          class Options {
+            @Argument { convert = (it) -> throw("oops!") }
+            foo: String
+          }
+          """
             .trimIndent(),
       )
 
@@ -1041,11 +1041,11 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument { convert = (it) -> it.noSuchMethod() }
-        foo: String
-      }
-    """
+          class Options {
+            @Argument { convert = (it) -> it.noSuchMethod() }
+            foo: String
+          }
+          """
             .trimIndent(),
       )
 
@@ -1063,12 +1063,12 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      const function overflow(it) = overflow(it)
-      class Options {
-        @Argument { convert = (it) -> overflow(it) }
-        foo: String
-      }
-    """
+          const function overflow(it) = overflow(it)
+          class Options {
+            @Argument { convert = (it) -> overflow(it) }
+            foo: String
+          }
+          """
             .trimIndent(),
       )
 
@@ -1086,19 +1086,19 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @BooleanFlag
-        `bool-true`: Boolean
-        @BooleanFlag
-        `bool-false`: Boolean
-        @BooleanFlag
-        `bool-nullable`: Boolean?
-        @BooleanFlag
-        `bool-default-true`: Boolean = true
-        @BooleanFlag
-        `bool-default-false`: Boolean = false
-      }
-    """
+          class Options {
+            @BooleanFlag
+            `bool-true`: Boolean
+            @BooleanFlag
+            `bool-false`: Boolean
+            @BooleanFlag
+            `bool-nullable`: Boolean?
+            @BooleanFlag
+            `bool-default-true`: Boolean = true
+            @BooleanFlag
+            `bool-default-false`: Boolean = false
+          }
+          """
             .trimIndent(),
       )
 
@@ -1115,7 +1115,7 @@ class CliCommandRunnerTest {
         `bool-nullable` = null
         `bool-default-true` = true
         `bool-default-false` = false
-        
+
         """
           .trimIndent()
       )
@@ -1128,11 +1128,11 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @BooleanFlag
-        foo: String
-      }
-    """
+          class Options {
+            @BooleanFlag
+            foo: String
+          }
+          """
             .trimIndent(),
       )
 
@@ -1151,25 +1151,25 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @CountedFlag { shortName = "a" }
-        int: Int
-        @CountedFlag { shortName = "b" }
-        int8: Int8
-        @CountedFlag { shortName = "c" }
-        int16: Int16
-        @CountedFlag { shortName = "d" }
-        int32: Int32
-        @CountedFlag { shortName = "x" }
-        uint: UInt
-        @CountedFlag { shortName = "y" }
-        uint8: UInt8
-        @CountedFlag { shortName = "g" }
-        uint16: UInt16
-        @CountedFlag { shortName = "i" }
-        uint32: UInt32
-      }
-    """
+          class Options {
+            @CountedFlag { shortName = "a" }
+            int: Int
+            @CountedFlag { shortName = "b" }
+            int8: Int8
+            @CountedFlag { shortName = "c" }
+            int16: Int16
+            @CountedFlag { shortName = "d" }
+            int32: Int32
+            @CountedFlag { shortName = "x" }
+            uint: UInt
+            @CountedFlag { shortName = "y" }
+            uint8: UInt8
+            @CountedFlag { shortName = "g" }
+            uint16: UInt16
+            @CountedFlag { shortName = "i" }
+            uint32: UInt32
+          }
+          """
             .trimIndent(),
       )
 
@@ -1189,7 +1189,7 @@ class CliCommandRunnerTest {
         uint8 = 6
         uint16 = 7
         uint32 = 8
-        
+
         """
           .trimIndent()
       )
@@ -1202,14 +1202,14 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Flag {
-          multiple = true
-          transformAll = (values) -> values.fold(0, (res, acc) -> res + acc)
-        }
-        foo: Int
-      }
-    """
+          class Options {
+            @Flag {
+              multiple = true
+              transformAll = (values) -> values.fold(0, (res, acc) -> res + acc)
+            }
+            foo: Int
+          }
+          """
             .trimIndent(),
       )
 
@@ -1222,7 +1222,7 @@ class CliCommandRunnerTest {
       .isEqualTo(
         """
         foo = 14
-        
+
         """
           .trimIndent()
       )
@@ -1235,21 +1235,21 @@ class CliCommandRunnerTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        none: String?
-        enum: *"a" | "b" | "c"
-        @Flag { completionCandidates = "paths" }
-        path: String?
-        @Flag { completionCandidates { "foo"; "bar"; "baz" } }
-        explicit: String?
-        @Argument
-        enumArg: *"a" | "b" | "c"
-        @Argument { completionCandidates = "paths" }
-        pathArg: String
-        @Argument { completionCandidates { "foo"; "bar"; "baz" } }
-        explicitArg: String
-      }
-    """
+          class Options {
+            none: String?
+            enum: *"a" | "b" | "c"
+            @Flag { completionCandidates = "paths" }
+            path: String?
+            @Flag { completionCandidates { "foo"; "bar"; "baz" } }
+            explicit: String?
+            @Argument
+            enumArg: *"a" | "b" | "c"
+            @Argument { completionCandidates = "paths" }
+            pathArg: String
+            @Argument { completionCandidates { "foo"; "bar"; "baz" } }
+            explicitArg: String
+          }
+          """
             .trimIndent(),
       )
     val exc =

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
@@ -58,7 +58,7 @@ class CliEvaluatorTest {
         name = "pigeon"
         age = 20 + 10
       }
-    """
+      """
         .trimIndent()
 
     private val packageServer = PackageServer()
@@ -243,12 +243,12 @@ person:
       .resolve("test2.pkl")
       .writeString(
         """
-      amends "test.pkl"
-      
-      person {
-        name = "barn owl"
-      }
-      """
+        amends "test.pkl"
+
+        person {
+          name = "barn owl"
+        }
+        """
           .trimIndent()
       )
 
@@ -655,9 +655,9 @@ result = someLib.x
       "output.pcf",
       """
       x = 1
-      
+
       y = 2
-      
+
       z = 3
       """
         .trimIndent(),
@@ -739,7 +739,7 @@ result = someLib.x
               }
             } 
           }
-        """
+          """
             .trimIndent(),
         )
       )
@@ -815,31 +815,31 @@ result = someLib.x
         writePklFile(
           "test0.pkl",
           """
-        output {
-          files {
-            ["foo.pcf"] {
-              value = new Dynamic {
-                ["bar"] = "baz"
+          output {
+            files {
+              ["foo.pcf"] {
+                value = new Dynamic {
+                  ["bar"] = "baz"
+                }
               }
             }
           }
-        }
-        """
+          """
             .trimIndent(),
         ),
         writePklFile(
           "test1.pkl",
           """
-        output {
-          files {
-            ["bar.pcf"] {
-              value = new Dynamic {
-                ["bar"] = "baz"
+          output {
+            files {
+              ["bar.pcf"] {
+                value = new Dynamic {
+                  ["bar"] = "baz"
+                }
               }
             }
           }
-        }
-        """
+          """
             .trimIndent(),
         ),
       )
@@ -860,27 +860,27 @@ result = someLib.x
         writePklFile(
           "bar.pkl",
           """
-        output {
-          files {
-            ["foo.pcf"] {
-              text = "myBar"
+          output {
+            files {
+              ["foo.pcf"] {
+                text = "myBar"
+              }
             }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
         writePklFile(
           "foo.pkl",
           """
-        output {
-          files {
-            ["foo.pcf"] {
-              text = "myFoo"
+          output {
+            files {
+              ["foo.pcf"] {
+                text = "myFoo"
+              }
             }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
       )
@@ -918,7 +918,7 @@ result = someLib.x
             }
           }
         }
-      """
+        """
           .trimIndent(),
       )
     val options =
@@ -949,7 +949,7 @@ result = someLib.x
             }
           }
         }
-      """
+        """
           .trimIndent(),
       )
     val options =
@@ -970,23 +970,23 @@ result = someLib.x
         writePklFile(
           "test1.pkl",
           """
-        output {
-          files {
-            ["."] { text = "bar" }
+          output {
+            files {
+              ["."] { text = "bar" }
+            }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
         writePklFile(
           "test2.pkl",
           """
-        output {
-          files {
-            ["myDir"] { text = "bar" }
+          output {
+            files {
+              ["myDir"] { text = "bar" }
+            }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
       )
@@ -1009,23 +1009,23 @@ result = someLib.x
         writePklFile(
           "test1.pkl",
           """
-        output {
-          files {
-            ["foo.txt"] { text = "bar" }
+          output {
+            files {
+              ["foo.txt"] { text = "bar" }
+            }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
         writePklFile(
           "test2.pkl",
           """
-        output {
-          files {
-            ["foo.txt"] { text = "bar" }
+          output {
+            files {
+              ["foo.txt"] { text = "bar" }
+            }
           }
-        }
-      """
+          """
             .trimIndent(),
         ),
       )
@@ -1045,13 +1045,13 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      output {
-        files {
-          ["foo.txt"] { text = "bar" }
-          ["./foo.txt"] { text = "bar" }
+        output {
+          files {
+            ["foo.txt"] { text = "bar" }
+            ["./foo.txt"] { text = "bar" }
+          }
         }
-      }
-    """
+        """
           .trimIndent(),
       )
     val options =
@@ -1071,12 +1071,12 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      output {
-        files {
-          ["foo:bar"] { text = "bar" }
+        output {
+          files {
+            ["foo:bar"] { text = "bar" }
+          }
         }
-      }
-    """
+        """
           .trimIndent(),
       )
 
@@ -1096,12 +1096,12 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      output {
-        files {
-          ["foo\\bar"] { text = "bar" }
+        output {
+          files {
+            ["foo\\bar"] { text = "bar" }
+          }
         }
-      }
-    """
+        """
           .trimIndent(),
       )
 
@@ -1120,10 +1120,10 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      foo {
-        bar = 1
-      }
-    """
+        foo {
+          bar = 1
+        }
+        """
           .trimIndent(),
       )
     val options =
@@ -1136,8 +1136,8 @@ result = someLib.x
     assertThat(buffer.toString(StandardCharsets.UTF_8))
       .isEqualTo(
         """
-      new Dynamic { bar = 1 }
-    """
+        new Dynamic { bar = 1 }
+        """
           .trimIndent()
       )
   }
@@ -1148,13 +1148,13 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      class Person {
-        name: String
+        class Person {
+          name: String
 
-        function toString() = "Person(\(name))"
-      }
-      person: Person = new { name = "Frodo" }
-    """
+          function toString() = "Person(\(name))"
+        }
+        person: Person = new { name = "Frodo" }
+        """
           .trimIndent(),
       )
     val options =
@@ -1173,10 +1173,10 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      person {
-        friend { name = "Bilbo" }
-      }
-    """
+        person {
+          friend { name = "Bilbo" }
+        }
+        """
           .trimIndent(),
       )
     val options =
@@ -1196,17 +1196,17 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      res = 1
-    """
+        res = 1
+        """
           .trimIndent(),
       )
     writePklFile(
       "PklProject",
       """
       amends "pkl:Project"
-      
+
       package = throw("invalid project package")
-    """
+      """
         .trimIndent(),
     )
     val options =
@@ -1225,8 +1225,8 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      res = read*("env:**")
-    """
+        res = read*("env:**")
+        """
           .trimIndent(),
       )
     writePklFile(
@@ -1234,14 +1234,14 @@ result = someLib.x
       // language=Pkl
       """
       amends "pkl:Project"
-      
+
       evaluatorSettings {
         env {
           ["foo"] = "foo"
           ["bar"] = "bar"
         }
       }
-    """
+      """
         .trimIndent(),
     )
     val options =
@@ -1251,12 +1251,12 @@ result = someLib.x
     assertThat(buffer.toString(StandardCharsets.UTF_8))
       .isEqualTo(
         """
-      res {
-        ["env:bar"] = "bar"
-        ["env:foo"] = "foo"
-      }
-      
-    """
+        res {
+          ["env:bar"] = "bar"
+          ["env:foo"] = "foo"
+        }
+
+        """
           .trimIndent()
       )
   }
@@ -1353,10 +1353,10 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-      import "package://localhost:0/birds@0.5.0#/catalog/Swallow.pkl"
-      
-      res = Swallow
-    """
+        import "package://localhost:0/birds@0.5.0#/catalog/Swallow.pkl"
+
+        res = Swallow
+        """
           .trimIndent(),
       )
     val buffer = ByteArrayOutputStream()
@@ -1375,14 +1375,14 @@ result = someLib.x
     assertThat(buffer.toString(StandardCharsets.UTF_8))
       .isEqualTo(
         """
-      res {
-        name = "Swallow"
-        favoriteFruit {
-          name = "Apple"
+        res {
+          name = "Swallow"
+          favoriteFruit {
+            name = "Apple"
+          }
         }
-      }
-      
-    """
+
+        """
           .trimIndent()
       )
     assertThat(tempDir.resolve("package-2")).doesNotExist()
@@ -1481,13 +1481,13 @@ result = someLib.x
     assertThat(output)
       .isEqualTo(
         """
-      name = "Ostrich"
+        name = "Ostrich"
 
-      favoriteFruit {
-        name = "Orange"
-      }
+        favoriteFruit {
+          name = "Orange"
+        }
 
-    """
+        """
           .trimIndent()
       )
     verify(getRequestedFor(urlEqualTo("birds@0.5.0")))
@@ -1590,13 +1590,13 @@ result = someLib.x
     homeDir.writeFile(
       "settings.pkl",
       """
-        amends "pkl:settings"
+      amends "pkl:settings"
 
-        http {
-          proxy {
-            address = "http://invalid.proxy.address"
-          }
+      http {
+        proxy {
+          address = "http://invalid.proxy.address"
         }
+      }
       """
         .trimIndent(),
     )
@@ -1677,26 +1677,26 @@ result = someLib.x
       writePklFile(
         "test.pkl",
         """
-          pigeon {
-            name = "Pigeon"
-            diet = "Seeds"
-          }
-          parrot {
-            name = "Parrot"
-            diet = "Seeds"
-          }
-          output {
-            files {
-              ["pigeon.json"] {
-                value = pigeon
-                renderer = new JsonRenderer {}
-              }
-              ["birds/parrot.yaml"] {
-                value = parrot
-                renderer = new YamlRenderer {}
-              }
+        pigeon {
+          name = "Pigeon"
+          diet = "Seeds"
+        }
+        parrot {
+          name = "Parrot"
+          diet = "Seeds"
+        }
+        output {
+          files {
+            ["pigeon.json"] {
+              value = pigeon
+              renderer = new JsonRenderer {}
+            }
+            ["birds/parrot.yaml"] {
+              value = parrot
+              renderer = new YamlRenderer {}
             }
           }
+        }
         """
           .trimIndent(),
       )
@@ -1713,10 +1713,10 @@ result = someLib.x
       realOutputDir.resolve("pigeon.json"),
       "pigeon.json",
       """
-        {
-          "name": "Pigeon",
-          "diet": "Seeds"
-        }
+      {
+        "name": "Pigeon",
+        "diet": "Seeds"
+      }
       """
         .trimIndent(),
     )
@@ -1725,8 +1725,8 @@ result = someLib.x
       realOutputDir.resolve("birds/parrot.yaml"),
       "parrot.yaml",
       """
-        name: Parrot
-        diet: Seeds
+      name: Parrot
+      diet: Seeds
       """
         .trimIndent(),
     )
@@ -1735,10 +1735,10 @@ result = someLib.x
       symlinkOutputDir.resolve("pigeon.json"),
       "pigeon.json",
       """
-        {
-          "name": "Pigeon",
-          "diet": "Seeds"
-        }
+      {
+        "name": "Pigeon",
+        "diet": "Seeds"
+      }
       """
         .trimIndent(),
     )
@@ -1747,8 +1747,8 @@ result = someLib.x
       symlinkOutputDir.resolve("birds/parrot.yaml"),
       "parrot.yaml",
       """
-        name: Parrot
-        diet: Seeds
+      name: Parrot
+      diet: Seeds
       """
         .trimIndent(),
     )

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliMainTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliMainTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,12 +69,12 @@ class CliMainTest {
     val code =
       """
       x = 3
-      
+
       output {
         value = x
         renderer = new JsonRenderer {}
       }
-    """
+      """
         .trimIndent()
     val inputFile = tempDir.resolve("test.pkl").writeString(code).toString()
     val outputFile = makeSymdir(tempDir, "out", "linkOut").resolve("test.pkl").toString()

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliPackageDownloaderTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliPackageDownloaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,11 +70,11 @@ class CliPackageDownloaderTest {
       "PklProject",
       """
       amends "pkl:Project"
-      
+
       evaluatorSettings {
         moduleCacheDir = ".my-cache"
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -210,7 +210,7 @@ class CliPackageDownloaderTest {
         Exception when making request `GET https://bogus.domain/notAPackage@1.0.0`:
         Error connecting to host `bogus.domain`.
 
-      """
+        """
           .trimIndent()
       )
   }

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliProjectPackagerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliProjectPackagerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,8 +85,8 @@ class CliProjectPackagerTest {
       .resolve("PklProject")
       .writeString(
         """
-      amends "pkl:Project"
-    """
+        amends "pkl:Project"
+        """
           .trimIndent()
       )
     val packager =
@@ -108,20 +108,20 @@ class CliProjectPackagerTest {
       "myTest.pkl",
       """
       amends "pkl:test"
-      
+
       facts {
         ["1 == 2"] {
           1 == 2
         }
       }
-    """
+      """
         .trimIndent(),
     )
     tempDir.writeFile(
       "PklProject",
       """
       amends "pkl:Project"
-      
+
       package {
         name = "mypackage"
         version = "1.0.0"
@@ -129,7 +129,7 @@ class CliProjectPackagerTest {
         packageZipUrl = "https://foo.com"
         apiTests { "myTest.pkl" }
       }
-    """
+      """
         .trimIndent(),
     )
     val buffer = StringWriter()
@@ -154,13 +154,13 @@ class CliProjectPackagerTest {
       .writeString(
         """
         amends "pkl:test"
-        
+
         facts {
           ["1 == 1"] {
             1 == 1
           }
         }
-      """
+        """
           .trimIndent()
       )
     tempDir
@@ -168,7 +168,7 @@ class CliProjectPackagerTest {
       .writeString(
         """
         amends "pkl:Project"
-        
+
         package {
           name = "mypackage"
           version = "1.0.0"
@@ -176,7 +176,7 @@ class CliProjectPackagerTest {
           packageZipUrl = "https://foo.com"
           apiTests { "myTest.pkl" }
         }
-      """
+        """
           .trimIndent()
       )
     val buffer = StringWriter()
@@ -203,13 +203,13 @@ class CliProjectPackagerTest {
         """
         amends "pkl:test"
         import "@birds/Bird.pkl"
-        
+
         examples {
           ["Bird"] {
             new Bird { name = "Finch"; favoriteFruit { name = "Tangerine" } }
           }
         }
-      """
+        """
           .trimIndent()
       )
     projectDir
@@ -226,8 +226,8 @@ class CliProjectPackagerTest {
             }
           }
         }
-        
-      """
+
+        """
           .trimIndent()
       )
     projectDir
@@ -235,7 +235,7 @@ class CliProjectPackagerTest {
       .writeString(
         """
         amends "pkl:Project"
-        
+
         package {
           name = "mypackage"
           version = "1.0.0"
@@ -249,7 +249,7 @@ class CliProjectPackagerTest {
             uri = "package://localhost:0/birds@0.5.0"
           }
         }
-      """
+        """
           .trimIndent()
       )
     projectDir
@@ -298,9 +298,9 @@ class CliProjectPackagerTest {
         "a/b/foo.pkl",
         """
         module foo
-        
+
         name: String
-      """
+        """
           .trimIndent(),
       )
 
@@ -311,7 +311,7 @@ class CliProjectPackagerTest {
         foo
         bar
         baz
-      """
+        """
           .trimIndent(),
       )
 
@@ -320,14 +320,14 @@ class CliProjectPackagerTest {
       .writeString(
         """
         amends "pkl:Project"
-        
+
         package {
           name = "mypackage"
           version = "1.0.0"
           baseUri = "package://example.com/mypackage"
           packageZipUrl = "https://foo.com"
         }
-      """
+        """
           .trimIndent()
       )
     val packager =
@@ -348,18 +348,18 @@ class CliProjectPackagerTest {
     assertThat(expectedMetadata)
       .hasContent(
         """
-      {
-        "name": "mypackage",
-        "packageUri": "package://example.com/mypackage@1.0.0",
-        "version": "1.0.0",
-        "packageZipUrl": "https://foo.com",
-        "packageZipChecksums": {
-          "sha256": "e83b67722ea17ba41717ce6e99ae8ee02d66df6294bd319ce403075b1071c3e0"
-        },
-        "dependencies": {},
-        "authors": []
-      }
-    """
+        {
+          "name": "mypackage",
+          "packageUri": "package://example.com/mypackage@1.0.0",
+          "version": "1.0.0",
+          "packageZipUrl": "https://foo.com",
+          "packageZipChecksums": {
+            "sha256": "e83b67722ea17ba41717ce6e99ae8ee02d66df6294bd319ce403075b1071c3e0"
+          },
+          "dependencies": {},
+          "authors": []
+        }
+        """
           .trimIndent()
       )
     assertThat(expectedArchive).exists()
@@ -395,21 +395,21 @@ class CliProjectPackagerTest {
     tempDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "mypackage"
-          version = "1.0.0"
-          baseUri = "package://example.com/mypackage"
-          packageZipUrl = "https://foo.com"
-          exclude {
-            "*.bin"
-            "child/main.pkl"
-            "*.test.pkl"
-            "examples/Ex1.pkl"
-            "tests/**"
-          }
+      amends "pkl:Project"
+
+      package {
+        name = "mypackage"
+        version = "1.0.0"
+        baseUri = "package://example.com/mypackage"
+        packageZipUrl = "https://foo.com"
+        exclude {
+          "*.bin"
+          "child/main.pkl"
+          "*.test.pkl"
+          "examples/Ex1.pkl"
+          "tests/**"
         }
+      }
       """
         .trimIndent(),
     )
@@ -444,21 +444,21 @@ class CliProjectPackagerTest {
     projectDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "mypackage"
-          version = "1.0.0"
-          baseUri = "package://example.com/mypackage"
-          packageZipUrl = "https://foo.com"
+      amends "pkl:Project"
+
+      package {
+        name = "mypackage"
+        version = "1.0.0"
+        baseUri = "package://example.com/mypackage"
+        packageZipUrl = "https://foo.com"
+      }
+
+      dependencies {
+        ["birds"] {
+          uri = "package://localhost:0/birds@0.5.0"
         }
-        
-        dependencies {
-          ["birds"] {
-            uri = "package://localhost:0/birds@0.5.0"
-          }
-          ["project2"] = import("../project2/PklProject")
-        }
+        ["project2"] = import("../project2/PklProject")
+      }
       """
         .trimIndent(),
     )
@@ -489,24 +489,24 @@ class CliProjectPackagerTest {
     project2Dir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "project2"
-          baseUri = "package://localhost:0/project2"
-          version = "5.0.0"
-          packageZipUrl = "https://foo.com/project2.zip"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "project2"
+        baseUri = "package://localhost:0/project2"
+        version = "5.0.0"
+        packageZipUrl = "https://foo.com/project2.zip"
+      }
       """
         .trimIndent(),
     )
     project2Dir.writeFile(
       "PklProject.deps.json",
       """
-        {
-          "schemaVersion": 1,
-          "resolvedDependencies": {}
-        }
+      {
+        "schemaVersion": 1,
+        "resolvedDependencies": {}
+      }
       """
         .trimIndent(),
     )
@@ -557,18 +557,18 @@ class CliProjectPackagerTest {
     assertThat(project2Metadata.readString())
       .isEqualTo(
         """
-    {
-      "name": "project2",
-      "packageUri": "package://localhost:0/project2@5.0.0",
-      "version": "5.0.0",
-      "packageZipUrl": "https://foo.com/project2.zip",
-      "packageZipChecksums": {
-        "sha256": "8739c76e681f900923b900c9df0ef75cf421d39cabb54650c4b9ad19b6a76d85"
-      },
-      "dependencies": {},
-      "authors": []
-    }
-    """
+        {
+          "name": "project2",
+          "packageUri": "package://localhost:0/project2@5.0.0",
+          "version": "5.0.0",
+          "packageZipUrl": "https://foo.com/project2.zip",
+          "packageZipChecksums": {
+            "sha256": "8739c76e681f900923b900c9df0ef75cf421d39cabb54650c4b9ad19b6a76d85"
+          },
+          "dependencies": {},
+          "authors": []
+        }
+        """
           .trimIndent()
       )
   }
@@ -582,44 +582,44 @@ class CliProjectPackagerTest {
     projectDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "mypackage"
-          version = "1.0.0"
-          baseUri = "package://example.com/mypackage"
-          packageZipUrl = "https://foo.com"
+      amends "pkl:Project"
+
+      package {
+        name = "mypackage"
+        version = "1.0.0"
+        baseUri = "package://example.com/mypackage"
+        packageZipUrl = "https://foo.com"
+      }
+
+      dependencies {
+        ["birds"] {
+          uri = "package://localhost:0/birds@0.5.0"
         }
-        
-        dependencies {
-          ["birds"] {
-            uri = "package://localhost:0/birds@0.5.0"
-          }
-          ["project2"] = import("../project2/PklProject")
-        }
+        ["project2"] = import("../project2/PklProject")
+      }
       """
         .trimIndent(),
     )
     projectDir.writeFile(
       "PklProject.deps.json",
       """
-        {
-          "schemaVersion": 1,
-          "resolvedDependencies": {
-            "package://localhost:0/birds@0": {
-              "type": "remote",
-              "uri": "projectpackage://localhost:0/birds@0.5.0",
-              "checksums": {
-                "sha256": "0a5ad2dc13f06f73f96ba94e8d01d48252bc934e2de71a837620ca0fef8a7453"
-              }
-            },
-            "package://localhost:0/project2@5": {
-              "type": "local",
-              "uri": "projectpackage://localhost:0/project2@5.0.0",
-              "path": "../project2"
+      {
+        "schemaVersion": 1,
+        "resolvedDependencies": {
+          "package://localhost:0/birds@0": {
+            "type": "remote",
+            "uri": "projectpackage://localhost:0/birds@0.5.0",
+            "checksums": {
+              "sha256": "0a5ad2dc13f06f73f96ba94e8d01d48252bc934e2de71a837620ca0fef8a7453"
             }
+          },
+          "package://localhost:0/project2@5": {
+            "type": "local",
+            "uri": "projectpackage://localhost:0/project2@5.0.0",
+            "path": "../project2"
           }
         }
+      }
       """
         .trimIndent(),
     )
@@ -627,24 +627,24 @@ class CliProjectPackagerTest {
     project2Dir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "project2"
-          baseUri = "package://localhost:0/project2"
-          version = "5.0.0"
-          packageZipUrl = "https://foo.com/project2.zip"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "project2"
+        baseUri = "package://localhost:0/project2"
+        version = "5.0.0"
+        packageZipUrl = "https://foo.com/project2.zip"
+      }
       """
         .trimIndent(),
     )
     project2Dir.writeFile(
       "PklProject.deps.json",
       """
-        {
-          "schemaVersion": 1,
-          "resolvedDependencies": {}
-        }
+      {
+        "schemaVersion": 1,
+        "resolvedDependencies": {}
+      }
       """
         .trimIndent(),
     )
@@ -667,23 +667,23 @@ class CliProjectPackagerTest {
     tempDir.writeFile(
       "main.pkl",
       """
-        import "../foo.pkl"
-  
-        res = foo
+      import "../foo.pkl"
+
+      res = foo
       """
         .trimIndent(),
     )
     tempDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "mypackage"
-          version = "1.0.0"
-          baseUri = "package://example.com/mypackage"
-          packageZipUrl = "https://foo.com"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "mypackage"
+        version = "1.0.0"
+        baseUri = "package://example.com/mypackage"
+        packageZipUrl = "https://foo.com"
+      }
       """
         .trimIndent(),
     )
@@ -702,12 +702,12 @@ class CliProjectPackagerTest {
     assertThat(e.message)
       .startsWith(
         """
-      –– Pkl Error ––
-      Path `../foo.pkl` includes path segments that are outside the project root directory.
-      
-      1 | import "../foo.pkl"
-                 ^^^^^^^^^^^^
-    """
+        –– Pkl Error ––
+        Path `../foo.pkl` includes path segments that are outside the project root directory.
+
+        1 | import "../foo.pkl"
+                   ^^^^^^^^^^^^
+        """
           .trimIndent()
       )
   }
@@ -730,14 +730,14 @@ class CliProjectPackagerTest {
     tempDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "mypackage"
-          version = "1.0.0"
-          baseUri = "package://example.com/mypackage"
-          packageZipUrl = "https://foo.com"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "mypackage"
+        version = "1.0.0"
+        baseUri = "package://example.com/mypackage"
+        packageZipUrl = "https://foo.com"
+      }
       """
         .trimIndent(),
     )
@@ -776,14 +776,14 @@ class CliProjectPackagerTest {
     tempDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "mypackage"
-          version = "1.0.0"
-          baseUri = "package://example.com/mypackage"
-          packageZipUrl = "https://foo.com"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "mypackage"
+        version = "1.0.0"
+        baseUri = "package://example.com/mypackage"
+        packageZipUrl = "https://foo.com"
+      }
       """
         .trimIndent(),
     )
@@ -814,21 +814,21 @@ class CliProjectPackagerTest {
     tempDir.writeFile(
       "foo/bar.pkl",
       """
-        import "baz.pkl"
+      import "baz.pkl"
       """
         .trimIndent(),
     )
     tempDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "mypackage"
-          version = "1.0.0"
-          baseUri = "package://example.com/mypackage"
-          packageZipUrl = "https://foo.com"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "mypackage"
+        version = "1.0.0"
+        baseUri = "package://example.com/mypackage"
+        packageZipUrl = "https://foo.com"
+      }
       """
         .trimIndent(),
     )
@@ -849,14 +849,14 @@ class CliProjectPackagerTest {
     tempDir.writeFile(
       "project1/PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "project1"
-          version = "1.0.0"
-          baseUri = "package://example.com/project1"
-          packageZipUrl = "https://foo.com"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "project1"
+        version = "1.0.0"
+        baseUri = "package://example.com/project1"
+        packageZipUrl = "https://foo.com"
+      }
       """
         .trimIndent(),
     )
@@ -864,14 +864,14 @@ class CliProjectPackagerTest {
     tempDir.writeFile(
       "project2/PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "project2"
-          version = "2.0.0"
-          baseUri = "package://example.com/project2"
-          packageZipUrl = "https://foo.com"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "project2"
+        version = "2.0.0"
+        baseUri = "package://example.com/project2"
+        packageZipUrl = "https://foo.com"
+      }
       """
         .trimIndent(),
     )
@@ -914,14 +914,14 @@ class CliProjectPackagerTest {
       "project/PklProject",
       // intentionally conflict with localhost:0/birds@0.5.0 from our test fixtures
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "birds"
-          version = "0.5.0"
-          baseUri = "package://localhost:0/birds"
-          packageZipUrl = "https://foo.com"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "birds"
+        version = "0.5.0"
+        baseUri = "package://localhost:0/birds"
+        packageZipUrl = "https://foo.com"
+      }
       """
         .trimIndent(),
     )
@@ -959,14 +959,14 @@ class CliProjectPackagerTest {
     tempDir.writeFile(
       "project/PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "mangos"
-          version = "1.0.0"
-          baseUri = "package://localhost:0/mangos"
-          packageZipUrl = "https://foo.com"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "mangos"
+        version = "1.0.0"
+        baseUri = "package://localhost:0/mangos"
+        packageZipUrl = "https://foo.com"
+      }
       """
         .trimIndent(),
     )
@@ -1008,14 +1008,14 @@ class CliProjectPackagerTest {
         @Deprecated { since = "0.26.1"; message = "do not use" }
         @ModuleInfo { minPklVersion = "0.26.0" }
         amends "pkl:Project"
-        
+
         package {
           name = "mypackage"
           version = "1.0.0"
           baseUri = "package://example.com/mypackage"
           packageZipUrl = "https://foo.com"
         }
-      """
+        """
           .trimIndent()
       )
     val packager =
@@ -1033,53 +1033,53 @@ class CliProjectPackagerTest {
     assertThat(expectedMetadata)
       .hasContent(
         """
-      {
-        "name": "mypackage",
-        "packageUri": "package://example.com/mypackage@1.0.0",
-        "version": "1.0.0",
-        "packageZipUrl": "https://foo.com",
-        "packageZipChecksums": {
-          "sha256": "8739c76e681f900923b900c9df0ef75cf421d39cabb54650c4b9ad19b6a76d85"
-        },
-        "dependencies": {},
-        "authors": [],
-        "annotations": [
-          {
-            "type": "PObject",
-            "classInfo": {
-              "moduleName": "pkl.base",
-              "class": "Unlisted",
-              "moduleUri": "pkl:base"
-            },
-            "properties": {}
+        {
+          "name": "mypackage",
+          "packageUri": "package://example.com/mypackage@1.0.0",
+          "version": "1.0.0",
+          "packageZipUrl": "https://foo.com",
+          "packageZipChecksums": {
+            "sha256": "8739c76e681f900923b900c9df0ef75cf421d39cabb54650c4b9ad19b6a76d85"
           },
-          {
-            "type": "PObject",
-            "classInfo": {
-              "moduleName": "pkl.base",
-              "class": "Deprecated",
-              "moduleUri": "pkl:base"
+          "dependencies": {},
+          "authors": [],
+          "annotations": [
+            {
+              "type": "PObject",
+              "classInfo": {
+                "moduleName": "pkl.base",
+                "class": "Unlisted",
+                "moduleUri": "pkl:base"
+              },
+              "properties": {}
             },
-            "properties": {
-              "since": "0.26.1",
-              "message": "do not use",
-              "replaceWith": null
-            }
-          },
-          {
-            "type": "PObject",
-            "classInfo": {
-              "moduleName": "pkl.base",
-              "class": "ModuleInfo",
-              "moduleUri": "pkl:base"
+            {
+              "type": "PObject",
+              "classInfo": {
+                "moduleName": "pkl.base",
+                "class": "Deprecated",
+                "moduleUri": "pkl:base"
+              },
+              "properties": {
+                "since": "0.26.1",
+                "message": "do not use",
+                "replaceWith": null
+              }
             },
-            "properties": {
-              "minPklVersion": "0.26.0"
+            {
+              "type": "PObject",
+              "classInfo": {
+                "moduleName": "pkl.base",
+                "class": "ModuleInfo",
+                "moduleUri": "pkl:base"
+              },
+              "properties": {
+                "minPklVersion": "0.26.0"
+              }
             }
-          }
-        ]
-      }
-    """
+          ]
+        }
+        """
           .trimIndent()
       )
   }

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliProjectResolverTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliProjectResolverTest.kt
@@ -74,13 +74,13 @@ class CliProjectResolverTest {
     tempDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
+      amends "pkl:Project"
 
-        dependencies {
-          ["birds"] {
-            uri = "package://localhost:0/birds@0.5.0"
-          }
+      dependencies {
+        ["birds"] {
+          uri = "package://localhost:0/birds@0.5.0"
         }
+      }
       """
         .trimIndent(),
     )
@@ -129,13 +129,13 @@ class CliProjectResolverTest {
     tempDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
+      amends "pkl:Project"
 
-        dependencies {
-          ["birds"] {
-            uri = "package://localhost:0/birds@0.5.0"
-          }
+      dependencies {
+        ["birds"] {
+          uri = "package://localhost:0/birds@0.5.0"
         }
+      }
       """
         .trimIndent(),
     )
@@ -185,35 +185,35 @@ class CliProjectResolverTest {
     projectDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
+      amends "pkl:Project"
 
-        dependencies {
-          ["birds"] {
-            uri = "package://localhost:0/birds@0.5.0"
-          }
-          ["project2"] = import("../project2/PklProject")
+      dependencies {
+        ["birds"] {
+          uri = "package://localhost:0/birds@0.5.0"
         }
+        ["project2"] = import("../project2/PklProject")
+      }
       """
         .trimIndent(),
     )
     projectDir.writeFile(
       "../project2/PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "project2"
-          baseUri = "package://localhost:0/package2"
-          version = "5.0.0"
-          packageZipUrl = "https://foo.com/package2.zip"
+      amends "pkl:Project"
+
+      package {
+        name = "project2"
+        baseUri = "package://localhost:0/package2"
+        version = "5.0.0"
+        packageZipUrl = "https://foo.com/package2.zip"
+      }
+
+      dependencies {
+        ["fruit"] {
+          uri = "package://localhost:0/fruit@1.0.5"
         }
-        
-        dependencies {
-          ["fruit"] {
-            uri = "package://localhost:0/fruit@1.0.5"
-          }
-          ["project3"] = import("../project3/PklProject")
-        }
+        ["project3"] = import("../project3/PklProject")
+      }
       """
         .trimIndent(),
     )
@@ -221,20 +221,20 @@ class CliProjectResolverTest {
     projectDir.writeFile(
       "../project3/PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "project3"
-          baseUri = "package://localhost:0/package3"
-          version = "5.0.0"
-          packageZipUrl = "https://foo.com/package3.zip"
+      amends "pkl:Project"
+
+      package {
+        name = "project3"
+        baseUri = "package://localhost:0/package3"
+        version = "5.0.0"
+        packageZipUrl = "https://foo.com/package3.zip"
+      }
+
+      dependencies {
+        ["fruit"] {
+          uri = "package://localhost:0/fruit@1.1.0"
         }
-        
-        dependencies {
-          ["fruit"] {
-            uri = "package://localhost:0/fruit@1.1.0"
-          }
-        }
+      }
       """
         .trimIndent(),
     )
@@ -293,28 +293,28 @@ class CliProjectResolverTest {
     projectDir.writeFile(
       "PklProject",
       """
-        amends "pkl:Project"
+      amends "pkl:Project"
 
-        dependencies {
-          ["birds"] {
-            uri = "package://localhost:0/birds@0.5.0"
-          }
-          ["fruit"] = import("../fruit/PklProject")
+      dependencies {
+        ["birds"] {
+          uri = "package://localhost:0/birds@0.5.0"
         }
+        ["fruit"] = import("../fruit/PklProject")
+      }
       """
         .trimIndent(),
     )
     projectDir.writeFile(
       "../fruit/PklProject",
       """
-        amends "pkl:Project"
-        
-        package {
-          name = "fruit"
-          baseUri = "package://localhost:0/fruit"
-          version = "1.0.0"
-          packageZipUrl = "https://foo.com/fruit.zip"
-        }
+      amends "pkl:Project"
+
+      package {
+        name = "fruit"
+        baseUri = "package://localhost:0/fruit"
+        version = "1.0.0"
+        packageZipUrl = "https://foo.com/fruit.zip"
+      }
       """
         .trimIndent(),
     )
@@ -375,7 +375,7 @@ class CliProjectResolverTest {
           uri = "package://localhost:0/birds@0.5.0"
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -389,7 +389,7 @@ class CliProjectResolverTest {
           uri = "package://localhost:0/fruit@1.1.0"
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -469,14 +469,14 @@ class CliProjectResolverTest {
       .resolve("PklProject")
       .writeString(
         """
-      amends "pkl:Project"
+        amends "pkl:Project"
 
-      dependencies {
-        ["birds"] {
-          uri = "package://localhost:0/birds@0.5.0"
+        dependencies {
+          ["birds"] {
+            uri = "package://localhost:0/birds@0.5.0"
+          }
         }
-      }
-    """
+        """
           .trimIndent()
       )
     // coerce an IOException by making this a directory

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/CliTestRunnerTest.kt
@@ -47,7 +47,7 @@ class CliTestRunnerTest {
           3 == 3
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     val out = StringWriter()
@@ -65,13 +65,13 @@ class CliTestRunnerTest {
     assertThat(out.toString().stripFileAndLines(tempDir))
       .isEqualTo(
         """
-      module test
-        facts
-          ✔ succeed
-      
-      100.0% tests pass [1 passed], 100.0% asserts pass [2 passed]
+        module test
+          facts
+            ✔ succeed
 
-    """
+        100.0% tests pass [1 passed], 100.0% asserts pass [2 passed]
+
+        """
           .trimIndent()
       )
     assertThat(err.toString()).isEqualTo("")
@@ -89,7 +89,7 @@ class CliTestRunnerTest {
           1 == 5
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     val out = StringWriter()
@@ -136,7 +136,7 @@ class CliTestRunnerTest {
           throw("uh oh")
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     val out = StringWriter()
@@ -154,19 +154,19 @@ class CliTestRunnerTest {
     assertThat(out.toString().stripFileAndLines(tempDir))
       .isEqualToNormalizingNewlines(
         """
-      module test
-        facts
-          ✘ fail
-             –– Pkl Error ––
-             uh oh
+        module test
+          facts
+            ✘ fail
+               –– Pkl Error ––
+               uh oh
 
-             5 | throw("uh oh")
-                 ^^^^^^^^^^^^^^
-             at test#facts["fail"][#1] (/tempDir/test.pkl, line xx)
+               5 | throw("uh oh")
+                   ^^^^^^^^^^^^^^
+               at test#facts["fail"][#1] (/tempDir/test.pkl, line xx)
 
-      0.0% tests pass [1/1 failed], 0.0% asserts pass [1/1 failed]
+        0.0% tests pass [1/1 failed], 0.0% asserts pass [1/1 failed]
 
-    """
+        """
           .trimIndent()
       )
     assertThat(err.toString()).isEqualTo("")
@@ -183,7 +183,7 @@ class CliTestRunnerTest {
           throw("uh oh")
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     val out = StringWriter()
@@ -201,19 +201,19 @@ class CliTestRunnerTest {
     assertThat(out.toString().stripFileAndLines(tempDir))
       .isEqualTo(
         """
-      module test
-        examples
-          ✘ fail
-             –– Pkl Error ––
-             uh oh
+        module test
+          examples
+            ✘ fail
+               –– Pkl Error ––
+               uh oh
 
-             5 | throw("uh oh")
-                 ^^^^^^^^^^^^^^
-             at test#examples["fail"][#1] (/tempDir/test.pkl, line xx)
+               5 | throw("uh oh")
+                   ^^^^^^^^^^^^^^
+               at test#examples["fail"][#1] (/tempDir/test.pkl, line xx)
 
-      0.0% tests pass [1/1 failed], 0.0% asserts pass [1/1 failed]
+        0.0% tests pass [1/1 failed], 0.0% asserts pass [1/1 failed]
 
-    """
+        """
           .trimIndent()
       )
     assertThat(err.toString()).isEqualTo("")
@@ -232,19 +232,19 @@ class CliTestRunnerTest {
           throw("uh oh")
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     tempDir
       .resolve("test.pkl-expected.pcf")
       .writeString(
         """
-      examples {
-        ["fail"] {
-          "never compared to"
+        examples {
+          ["fail"] {
+            "never compared to"
+          }
         }
-      }
-    """
+        """
           .trimIndent()
       )
     val out = StringWriter()
@@ -262,19 +262,19 @@ class CliTestRunnerTest {
     assertThat(out.toString().stripFileAndLines(tempDir))
       .isEqualToNormalizingNewlines(
         """
-      module test
-        examples
-          ✘ fail
-             –– Pkl Error ––
-             uh oh
-      
-             5 | throw("uh oh")
-                 ^^^^^^^^^^^^^^
-             at test#examples["fail"][#1] (/tempDir/test.pkl, line xx)
+        module test
+          examples
+            ✘ fail
+               –– Pkl Error ––
+               uh oh
 
-      0.0% tests pass [1/1 failed], 0.0% asserts pass [1/1 failed]
+               5 | throw("uh oh")
+                   ^^^^^^^^^^^^^^
+               at test#examples["fail"][#1] (/tempDir/test.pkl, line xx)
 
-    """
+        0.0% tests pass [1/1 failed], 0.0% asserts pass [1/1 failed]
+
+        """
           .trimIndent()
       )
     assertThat(err.toString()).isEqualTo("")
@@ -296,7 +296,7 @@ class CliTestRunnerTest {
           5 == 9
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     val noopWriter = noopWriter()
@@ -314,19 +314,19 @@ class CliTestRunnerTest {
     assertThat(junitReport)
       .isEqualTo(
         """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <testsuite name="test" tests="2" failures="1">
-          <testcase classname="test.facts" name="foo"></testcase>
-          <testcase classname="test.facts" name="bar">
-              <failure message="Fact Failure">5 == 9 (/tempDir/test.pkl, line xx)
-        │
-        false</failure>
-          </testcase>
-          <system-err><![CDATA[9 = 9
-      ]]></system-err>
-      </testsuite>
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuite name="test" tests="2" failures="1">
+            <testcase classname="test.facts" name="foo"></testcase>
+            <testcase classname="test.facts" name="bar">
+                <failure message="Fact Failure">5 == 9 (/tempDir/test.pkl, line xx)
+          │
+          false</failure>
+            </testcase>
+            <system-err><![CDATA[9 = 9
+        ]]></system-err>
+        </testsuite>
 
-    """
+        """
           .trimIndent()
       )
   }
@@ -346,7 +346,7 @@ class CliTestRunnerTest {
           throw("uh oh")
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     val noopWriter = noopWriter()
@@ -364,23 +364,23 @@ class CliTestRunnerTest {
     assertThat(junitReport)
       .isEqualTo(
         """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <testsuite name="test" tests="2" failures="1">
-          <testcase classname="test.facts" name="foo"></testcase>
-          <testcase classname="test.facts" name="fail">
-              <error message="uh oh">–– Pkl Error ––
-      uh oh
-      
-      9 | throw(&quot;uh oh&quot;)
-          ^^^^^^^^^^^^^^
-      at test#facts[&quot;fail&quot;][#1] (/tempDir/test.pkl, line xx)
-      </error>
-          </testcase>
-          <system-err><![CDATA[9 = 9
-      ]]></system-err>
-      </testsuite>
-      
-    """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuite name="test" tests="2" failures="1">
+            <testcase classname="test.facts" name="foo"></testcase>
+            <testcase classname="test.facts" name="fail">
+                <error message="uh oh">–– Pkl Error ––
+        uh oh
+
+        9 | throw(&quot;uh oh&quot;)
+            ^^^^^^^^^^^^^^
+        at test#facts[&quot;fail&quot;][#1] (/tempDir/test.pkl, line xx)
+        </error>
+            </testcase>
+            <system-err><![CDATA[9 = 9
+        ]]></system-err>
+        </testsuite>
+
+        """
           .trimIndent()
       )
   }
@@ -390,7 +390,7 @@ class CliTestRunnerTest {
     val foo =
       """
       module foo
-      
+
       amends "pkl:test"
 
       facts {
@@ -398,13 +398,13 @@ class CliTestRunnerTest {
           1 == 1
         }
       }
-    """
+      """
         .trimIndent()
 
     val bar =
       """
       module foo
-      
+
       amends "pkl:test"
 
       facts {
@@ -412,7 +412,7 @@ class CliTestRunnerTest {
           1 == 1
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(foo).toString()
     val input2 = tempDir.resolve("test.pkl").writeString(bar).toString()
@@ -438,7 +438,7 @@ class CliTestRunnerTest {
           true
         }
       }
-    """
+      """
         .trimIndent()
 
     val code2 =
@@ -450,7 +450,7 @@ class CliTestRunnerTest {
           true
         }
       }
-    """
+      """
         .trimIndent()
     val input1 = tempDir.resolve("test1.pkl").writeString(code1).toString()
     val input2 = tempDir.resolve("test2.pkl").writeString(code2).toString()
@@ -482,7 +482,7 @@ class CliTestRunnerTest {
           5 == 9
         }
       }
-    """
+      """
         .trimIndent()
 
     val code2 =
@@ -500,7 +500,7 @@ class CliTestRunnerTest {
           true
         }
       }
-    """
+      """
         .trimIndent()
     val input1 = tempDir.resolve("test1.pkl").writeString(code1).toString()
     val input2 = tempDir.resolve("test2.pkl").writeString(code2).toString()
@@ -547,7 +547,7 @@ class CliTestRunnerTest {
             </testsuite>
         </testsuites>
 
-      """
+        """
           .trimIndent()
       )
   }
@@ -563,7 +563,7 @@ class CliTestRunnerTest {
           true
         }
       }
-    """
+      """
         .trimIndent()
 
     val code2 =
@@ -575,7 +575,7 @@ class CliTestRunnerTest {
           true
         }
       }
-    """
+      """
         .trimIndent()
     val input1 = tempDir.resolve("test1.pkl").writeString(code1).toString()
     val input2 = tempDir.resolve("test2.pkl").writeString(code2).toString()
@@ -620,19 +620,19 @@ class CliTestRunnerTest {
           2
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     tempDir
       .resolve("test.pkl-expected.pcf")
       .writeString(
         """
-      examples {
-        ["nums"] {
-          1
+        examples {
+          ["nums"] {
+            1
+          }
         }
-      }
-    """
+        """
           .trimIndent()
       )
     val out = StringWriter()
@@ -676,7 +676,7 @@ class CliTestRunnerTest {
           2
         }
       }
-    """
+      """
         .trimIndent()
     val input = tempDir.resolve("test.pkl").writeString(code).toString()
     val out = StringWriter()
@@ -694,13 +694,13 @@ class CliTestRunnerTest {
     assertThat(out.toString())
       .isEqualTo(
         """
-          module test
-            examples
-              ✍️ nums
+        module test
+          examples
+            ✍️ nums
 
-          1 examples written
-          
-          """
+        1 examples written
+
+        """
           .trimIndent()
       )
   }
@@ -738,13 +738,13 @@ class CliTestRunnerTest {
       assertThat(out.toString().stripFileAndLines(tempDir))
         .isEqualTo(
           """
-            module test
-              facts
-                ✔ localeTest
+          module test
+            facts
+              ✔ localeTest
 
-            100.0% tests pass [1 passed], 100.0% asserts pass [1 passed]
+          100.0% tests pass [1 passed], 100.0% asserts pass [1 passed]
 
-            """
+          """
             .trimIndent()
         )
       assertThat(err.toString()).isEqualTo("")

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,10 +102,10 @@ class PklJavaCodegenCommand : ModulesCommand(name = "pkl-codegen-java", helpLink
       names = arrayOf("--non-null-annotation"),
       help =
         """
-      Fully qualified name of the annotation type to use for annotating non-null types.
-      The specified annotation type must be annotated with `@java.lang.annotation.Target(ElementType.TYPE_USE)`
-      or the generated code may not compile.
-    """
+        Fully qualified name of the annotation type to use for annotating non-null types.
+        The specified annotation type must be annotated with `@java.lang.annotation.Target(ElementType.TYPE_USE)`
+        or the generated code may not compile.
+        """
           .trimIndent(),
     )
 
@@ -122,10 +122,10 @@ class PklJavaCodegenCommand : ModulesCommand(name = "pkl-codegen-java", helpLink
         metavar = "old_name=new_name",
         help =
           """
-            Replace a prefix in the names of the generated Java classes (repeatable).
-            By default, the names of generated classes are derived from the Pkl module names.
-            With this option, you can override or modify the default names, renaming entire
-            classes or just their packages.
+          Replace a prefix in the names of the generated Java classes (repeatable).
+          By default, the names of generated classes are derived from the Pkl module names.
+          With this option, you can override or modify the default names, renaming entire
+          classes or just their packages.
           """
             .trimIndent(),
       )

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
@@ -41,13 +41,13 @@ class JavaCodeGeneratorTest {
     private val simpleClass: Class<*> by lazy {
       generateJavaCode(
           """
-        module my.mod
+          module my.mod
 
-        class Simple {
-          str: String
-          list: List<Int>
-        }
-      """
+          class Simple {
+            str: String
+            list: List<Int>
+          }
+          """
             .trimIndent()
         )
         .compile()
@@ -205,7 +205,7 @@ class JavaCodeGeneratorTest {
           _enum = north
           bytes = [1, 2, 3, 4]
         }
-      """
+        """
           .trimIndent()
       )
   }
@@ -215,11 +215,11 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      class ClassWithDeprecatedProperty {
-         @Deprecated { message = "property deprecation message" } 
-         deprecatedProperty: Int = 1337
-      }
-    """
+        class ClassWithDeprecatedProperty {
+           @Deprecated { message = "property deprecation message" } 
+           deprecatedProperty: Int = 1337
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateJavadoc = true),
       )
@@ -232,7 +232,7 @@ class JavaCodeGeneratorTest {
         |     */
         |    @Deprecated
         |    public final long deprecatedProperty;
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -244,7 +244,7 @@ class JavaCodeGeneratorTest {
         |    public ClassWithDeprecatedProperty withDeprecatedProperty(long deprecatedProperty) {
         |      return new ClassWithDeprecatedProperty(deprecatedProperty);
         |    }
-      """
+        """
           .trimMargin()
       )
   }
@@ -254,11 +254,11 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      class ClassWithDeprecatedProperty {
-         @Deprecated { message = "property deprecation message" } 
-         deprecatedProperty: Int = 1337
-      }
-    """
+        class ClassWithDeprecatedProperty {
+           @Deprecated { message = "property deprecation message" } 
+           deprecatedProperty: Int = 1337
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateGetters = true, generateJavadoc = true),
       )
@@ -267,7 +267,7 @@ class JavaCodeGeneratorTest {
         """
         |  public static final class ClassWithDeprecatedProperty {
         |    private final long deprecatedProperty;
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -279,7 +279,7 @@ class JavaCodeGeneratorTest {
         |    public long getDeprecatedProperty() {
         |      return deprecatedProperty;
         |    }
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -291,7 +291,7 @@ class JavaCodeGeneratorTest {
         |    public ClassWithDeprecatedProperty withDeprecatedProperty(long deprecatedProperty) {
         |      return new ClassWithDeprecatedProperty(deprecatedProperty);
         |    }
-      """
+        """
           .trimMargin()
       )
   }
@@ -301,23 +301,23 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      @Deprecated { message = "class deprecation message" }
-      class DeprecatedClass {
-        propertyOfDeprecatedClass: Int = 42
-      }
-    """
+        @Deprecated { message = "class deprecation message" }
+        class DeprecatedClass {
+          propertyOfDeprecatedClass: Int = 42
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateJavadoc = true),
       )
     assertThat(javaCode)
       .contains(
         """
-      |  /**
-      |   * @deprecated class deprecation message
-      |   */
-      |  @Deprecated
-      |  public static final class DeprecatedClass {
-    """
+        |  /**
+        |   * @deprecated class deprecation message
+        |   */
+        |  @Deprecated
+        |  public static final class DeprecatedClass {
+        """
           .trimMargin()
       )
   }
@@ -328,11 +328,11 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      @Deprecated{ message = "module class deprecation message" }
-      module DeprecatedModule
-      
-      propertyInDeprecatedModuleClass : Int = 42
-    """
+        @Deprecated{ message = "module class deprecation message" }
+        module DeprecatedModule
+
+        propertyInDeprecatedModuleClass : Int = 42
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateJavadoc = generateJavadoc),
       )
@@ -340,9 +340,9 @@ class JavaCodeGeneratorTest {
     assertThat(javaCode)
       .contains(
         """
-      |@Deprecated
-      |public final class DeprecatedModule {
-    """
+        |@Deprecated
+        |public final class DeprecatedModule {
+        """
           .trimMargin()
       )
 
@@ -350,10 +350,10 @@ class JavaCodeGeneratorTest {
       assertThat(javaCode)
         .contains(
           """
-        |/**
-        | * @deprecated module class deprecation message
-        | */
-      """
+          |/**
+          | * @deprecated module class deprecation message
+          | */
+          """
             .trimMargin()
         )
     } else {
@@ -367,11 +367,11 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      class ClassWithDeprecatedProperty {
-         @Deprecated
-         deprecatedProperty: Int = 1337
-      }
-    """
+        class ClassWithDeprecatedProperty {
+           @Deprecated
+           deprecatedProperty: Int = 1337
+        }
+        """
           .trimIndent(),
         // no message, so no Javadoc, regardless of flag
         JavaCodeGeneratorOptions(generateJavadoc = generateJavadoc),
@@ -383,7 +383,7 @@ class JavaCodeGeneratorTest {
         |  public static final class ClassWithDeprecatedProperty {
         |    @Deprecated
         |    public final long deprecatedProperty;
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -392,7 +392,7 @@ class JavaCodeGeneratorTest {
         |    public ClassWithDeprecatedProperty withDeprecatedProperty(long deprecatedProperty) {
         |      return new ClassWithDeprecatedProperty(deprecatedProperty);
         |    }
-      """
+        """
           .trimMargin()
       )
       .doesNotContain("* @deprecated")
@@ -407,7 +407,7 @@ class JavaCodeGeneratorTest {
            @Deprecated
            deprecatedProperty: Int = 1337
         }
-      """
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateGetters = true),
       )
@@ -417,7 +417,7 @@ class JavaCodeGeneratorTest {
         """
         |  public static final class ClassWithDeprecatedProperty {
         |    private final long deprecatedProperty;
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -426,7 +426,7 @@ class JavaCodeGeneratorTest {
         |    public long getDeprecatedProperty() {
         |      return deprecatedProperty;
         |    }
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -435,7 +435,7 @@ class JavaCodeGeneratorTest {
         |    public ClassWithDeprecatedProperty withDeprecatedProperty(long deprecatedProperty) {
         |      return new ClassWithDeprecatedProperty(deprecatedProperty);
         |    }
-      """
+        """
           .trimMargin()
       )
       .doesNotContain("* @deprecated")
@@ -446,11 +446,11 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      @Deprecated
-      class DeprecatedClass {
-        propertyOfDeprecatedClass: Int = 42
-      }
-    """
+        @Deprecated
+        class DeprecatedClass {
+          propertyOfDeprecatedClass: Int = 42
+        }
+        """
           .trimIndent()
       )
 
@@ -459,7 +459,7 @@ class JavaCodeGeneratorTest {
         """
         |  @Deprecated
         |  public static final class DeprecatedClass {
-      """
+        """
           .trimMargin()
       )
       .doesNotContain("* @deprecated")
@@ -470,11 +470,11 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      @Deprecated
-      module DeprecatedModule
-      
-      propertyInDeprecatedModuleClass : Int = 42
-    """
+        @Deprecated
+        module DeprecatedModule
+
+        propertyInDeprecatedModuleClass : Int = 42
+        """
           .trimIndent()
       )
 
@@ -483,7 +483,7 @@ class JavaCodeGeneratorTest {
         """
         |@Deprecated
         |public final class DeprecatedModule {
-      """
+        """
           .trimMargin()
       )
       .doesNotContain("* @deprecated")
@@ -511,7 +511,7 @@ class JavaCodeGeneratorTest {
         |   */
         |  @Deprecated
         |  public final long deprecatedProperty;
-      """
+        """
           .trimMargin()
       )
   }
@@ -606,9 +606,9 @@ class JavaCodeGeneratorTest {
       assertThrows<JavaCodeGeneratorException> {
         generateJavaCode(
           """
-        module my.mod
-        typealias MyTypeAlias = "foo-bar" | "foo bar"
-      """
+          module my.mod
+          typealias MyTypeAlias = "foo-bar" | "foo bar"
+          """
             .trimIndent()
         )
       }
@@ -623,9 +623,9 @@ class JavaCodeGeneratorTest {
       assertThrows<JavaCodeGeneratorException> {
         generateJavaCode(
           """
-        module my.mod
-        typealias MyTypeAlias = "foo" | "" | "bar"
-      """
+          module my.mod
+          typealias MyTypeAlias = "foo" | "" | "bar"
+          """
             .trimIndent()
         )
       }
@@ -639,9 +639,9 @@ class JavaCodeGeneratorTest {
       assertThrows<JavaCodeGeneratorException> {
         generateJavaCode(
           """
-        module my.mod
-        typealias MyTypeAlias = "foo" | "✅" | "bar"
-      """
+          module my.mod
+          typealias MyTypeAlias = "foo" | "✅" | "bar"
+          """
             .trimIndent()
         )
       }
@@ -653,17 +653,17 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      class Foo {
-        other: Int
-        bar: Bar
-      }
-      class Bar {
-        foo: Foo
-        other: String
-      }
-    """
+        class Foo {
+          other: Int
+          bar: Bar
+        }
+        class Bar {
+          foo: Foo
+          other: String
+        }
+        """
           .trimIndent()
       )
 
@@ -680,7 +680,7 @@ class JavaCodeGeneratorTest {
         |      this.other = other;
         |      this.bar = bar;
         |    }
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -694,7 +694,7 @@ class JavaCodeGeneratorTest {
         |      this.foo = foo;
         |      this.other = other;
         |    }
-      """
+        """
           .trimMargin()
       )
   }
@@ -704,19 +704,19 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      abstract class Foo {
-        one: Int
-      }
-      open class None extends Foo {}
-      open class Bar extends None {
-        two: String?
-      }
-      class Baz extends Bar {
-        three: Duration
-      }
-    """
+        abstract class Foo {
+          one: Int
+        }
+        open class None extends Foo {}
+        open class Bar extends None {
+          two: String?
+        }
+        class Baz extends Bar {
+          three: Duration
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateGetters = true),
       )
@@ -731,7 +731,7 @@ class JavaCodeGeneratorTest {
         |    protected Foo(@Named("one") long one) {
         |      this.one = one;
         |    }
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -740,7 +740,7 @@ class JavaCodeGeneratorTest {
         |    public None(@Named("one") long one) {
         |      super(one);
         |    }
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -752,7 +752,7 @@ class JavaCodeGeneratorTest {
         |      super(one);
         |      this.two = two;
         |    }
-      """
+        """
           .trimMargin()
       )
       .isEqualToResourceFile("Inheritance.jva")
@@ -763,12 +763,12 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      class Foo
-      abstract class Bar
-      class Baz extends Bar
-    """
+        class Foo
+        abstract class Bar
+        class Baz extends Bar
+        """
           .trimIndent()
       )
 
@@ -778,7 +778,7 @@ class JavaCodeGeneratorTest {
         |  public static final class Foo {
         |    public Foo() {
         |    }
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -786,7 +786,7 @@ class JavaCodeGeneratorTest {
         |  public abstract static class Bar {
         |    protected Bar() {
         |    }
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -794,7 +794,7 @@ class JavaCodeGeneratorTest {
         |  public static final class Baz extends Bar {
         |    public Baz() {
         |    }
-      """
+        """
           .trimMargin()
       )
   }
@@ -808,7 +808,7 @@ class JavaCodeGeneratorTest {
         |public final class Mod {
         |  private Mod() {
         |  }
-      """
+        """
           .trimMargin()
       )
 
@@ -816,10 +816,10 @@ class JavaCodeGeneratorTest {
     assertThat(javaCode)
       .contains(
         """
-      |public abstract class Mod {
-      |  protected Mod() {
-      |  }
-    """
+        |public abstract class Mod {
+        |  protected Mod() {
+        |  }
+        """
           .trimMargin()
       )
 
@@ -827,10 +827,10 @@ class JavaCodeGeneratorTest {
     assertThat(javaCode)
       .contains(
         """
-      |public class Mod {
-      |  public Mod() {
-      |  }
-    """
+        |public class Mod {
+        |  public Mod() {
+        |  }
+        """
           .trimMargin()
       )
   }
@@ -861,12 +861,12 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      class GeneratedAnnotation {
-        test: Boolean = true
-      }
-    """
+        class GeneratedAnnotation {
+          test: Boolean = true
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(addGeneratedAnnotation = true),
       )
@@ -879,16 +879,16 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      class GenerateGetters {
-        urgent: Boolean = true
-        url: String = "https://apple.com"
-        diskSize: DataSize = 4.mb
-        ETA: Duration = 3.s
-        package: String
-      }
-    """
+        class GenerateGetters {
+          urgent: Boolean = true
+          url: String = "https://apple.com"
+          diskSize: DataSize = 4.mb
+          ETA: Duration = 3.s
+          package: String
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateGetters = true),
       )
@@ -919,7 +919,7 @@ class JavaCodeGeneratorTest {
         |    public Bar withX(long x) {
         |      return new Bar(x, y);
         |    }
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -927,7 +927,7 @@ class JavaCodeGeneratorTest {
         |    public Bar withY(@NonNull String y) {
         |      return new Bar(x, y);
         |    }
-      """
+        """
           .trimMargin()
       )
       .doesNotContain("public Foo withX") // because `Foo` is abstract
@@ -938,22 +938,22 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
-      
-      pigeon: String
-      parrot: String
-    """
+        module my.mod
+
+        pigeon: String
+        parrot: String
+        """
           .trimIndent()
       )
 
     assertThat(javaCode)
       .contains(
         """
-      |public final class Mod {
-      |  public final @NonNull String pigeon;
-      |
-      |  public final @NonNull String parrot;
-    """
+        |public final class Mod {
+        |  public final @NonNull String pigeon;
+        |
+        |  public final @NonNull String parrot;
+        """
           .trimMargin()
       )
   }
@@ -963,14 +963,14 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      hidden pigeon1: String
-      parrot1: String
+        hidden pigeon1: String
+        parrot1: String
 
-      class Persons {
-        hidden pigeon2: String
-        parrot2: String
-      }
-    """
+        class Persons {
+          hidden pigeon2: String
+          parrot2: String
+        }
+        """
           .trimIndent()
       )
 
@@ -986,22 +986,22 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      /// module comment.
-      /// *emphasized* `code`.
-      module my.mod
-
-      /// module property comment.
-      /// *emphasized* `code`.
-      pigeon: Person
-
-      /// class comment.
-      /// *emphasized* `code`.
-      class Person {
-        /// class property comment.
+        /// module comment.
         /// *emphasized* `code`.
-        name: String
-      }
-    """
+        module my.mod
+
+        /// module property comment.
+        /// *emphasized* `code`.
+        pigeon: Person
+
+        /// class comment.
+        /// *emphasized* `code`.
+        class Person {
+          /// class property comment.
+          /// *emphasized* `code`.
+          name: String
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateJavadoc = true),
       )
@@ -1014,18 +1014,18 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      /// module property comment.
-      /// can contain /* and */ characters.
-      pigeon: Person
-
-      class Person {
-        /// class property comment.
+        /// module property comment.
         /// can contain /* and */ characters.
-        name: String
-      }
-    """
+        pigeon: Person
+
+        class Person {
+          /// class property comment.
+          /// can contain /* and */ characters.
+          name: String
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateGetters = true, generateJavadoc = true),
       )
@@ -1039,7 +1039,7 @@ class JavaCodeGeneratorTest {
         |   * can contain /* and *&#47; characters.
         |   */
         |  public @NonNull Person getPigeon() {
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -1049,7 +1049,7 @@ class JavaCodeGeneratorTest {
         |     * can contain /* and *&#47; characters.
         |     */
         |    public @NonNull String getName() {
-      """
+        """
           .trimMargin()
       )
   }
@@ -1059,26 +1059,8 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module mod
+        module mod
 
-      uint8: UInt8
-      uint16: UInt16
-      uint32: UInt32
-      uint: UInt
-      int8: Int8
-      int16: Int16
-      int32: Int32
-      uri: Uri
-
-      pair: Pair<UInt8, UInt16>
-      list: List<UInt32>
-      set: Set<UInt>
-      map: Map<Int8, Int16>
-      listing: Listing<Int32>
-      mapping: Mapping<Uri, UInt8>
-      nullable: UInt16?
-
-      class Foo {
         uint8: UInt8
         uint16: UInt16
         uint32: UInt32
@@ -1087,9 +1069,27 @@ class JavaCodeGeneratorTest {
         int16: Int16
         int32: Int32
         uri: Uri
-        list: List<UInt>
-      }
-    """
+
+        pair: Pair<UInt8, UInt16>
+        list: List<UInt32>
+        set: Set<UInt>
+        map: Map<Int8, Int16>
+        listing: Listing<Int32>
+        mapping: Mapping<Uri, UInt8>
+        nullable: UInt16?
+
+        class Foo {
+          uint8: UInt8
+          uint16: UInt16
+          uint32: UInt32
+          uint: UInt
+          int8: Int8
+          int16: Int16
+          int32: Int32
+          uri: Uri
+          list: List<UInt>
+        }
+        """
           .trimIndent()
       )
 
@@ -1113,7 +1113,7 @@ class JavaCodeGeneratorTest {
         |  public final int int32;
         |
         |  public final @NonNull URI uri;
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -1131,7 +1131,7 @@ class JavaCodeGeneratorTest {
         |  public final @NonNull Map<@NonNull URI, @NonNull Short> mapping;
         |
         |  public final Integer nullable;
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -1154,7 +1154,7 @@ class JavaCodeGeneratorTest {
         |    public final @NonNull URI uri;
         |
         |    public final @NonNull List<@NonNull Long> list;
-      """
+        """
           .trimMargin()
       )
   }
@@ -1164,10 +1164,10 @@ class JavaCodeGeneratorTest {
     var javaCode =
       generateJavaCode(
         """
-      module mod
-      
-      foo: String
-    """
+        module mod
+
+        foo: String
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(nonNullAnnotation = "com.example.Annotations\$NonNull"),
       )
@@ -1179,40 +1179,40 @@ class JavaCodeGeneratorTest {
     javaCode =
       generateJavaCode(
         """
-      module mod
-      
-      foo: Int
-      bar: Int?
-      baz: Any
-      qux: String
-      foo2: List<String>?
-      bar2: List<String?>
-      baz2: List<String>
-      qux2: List<Int>
-    """
+        module mod
+
+        foo: Int
+        bar: Int?
+        baz: Any
+        qux: String
+        foo2: List<String>?
+        bar2: List<String?>
+        baz2: List<String>
+        qux2: List<Int>
+        """
           .trimIndent()
       )
 
     assertThat(javaCode)
       .contains(
         """
-      |public final class Mod {
-      |  public final long foo;
-      |
-      |  public final Long bar;
-      |
-      |  public final Object baz;
-      |
-      |  public final @NonNull String qux;
-      |
-      |  public final List<@NonNull String> foo2;
-      |
-      |  public final @NonNull List<String> bar2;
-      |
-      |  public final @NonNull List<@NonNull String> baz2;
-      |
-      |  public final @NonNull List<@NonNull Long> qux2;
-    """
+        |public final class Mod {
+        |  public final long foo;
+        |
+        |  public final Long bar;
+        |
+        |  public final Object baz;
+        |
+        |  public final @NonNull String qux;
+        |
+        |  public final List<@NonNull String> foo2;
+        |
+        |  public final @NonNull List<String> bar2;
+        |
+        |  public final @NonNull List<@NonNull String> baz2;
+        |
+        |  public final @NonNull List<@NonNull Long> qux2;
+        """
           .trimMargin()
       )
   }
@@ -1260,7 +1260,7 @@ class JavaCodeGeneratorTest {
         |  public final @NonNull List<@NonNull Long> recursive1;
         |
         |  public final @NonNull List<@NonNull String> recursive2;
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -1275,7 +1275,7 @@ class JavaCodeGeneratorTest {
         |    public final @NonNull List<@NonNull Long> recursive1;
         |
         |    public final @NonNull List<@NonNull String> recursive2;
-      """
+        """
           .trimMargin()
       )
   }
@@ -1285,27 +1285,15 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module mod
+        module mod
 
-      class Person { name: String }
+        class Person { name: String }
 
-      typealias List2<E> = List<E>
-      typealias Map2<V, K> = Map<K, V>
-      typealias StringMap<V> = Map<String, V>
-      typealias MMap<X> = Map<X, X>
+        typealias List2<E> = List<E>
+        typealias Map2<V, K> = Map<K, V>
+        typealias StringMap<V> = Map<String, V>
+        typealias MMap<X> = Map<X, X>
 
-      res1: List2<Int>
-      res2: List2<List2<String>>
-      res3: Map2<String, Int>
-      res4: StringMap<Duration>
-      res5: MMap<Person?>
-
-      res6: List2
-      res7: Map2
-      res8: StringMap
-      res9: MMap
-
-      class Foo {
         res1: List2<Int>
         res2: List2<List2<String>>
         res3: Map2<String, Int>
@@ -1316,8 +1304,20 @@ class JavaCodeGeneratorTest {
         res7: Map2
         res8: StringMap
         res9: MMap
-      }
-    """
+
+        class Foo {
+          res1: List2<Int>
+          res2: List2<List2<String>>
+          res3: Map2<String, Int>
+          res4: StringMap<Duration>
+          res5: MMap<Person?>
+
+          res6: List2
+          res7: Map2
+          res8: StringMap
+          res9: MMap
+        }
+        """
           .trimIndent()
       )
 
@@ -1343,7 +1343,7 @@ class JavaCodeGeneratorTest {
         |  public final @NonNull Map<@NonNull String, @NonNull Object> res8;
         |
         |  public final @NonNull Map<@NonNull Object, @NonNull Object> res9;
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -1366,7 +1366,7 @@ class JavaCodeGeneratorTest {
         |    public final @NonNull Map<@NonNull String, @NonNull Object> res8;
         |
         |    public final @NonNull Map<@NonNull Object, @NonNull Object> res9;
-      """
+        """
           .trimMargin()
       )
   }
@@ -1376,10 +1376,10 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module mod
+        module mod
 
-      x: "Pigeon"|"Barn Owl"|"Parrot"
-    """
+        x: "Pigeon"|"Barn Owl"|"Parrot"
+        """
           .trimIndent()
       )
 
@@ -1392,10 +1392,10 @@ class JavaCodeGeneratorTest {
       assertThrows<JavaCodeGeneratorException> {
         generateJavaCode(
           """
-        module mod
+          module mod
 
-        x: "Pigeon"|Int|"Parrot"
-      """
+          x: "Pigeon"|Int|"Parrot"
+          """
             .trimIndent()
         )
       }
@@ -1407,17 +1407,17 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module mod
+        module mod
 
-      v1: "RELEASE"
-      v2: "RELEASE"|String
-      v3: String|"RELEASE"
-      v4: "RELEASE"|String|"LATEST"
-      v5: Version|String|"LATEST"
-      v6: (Version|String)|("LATEST"|String)
-      
-      typealias Version = "RELEASE"|String|"LATEST"
-    """
+        v1: "RELEASE"
+        v2: "RELEASE"|String
+        v3: String|"RELEASE"
+        v4: "RELEASE"|String|"LATEST"
+        v5: Version|String|"LATEST"
+        v6: (Version|String)|("LATEST"|String)
+
+        typealias Version = "RELEASE"|String|"LATEST"
+        """
           .trimIndent()
       )
 
@@ -1435,22 +1435,22 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module mod
+        module mod
 
-      typealias Version1 = "RELEASE"|String
-      typealias Version2 = String|"RELEASE"
-      typealias Version3 = "RELEASE"|String|"LATEST"
-      typealias Version4 = Version3|String|"LATEST"
-      typealias Version5 = (Version4|String)|("LATEST"|String)
-      typealias Version6 = Version5
-      
-      v1: Version1
-      v2: Version2
-      v3: Version3
-      v4: Version4
-      v5: Version5
-      v6: Version6
-    """
+        typealias Version1 = "RELEASE"|String
+        typealias Version2 = String|"RELEASE"
+        typealias Version3 = "RELEASE"|String|"LATEST"
+        typealias Version4 = Version3|String|"LATEST"
+        typealias Version5 = (Version4|String)|("LATEST"|String)
+        typealias Version6 = Version5
+
+        v1: Version1
+        v2: Version2
+        v3: Version3
+        v4: Version4
+        v5: Version5
+        v6: Version6
+        """
           .trimIndent()
       )
 
@@ -1468,10 +1468,10 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      name: String
-    """
+        name: String
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(paramsAnnotation = "org.project.MyAnnotation"),
       )
@@ -1486,10 +1486,10 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      name: String
-    """
+        name: String
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(paramsAnnotation = null),
       )
@@ -1502,15 +1502,15 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      server: Server
+        server: Server
 
-      class Server {
-        port: Int
-        urls: Listing<Uri>
-      }
-    """
+        class Server {
+          port: Int
+          urls: Listing<Uri>
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateSpringBootConfig = true),
       )
@@ -1520,20 +1520,20 @@ class JavaCodeGeneratorTest {
         """
         |@ConfigurationProperties
         |public final class Mod {
-      """
+        """
           .trimMargin()
       )
       .contains(
         """
         |  public final @NonNull Server server;
-      """
+        """
           .trimMargin()
       )
       .contains(
         """
         |  @ConfigurationProperties("server")
         |  public static final class Server {
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -1541,7 +1541,7 @@ class JavaCodeGeneratorTest {
         |    public final long port;
         |
         |    public final @NonNull List<@NonNull URI> urls;
-      """
+        """
           .trimMargin()
       )
       .doesNotContain("@ConstructorBinding")
@@ -1549,8 +1549,9 @@ class JavaCodeGeneratorTest {
 
     // not worthwhile to add spring & spring boot dependency just so that this test can compile
     // their annotations
-    val javaCodeWithoutSpringAnnotations =
-      javaCode.deleteLines { it.contains("ConfigurationProperties") }
+    val javaCodeWithoutSpringAnnotations = javaCode.deleteLines {
+      it.contains("ConfigurationProperties")
+    }
     assertThat(javaCodeWithoutSpringAnnotations).compilesSuccessfully()
   }
 
@@ -1560,11 +1561,11 @@ class JavaCodeGeneratorTest {
       PklModule(
         "library",
         """
-          module library
+        module library
 
-          class Person { name: String; age: Int }
-          
-          pigeon: Person
+        class Person { name: String; age: Int }
+
+        pigeon: Person
         """
           .trimIndent(),
       )
@@ -1573,13 +1574,13 @@ class JavaCodeGeneratorTest {
       PklModule(
         "client",
         """
-          module client
-          
-          import "library.pkl"
-          
-          lib: library
-          
-          parrot: library.Person
+        module client
+
+        import "library.pkl"
+
+        lib: library
+
+        parrot: library.Person
         """
           .trimIndent(),
       )
@@ -1596,7 +1597,7 @@ class JavaCodeGeneratorTest {
         |  public final @NonNull Library lib;
         |
         |  public final Library. @NonNull Person parrot;
-      """
+        """
           .trimMargin()
       )
   }
@@ -1607,11 +1608,11 @@ class JavaCodeGeneratorTest {
       PklModule(
         "base",
         """
-          open module base
-        
-          open class Person { name: String }
-        
-          pigeon: Person
+        open module base
+
+        open class Person { name: String }
+
+        pigeon: Person
         """
           .trimIndent(),
       )
@@ -1620,13 +1621,13 @@ class JavaCodeGeneratorTest {
       PklModule(
         "derived",
         """
-          module derived
-          extends "base.pkl"
-          
-          class Person2 extends Person { age: Int }
-          
-          person1: Person
-          person2: Person2
+        module derived
+        extends "base.pkl"
+
+        class Person2 extends Person { age: Int }
+
+        person1: Person
+        person2: Person2
         """
           .trimIndent(),
       )
@@ -1643,7 +1644,7 @@ class JavaCodeGeneratorTest {
         |  public final Base. @NonNull Person person1;
         |
         |  public final @NonNull Person2 person2;
-      """
+        """
           .trimMargin()
       )
   }
@@ -1660,9 +1661,9 @@ class JavaCodeGeneratorTest {
       PklModule(
         "base",
         """
-          abstract module base
-    
-          typealias Version = "LATEST"|String
+        abstract module base
+
+        typealias Version = "LATEST"|String
         """
           .trimIndent(),
       )
@@ -1671,11 +1672,11 @@ class JavaCodeGeneratorTest {
       PklModule(
         "derived",
         """
-          module derived
-          
-          extends "base.pkl"
-          
-          v: Version = "1.2.3"
+        module derived
+
+        extends "base.pkl"
+
+        v: Version = "1.2.3"
         """
           .trimIndent(),
       )
@@ -1690,7 +1691,7 @@ class JavaCodeGeneratorTest {
         """
         |public final class Derived extends Base {
         |  public final @NonNull String v;
-      """
+        """
           .trimMargin()
       )
   }
@@ -1701,19 +1702,19 @@ class JavaCodeGeneratorTest {
       PklModule(
         "Mod.pkl",
         """
-          module org.pkl.Mod
-    
-          foo: Foo
-    
-          bar: Bar
-    
-          class Foo {
-            prop: String
-          }
-    
-          class Bar {
-            prop: Int
-          }
+        module org.pkl.Mod
+
+        foo: Foo
+
+        bar: Bar
+
+        class Foo {
+          prop: String
+        }
+
+        class Bar {
+          prop: Int
+        }
         """
           .trimIndent(),
       )
@@ -1734,19 +1735,19 @@ class JavaCodeGeneratorTest {
       PklModule(
         "mod.pkl",
         """
-          module my.mod
-    
-          foo: Foo
-    
-          bar: Bar
-    
-          class Foo {
-            prop: String
-          }
-    
-          class Bar {
-            prop: Int
-          }
+        module my.mod
+
+        foo: Foo
+
+        bar: Bar
+
+        class Foo {
+          prop: String
+        }
+
+        class Bar {
+          prop: Int
+        }
         """
           .trimIndent(),
       )
@@ -1766,39 +1767,39 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module mod
-  
-      class BigStruct {
-        boolean: Boolean
-        int: Int
-        float: Float
-        string: String
-        duration: Duration
-        dataSize: DataSize
-        pair: Pair
-        pair2: Pair<String, SmallStruct>
-        coll: Collection
-        coll2: Collection<SmallStruct>
-        list: List
-        list2: List<SmallStruct>
-        set: Set
-        set2: Set<SmallStruct>
-        map: Map
-        map2: Map<String, SmallStruct>
-        container: Mapping
-        container2: Mapping<String, SmallStruct>
-        other: SmallStruct
-        regex: Regex
-        nonNull: NonNull
-        enum: Direction
-      }
-  
-      class SmallStruct {
-        name: String
-      }
-  
-      typealias Direction = "north"|"east"|"south"|"west"
-    """
+        module mod
+
+        class BigStruct {
+          boolean: Boolean
+          int: Int
+          float: Float
+          string: String
+          duration: Duration
+          dataSize: DataSize
+          pair: Pair
+          pair2: Pair<String, SmallStruct>
+          coll: Collection
+          coll2: Collection<SmallStruct>
+          list: List
+          list2: List<SmallStruct>
+          set: Set
+          set2: Set<SmallStruct>
+          map: Map
+          map2: Map<String, SmallStruct>
+          container: Mapping
+          container2: Mapping<String, SmallStruct>
+          other: SmallStruct
+          regex: Regex
+          nonNull: NonNull
+          enum: Direction
+        }
+
+        class SmallStruct {
+          name: String
+        }
+
+        typealias Direction = "north"|"east"|"south"|"west"
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(implementSerializable = true),
       )
@@ -1877,9 +1878,9 @@ class JavaCodeGeneratorTest {
     var javaCode =
       generateJavaCode(
         """
-      module my.mod
-      abstract class Foo { str: String }
-    """
+        module my.mod
+        abstract class Foo { str: String }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(implementSerializable = true),
       )
@@ -1889,8 +1890,8 @@ class JavaCodeGeneratorTest {
     javaCode =
       generateJavaCode(
         """
-      module my.mod
-    """
+        module my.mod
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(implementSerializable = true),
       )
@@ -1903,11 +1904,11 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module Person
-      name: String
-      address: Address
-      class Address { city: String }
-    """
+        module Person
+        name: String
+        address: Address
+        class Address { city: String }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(implementSerializable = true),
       )
@@ -1917,14 +1918,14 @@ class JavaCodeGeneratorTest {
         """
         |public final class Person implements Serializable {
         |  private static final long serialVersionUID = 0L;
-      """
+        """
           .trimMargin()
       )
       .contains(
         """
         |  public static final class Address implements Serializable {
         |    private static final long serialVersionUID = 0L;
-      """
+        """
           .trimMargin()
       )
   }
@@ -1934,22 +1935,22 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      open class Foo
+        open class Foo
 
-      class TheFoo extends Foo {
-        fooProp: String
-      }
+        class TheFoo extends Foo {
+          fooProp: String
+        }
 
-      open class OpenClass {
-        prop: Foo
-      }
+        open class OpenClass {
+          prop: Foo
+        }
 
-      class TheClass extends OpenClass {
-        prop: TheFoo
-      }
-    """
+        class TheClass extends OpenClass {
+          prop: TheFoo
+        }
+        """
           .trimIndent()
       )
 
@@ -1968,7 +1969,7 @@ class JavaCodeGeneratorTest {
         |    public TheClass withProp(@NonNull TheFoo prop) {
         |      return new TheClass(prop);
         |    }
-      """
+        """
           .trimMargin()
       )
   }
@@ -1978,22 +1979,22 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      open class Foo
+        open class Foo
 
-      class TheFoo extends Foo {
-        fooProp: String
-      }
+        class TheFoo extends Foo {
+          fooProp: String
+        }
 
-      open class OpenClass {
-        prop: Foo
-      }
+        open class OpenClass {
+          prop: Foo
+        }
 
-      class TheClass extends OpenClass {
-        prop: TheFoo
-      }
-    """
+        class TheClass extends OpenClass {
+          prop: TheFoo
+        }
+        """
           .trimIndent(),
         JavaCodeGeneratorOptions(generateGetters = true),
       )
@@ -2014,7 +2015,7 @@ class JavaCodeGeneratorTest {
         |    public @NonNull TheFoo getProp() {
         |      return prop;
         |    }
-      """
+        """
           .trimMargin()
       )
   }
@@ -2028,16 +2029,16 @@ class JavaCodeGeneratorTest {
         .generateFiles(
           "MyModule.pkl" to
             """
-              module a.b.c.MyModule
-              
-              foo: String = "abc"
+            module a.b.c.MyModule
+
+            foo: String = "abc"
             """
               .trimIndent(),
           "AnotherModule.pkl" to
             """
-              module d.e.f.AnotherModule
-              
-              bar: Int = 123
+            module d.e.f.AnotherModule
+
+            bar: Int = 123
             """
               .trimIndent(),
         )
@@ -2064,23 +2065,23 @@ class JavaCodeGeneratorTest {
         .generateFiles(
           "com/foo/bar/Module1" to
             """
-              module com.foo.bar.Module1
-              
-              bar: String
+            module com.foo.bar.Module1
+
+            bar: String
             """
               .trimIndent(),
           "com/Module2" to
             """
-              module com.Module2
-              
-              com: String
+            module com.Module2
+
+            com: String
             """
               .trimIndent(),
           "org/baz/Module3" to
             """
-              module org.baz.Module3
-              
-              baz: String
+            module org.baz.Module3
+
+            baz: String
             """
               .trimIndent(),
         )
@@ -2114,34 +2115,34 @@ class JavaCodeGeneratorTest {
         .generateFiles(
           "org/foo/Module1" to
             """
-              module org.foo.Module1
-              
-              class Person {
-                name: String
-              }
+            module org.foo.Module1
+
+            class Person {
+              name: String
+            }
             """
               .trimIndent(),
           "org/bar/Module2" to
             """
-              module org.bar.Module2
-              
-              import "../../org/foo/Module1.pkl"
+            module org.bar.Module2
 
-              class Group {
-                owner: Module1.Person
-                name: String
-              }
+            import "../../org/foo/Module1.pkl"
+
+            class Group {
+              owner: Module1.Person
+              name: String
+            }
             """
               .trimIndent(),
           "org/baz/Module3" to
             """
-              module org.baz.Module3
-              
-              import "../../org/bar/Module2.pkl"
+            module org.baz.Module3
 
-              class Supergroup {
-                owner: Module2.Group
-              }
+            import "../../org/bar/Module2.pkl"
+
+            class Supergroup {
+              owner: Module2.Group
+            }
             """
               .trimIndent(),
         )
@@ -2191,16 +2192,16 @@ class JavaCodeGeneratorTest {
         .generateFiles(
           "MyModule.pkl" to
             """
-              module a.b.c.MyModule
-              
-              foo: String = "abc"
+            module a.b.c.MyModule
+
+            foo: String = "abc"
             """
               .trimIndent(),
           "lower_module.pkl" to
             """
-              module d.e.f.lower_module 
-              
-              bar: Int = 123
+            module d.e.f.lower_module 
+
+            bar: Int = 123
             """
               .trimIndent(),
         )
@@ -2223,14 +2224,14 @@ class JavaCodeGeneratorTest {
     val javaCode =
       generateJavaCode(
         """
-      module my.mod
+        module my.mod
 
-      open class Foo {
-        name: String
-      }
-      
-      class Bar extends Foo {}
-    """
+        open class Foo {
+          name: String
+        }
+
+        class Bar extends Foo {}
+        """
           .trimIndent()
       )
 
@@ -2255,7 +2256,7 @@ class JavaCodeGeneratorTest {
         Bar {
           name = name1
         }
-      """
+        """
           .trimIndent()
       )
   }

--- a/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
+++ b/pkl-codegen-kotlin/src/main/kotlin/org/pkl/codegen/kotlin/Main.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,10 +91,10 @@ class PklKotlinCodegenCommand : ModulesCommand(name = "pkl-codegen-kotlin", help
         metavar = "old_name=new_name",
         help =
           """
-            Replace a prefix in the names of the generated Kotlin classes (repeatable).
-            By default, the names of generated classes are derived from the Pkl module names.
-            With this option, you can override or modify the default names, renaming entire
-            classes or just their packages.
+          Replace a prefix in the names of the generated Kotlin classes (repeatable).
+          By default, the names of generated classes are derived from the Pkl module names.
+          With this option, you can override or modify the default names, renaming entire
+          classes or just their packages.
           """
             .trimIndent(),
       )

--- a/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorTest.kt
+++ b/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/CliKotlinCodeGeneratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ class CliKotlinCodeGeneratorTest {
       open class Mod1(
         open val pigeon: Person
       ) {
-    """
+      """
         .trimIndent(),
       module1KotlinFile.readString(),
     )
@@ -88,7 +88,7 @@ class CliKotlinCodeGeneratorTest {
         pigeon: Mod1.Person,
         val parrot: Mod1.Person
       ) : Mod1(pigeon) {
-    """
+      """
         .trimIndent(),
       module2KotlinFile.readString(),
     )

--- a/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
+++ b/pkl-codegen-kotlin/src/test/kotlin/org/pkl/codegen/kotlin/KotlinCodeGeneratorTest.kt
@@ -74,13 +74,13 @@ class KotlinCodeGeneratorTest {
     private val simpleClass: KClass<*> by lazy {
       generateKotlinCode(
           """
-        module my.mod
+          module my.mod
 
-        open class Simple {
-          str: String
-          list: List<Int>
-        }
-      """
+          open class Simple {
+            str: String
+            list: List<Int>
+          }
+          """
             .trimIndent()
         )
         .compile()
@@ -128,7 +128,7 @@ class KotlinCodeGeneratorTest {
         }
 
         typealias Direction = "north"|"east"|"south"|"west"
-      """
+        """
           .trimIndent()
       )
     }
@@ -214,10 +214,10 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      open class `A Person` {
-        `first name`: String
-      }
-    """
+        open class `A Person` {
+          `first name`: String
+        }
+        """
           .trimIndent()
       )
 
@@ -228,18 +228,18 @@ class KotlinCodeGeneratorTest {
         |  open class `A Person`(
         |    open val `first name`: String
         |  )
-      """
-          .trimMargin()
-      )
-      .contains(
-        """
-          |  override fun toString(): String = ""${'"'}A Person(first name=${'$'}`first name`)""${'"'}
         """
           .trimMargin()
       )
       .contains(
         """
-          |  open fun copy(`first name`: String = this.`first name`): `A Person` = `A Person`(`first name`)
+        |  override fun toString(): String = ""${'"'}A Person(first name=${'$'}`first name`)""${'"'}
+        """
+          .trimMargin()
+      )
+      .contains(
+        """
+        |  open fun copy(`first name`: String = this.`first name`): `A Person` = `A Person`(`first name`)
         """
           .trimMargin()
       )
@@ -250,21 +250,21 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      class ClassWithDeprecatedProperty {
-        @Deprecated { message = "property deprecation message" } 
-        deprecatedProperty: Int = 1337
-      }
-    """
+        class ClassWithDeprecatedProperty {
+          @Deprecated { message = "property deprecation message" } 
+          deprecatedProperty: Int = 1337
+        }
+        """
           .trimIndent()
       )
 
     assertThat(kotlinCode)
       .contains(
         """
-      |  data class ClassWithDeprecatedProperty(
-      |    @Deprecated(message = "property deprecation message")
-      |    val deprecatedProperty: Long
-    """
+        |  data class ClassWithDeprecatedProperty(
+        |    @Deprecated(message = "property deprecation message")
+        |    val deprecatedProperty: Long
+        """
           .trimMargin()
       )
   }
@@ -274,20 +274,20 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      @Deprecated { message = "class deprecation message" }
-      class DeprecatedClass {
-        propertyOfDeprecatedClass: Int = 42
-      }
-    """
+        @Deprecated { message = "class deprecation message" }
+        class DeprecatedClass {
+          propertyOfDeprecatedClass: Int = 42
+        }
+        """
           .trimIndent()
       )
 
     assertThat(kotlinCode)
       .contains(
         """
-      |  @Deprecated(message = "class deprecation message")
-      |  data class DeprecatedClass(
-    """
+        |  @Deprecated(message = "class deprecation message")
+        |  data class DeprecatedClass(
+        """
           .trimMargin()
       )
   }
@@ -297,20 +297,20 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      @Deprecated{ message = "module class deprecation message" }
-      module DeprecatedModule
-      
-      propertyInDeprecatedModuleClass : Int = 42
-    """
+        @Deprecated{ message = "module class deprecation message" }
+        module DeprecatedModule
+
+        propertyInDeprecatedModuleClass : Int = 42
+        """
           .trimIndent()
       )
 
     assertThat(kotlinCode)
       .contains(
         """
-      |@Deprecated(message = "module class deprecation message")
-      |data class DeprecatedModule(
-    """
+        |@Deprecated(message = "module class deprecation message")
+        |data class DeprecatedModule(
+        """
           .trimMargin()
       )
   }
@@ -320,21 +320,21 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      class ClassWithDeprecatedProperty {
-         @Deprecated
-         deprecatedProperty: Int = 1337
-      }
-    """
+        class ClassWithDeprecatedProperty {
+           @Deprecated
+           deprecatedProperty: Int = 1337
+        }
+        """
           .trimIndent()
       )
 
     assertThat(kotlinCode)
       .contains(
         """
-      |  data class ClassWithDeprecatedProperty(
-      |    @Deprecated
-      |    val deprecatedProperty: Long
-    """
+        |  data class ClassWithDeprecatedProperty(
+        |    @Deprecated
+        |    val deprecatedProperty: Long
+        """
           .trimMargin()
       )
   }
@@ -344,20 +344,20 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      @Deprecated
-      class DeprecatedClass {
-        propertyOfDeprecatedClass: Int = 42
-      }
-    """
+        @Deprecated
+        class DeprecatedClass {
+          propertyOfDeprecatedClass: Int = 42
+        }
+        """
           .trimIndent()
       )
 
     assertThat(kotlinCode)
       .contains(
         """
-      |  @Deprecated
-      |  data class DeprecatedClass(
-    """
+        |  @Deprecated
+        |  data class DeprecatedClass(
+        """
           .trimMargin()
       )
   }
@@ -367,20 +367,20 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      @Deprecated
-      module DeprecatedModule
-      
-      propertyInDeprecatedModuleClass : Int = 42
-    """
+        @Deprecated
+        module DeprecatedModule
+
+        propertyInDeprecatedModuleClass : Int = 42
+        """
           .trimIndent()
       )
 
     assertThat(kotlinCode)
       .contains(
         """
-      |@Deprecated
-      |data class DeprecatedModule(
-    """
+        |@Deprecated
+        |data class DeprecatedModule(
+        """
           .trimMargin()
       )
   }
@@ -469,9 +469,9 @@ class KotlinCodeGeneratorTest {
       assertThrows<KotlinCodeGeneratorException> {
         generateKotlinCode(
           """
-        module my.mod
-        typealias MyTypeAlias = "foo-bar" | "foo bar"
-      """
+          module my.mod
+          typealias MyTypeAlias = "foo-bar" | "foo bar"
+          """
             .trimIndent()
         )
       }
@@ -485,9 +485,9 @@ class KotlinCodeGeneratorTest {
       assertThrows<KotlinCodeGeneratorException> {
         generateKotlinCode(
           """
-        module my.mod
-        typealias MyTypeAlias = "foo" | "" | "bar"
-      """
+          module my.mod
+          typealias MyTypeAlias = "foo" | "" | "bar"
+          """
             .trimIndent()
         )
       }
@@ -500,9 +500,9 @@ class KotlinCodeGeneratorTest {
       assertThrows<KotlinCodeGeneratorException> {
         generateKotlinCode(
           """
-        module my.mod
-        typealias MyTypeAlias = "foo" | "✅" | "bar"
-      """
+          module my.mod
+          typealias MyTypeAlias = "foo" | "✅" | "bar"
+          """
             .trimIndent()
         )
       }
@@ -514,16 +514,16 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      class Person {
-        name: String
-        age: Int
-        hobbies: List<String>
-        friends: Map<String, Person>
-        sibling: Person?
-      }
-    """
+        class Person {
+          name: String
+          age: Int
+          hobbies: List<String>
+          friends: Map<String, Person>
+          sibling: Person?
+        }
+        """
           .trimIndent()
       )
 
@@ -532,12 +532,12 @@ class KotlinCodeGeneratorTest {
       .isEqualTo(
         """
         package my
-  
+
         import kotlin.Long
         import kotlin.String
         import kotlin.collections.List
         import kotlin.collections.Map
-  
+
         object Mod {
           data class Person(
             val name: String,
@@ -547,8 +547,8 @@ class KotlinCodeGeneratorTest {
             val sibling: Person?
           )
         }
-        
-      """
+
+        """
           .trimIndent()
       )
   }
@@ -558,13 +558,13 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      class Person {
-        age: Int
-        name: Regex
-      }
-    """
+        class Person {
+          age: Int
+          name: Regex
+        }
+        """
           .trimIndent()
       )
 
@@ -578,12 +578,12 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      class Foo {
-        bytes: Bytes
-      }
-    """
+        class Foo {
+          bytes: Bytes
+        }
+        """
           .trimIndent()
       )
 
@@ -597,17 +597,17 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      open class Foo {
-        other: Int
-        bar: Bar
-      }
-      open class Bar {
-        foo: Foo
-        other: String
-      }
-    """
+        open class Foo {
+          other: Int
+          bar: Bar
+        }
+        open class Bar {
+          foo: Foo
+          other: String
+        }
+        """
           .trimIndent()
       )
 
@@ -619,7 +619,7 @@ class KotlinCodeGeneratorTest {
         |    open val other: Long,
         |    open val bar: Bar
         |  )
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -628,7 +628,7 @@ class KotlinCodeGeneratorTest {
         |    open val foo: Foo,
         |    open val other: String
         |  )
-      """
+        """
           .trimMargin()
       )
   }
@@ -638,19 +638,19 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      open class Foo {
-        one: Int
-      }
-      open class None extends Foo {}
-      open class Bar extends None {
-        two: String
-      }
-      class Baz extends Bar {
-        three: Duration
-      }
-    """
+        open class Foo {
+          one: Int
+        }
+        open class None extends Foo {}
+        open class Bar extends None {
+          two: String
+        }
+        class Baz extends Bar {
+          three: Duration
+        }
+        """
           .trimIndent()
       )
 
@@ -661,7 +661,7 @@ class KotlinCodeGeneratorTest {
         |  open class Foo(
         |    open val one: Long
         |  )
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -669,7 +669,7 @@ class KotlinCodeGeneratorTest {
         |  open class None(
         |    one: Long
         |  ) : Foo(one)
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -678,7 +678,7 @@ class KotlinCodeGeneratorTest {
         |    one: Long,
         |    open val two: String
         |  ) : None(one)
-      """
+        """
           .trimMargin()
       )
       .isEqualToResourceFile("Inheritance.kotlin")
@@ -689,25 +689,25 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      class Foo
-      abstract class Bar
-      class Baz extends Bar
-    """
+        class Foo
+        abstract class Bar
+        class Baz extends Bar
+        """
           .trimIndent()
       )
 
     assertThat(kotlinCode)
       .contains(
         """
-      |  data class Foo
-      |
-      |  abstract class Bar
-      |
-      |  class Baz : Bar() {
-      |    fun copy(): Baz = Baz()
-    """
+        |  data class Foo
+        |
+        |  abstract class Bar
+        |
+        |  class Baz : Bar() {
+        |    fun copy(): Baz = Baz()
+        """
           .trimMargin()
       )
   }
@@ -718,13 +718,13 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      abstract class Foo { one: Int }
-      abstract class Bar extends Foo { two: String }
-      class Baz extends Bar { three: Duration }
-      class Qux extends Bar {}
-    """
+        abstract class Foo { one: Int }
+        abstract class Bar extends Foo { two: String }
+        class Baz extends Bar { three: Duration }
+        class Qux extends Bar {}
+        """
           .trimIndent()
       )
 
@@ -736,7 +736,7 @@ class KotlinCodeGeneratorTest {
         |  abstract class Foo(
         |    open val one: Long
         |  )
-      """
+        """
           .trimMargin()
       )
       // missing trailing `{` proves that no methods are generated
@@ -746,7 +746,7 @@ class KotlinCodeGeneratorTest {
         |    one: Long,
         |    open val two: String
         |  ) : Foo(one)
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -761,7 +761,7 @@ class KotlinCodeGeneratorTest {
         |      two: String = this.two,
         |      three: Duration = this.three
         |    ): Baz = Baz(one, two, three)
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -771,7 +771,7 @@ class KotlinCodeGeneratorTest {
         |    two: String
         |  ) : Bar(one, two) {
         |    fun copy(one: Long = this.one, two: String = this.two): Qux = Qux(one, two)
-      """
+        """
           .trimMargin()
       )
   }
@@ -782,13 +782,13 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      open class Foo { one: Int }
-      abstract class Bar extends Foo { two: String }
-      class Baz extends Bar { three: Duration }
-      class Qux extends Bar {}
-    """
+        open class Foo { one: Int }
+        abstract class Bar extends Foo { two: String }
+        class Baz extends Bar { three: Duration }
+        class Qux extends Bar {}
+        """
           .trimIndent()
       )
 
@@ -800,7 +800,7 @@ class KotlinCodeGeneratorTest {
         |    open val one: Long
         |  ) {
         |    open fun copy(one: Long = this.one): Foo = Foo(one)
-      """
+        """
           .trimMargin()
       )
       // missing trailing `{` proves that no methods are generated
@@ -810,7 +810,7 @@ class KotlinCodeGeneratorTest {
         |    one: Long,
         |    open val two: String
         |  ) : Foo(one)
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -827,7 +827,7 @@ class KotlinCodeGeneratorTest {
         |    ): Baz = Baz(one, two, three)
         |
         |    override fun copy(one: Long): Baz = Baz(one, two, three)
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -839,7 +839,7 @@ class KotlinCodeGeneratorTest {
         |    fun copy(one: Long = this.one, two: String = this.two): Qux = Qux(one, two)
         |
         |    override fun copy(one: Long): Qux = Qux(one, two)
-      """
+        """
           .trimMargin()
       )
   }
@@ -850,13 +850,13 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      open class Foo { one: Int }
-      abstract class Bar extends Foo {}
-      class Baz extends Bar { two: Duration }
-      class Qux extends Bar {}
-    """
+        open class Foo { one: Int }
+        abstract class Bar extends Foo {}
+        class Baz extends Bar { two: Duration }
+        class Qux extends Bar {}
+        """
           .trimIndent()
       )
 
@@ -868,7 +868,7 @@ class KotlinCodeGeneratorTest {
         |    open val one: Long
         |  ) {
         |    open fun copy(one: Long = this.one): Foo = Foo(one)
-      """
+        """
           .trimMargin()
       )
       // missing trailing `{` proves that no methods are generated
@@ -877,7 +877,7 @@ class KotlinCodeGeneratorTest {
         |  abstract class Bar(
         |    one: Long
         |  ) : Foo(one)
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -889,7 +889,7 @@ class KotlinCodeGeneratorTest {
         |    fun copy(one: Long = this.one, two: Duration = this.two): Baz = Baz(one, two)
         |
         |    override fun copy(one: Long): Baz = Baz(one, two)
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -898,7 +898,7 @@ class KotlinCodeGeneratorTest {
         |    one: Long
         |  ) : Bar(one) {
         |    override fun copy(one: Long): Qux = Qux(one)
-      """
+        """
           .trimMargin()
       )
   }
@@ -929,15 +929,15 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      pigeon: Person
-      parrot: Person
+        pigeon: Person
+        parrot: Person
 
-      class Person {
-        name: String
-      }
-    """
+        class Person {
+          name: String
+        }
+        """
           .trimIndent()
       )
 
@@ -948,7 +948,7 @@ class KotlinCodeGeneratorTest {
         package my
 
         import kotlin.String
-  
+
         data class Mod(
           val pigeon: Person,
           val parrot: Person
@@ -957,8 +957,8 @@ class KotlinCodeGeneratorTest {
             val name: String
           )
         }
-        
-      """
+
+        """
           .trimIndent()
       )
   }
@@ -968,15 +968,15 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module mod
+        module mod
 
-      pigeon: Person
-      parrot: Person
+        pigeon: Person
+        parrot: Person
 
-      class Person {
-        name: String
-      }
-    """
+        class Person {
+          name: String
+        }
+        """
           .trimIndent()
       )
 
@@ -994,8 +994,8 @@ class KotlinCodeGeneratorTest {
             val name: String
           )
         }
-        
-      """
+
+        """
           .trimIndent()
       )
   }
@@ -1005,16 +1005,16 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      hidden pigeon1: String
-      parrot1: String
+        hidden pigeon1: String
+        parrot1: String
 
-      class Persons {
-        hidden pigeon2: String
-        parrot2: String
-      }
-    """
+        class Persons {
+          hidden pigeon2: String
+          parrot2: String
+        }
+        """
           .trimIndent()
       )
 
@@ -1030,34 +1030,34 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      /// module comment.
-      /// *emphasized* `code`.
-      module my.mod
-
-      /// module property comment.
-      /// *emphasized* `code`.
-      pigeon: Person
-
-      /// class comment.
-      /// *emphasized* `code`.
-      open class Product {
-        /// class property comment.
+        /// module comment.
         /// *emphasized* `code`.
-        price: String
-      }
+        module my.mod
 
-      /// class comment.
-      /// *emphasized* `code`.
-      class Person {
-        /// class property comment.
+        /// module property comment.
         /// *emphasized* `code`.
-        name: String
-      }
+        pigeon: Person
 
-      /// type alias comment.
-      /// *emphasized* `code`.
-      typealias Email = String(contains("@"))
-    """
+        /// class comment.
+        /// *emphasized* `code`.
+        open class Product {
+          /// class property comment.
+          /// *emphasized* `code`.
+          price: String
+        }
+
+        /// class comment.
+        /// *emphasized* `code`.
+        class Person {
+          /// class property comment.
+          /// *emphasized* `code`.
+          name: String
+        }
+
+        /// type alias comment.
+        /// *emphasized* `code`.
+        typealias Email = String(contains("@"))
+        """
           .trimIndent(),
         generateKdoc = true,
       )
@@ -1070,12 +1070,12 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      /// module comment.
-      /// *emphasized* `code`.
-      module my.mod
+        /// module comment.
+        /// *emphasized* `code`.
+        module my.mod
 
-      class Product
-    """
+        class Product
+        """
           .trimIndent(),
         generateKdoc = true,
       )
@@ -1083,17 +1083,17 @@ class KotlinCodeGeneratorTest {
     assertThat(kotlinCode)
       .isEqualTo(
         """
-      package my
+        package my
 
-      /**
-       * module comment.
-       * *emphasized* `code`.
-       */
-      object Mod {
-        data class Product
-      }
-      
-    """
+        /**
+         * module comment.
+         * *emphasized* `code`.
+         */
+        object Mod {
+          data class Product
+        }
+
+        """
           .trimIndent()
       )
   }
@@ -1103,26 +1103,8 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module mod
+        module mod
 
-      uint8: UInt8
-      uint16: UInt16
-      uint32: UInt32
-      uint: UInt
-      int8: Int8
-      int16: Int16
-      int32: Int32
-      uri: Uri
-
-      pair: Pair<UInt8, UInt16>
-      list: List<UInt32>
-      set: Set<UInt>
-      map: Map<Int8, Int16>
-      listing: Listing<Int32>
-      mapping: Mapping<Uri, UInt8>
-      nullable: UInt16?
-
-      class Foo {
         uint8: UInt8
         uint16: UInt16
         uint32: UInt32
@@ -1131,9 +1113,27 @@ class KotlinCodeGeneratorTest {
         int16: Int16
         int32: Int32
         uri: Uri
-        list: List<UInt>
-      }
-    """
+
+        pair: Pair<UInt8, UInt16>
+        list: List<UInt32>
+        set: Set<UInt>
+        map: Map<Int8, Int16>
+        listing: Listing<Int32>
+        mapping: Mapping<Uri, UInt8>
+        nullable: UInt16?
+
+        class Foo {
+          uint8: UInt8
+          uint16: UInt16
+          uint32: UInt32
+          uint: UInt
+          int8: Int8
+          int16: Int16
+          int32: Int32
+          uri: Uri
+          list: List<UInt>
+        }
+        """
           .trimIndent()
       )
 
@@ -1150,7 +1150,7 @@ class KotlinCodeGeneratorTest {
         import kotlin.collections.List
         import kotlin.collections.Map
         import kotlin.collections.Set
-  
+
         data class Mod(
           val uint8: Short,
           val uint16: Int,
@@ -1180,8 +1180,8 @@ class KotlinCodeGeneratorTest {
             val list: List<Long>
           )
         }
-        
-      """
+
+        """
           .trimIndent()
       )
   }
@@ -1191,28 +1191,28 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module mod
+        module mod
 
-      typealias Simple = String
-      typealias Constrained = String(length >= 3)
-      typealias Parameterized = List<Int(nonZero)>
-      typealias Recursive1 = Parameterized(nonEmpty)
-      typealias Recursive2 = List<Constrained>
+        typealias Simple = String
+        typealias Constrained = String(length >= 3)
+        typealias Parameterized = List<Int(nonZero)>
+        typealias Recursive1 = Parameterized(nonEmpty)
+        typealias Recursive2 = List<Constrained>
 
-      simple: Simple
-      constrained: Constrained
-      parameterized: Parameterized
-      recursive1: Recursive1
-      recursive2: Recursive2
-
-      class Foo {
         simple: Simple
         constrained: Constrained
         parameterized: Parameterized
         recursive1: Recursive1
         recursive2: Recursive2
-      }
-    """
+
+        class Foo {
+          simple: Simple
+          constrained: Constrained
+          parameterized: Parameterized
+          recursive1: Recursive1
+          recursive2: Recursive2
+        }
+        """
           .trimIndent()
       )
 
@@ -1223,17 +1223,17 @@ class KotlinCodeGeneratorTest {
         import kotlin.Long
         import kotlin.String
         import kotlin.collections.List
-  
+
         typealias Simple = String
-  
+
         typealias Constrained = String
-  
+
         typealias Parameterized = List<Long>
-  
+
         typealias Recursive1 = Parameterized
-  
+
         typealias Recursive2 = List<Constrained>
-  
+
         data class Mod(
           val simple: Simple,
           val constrained: Constrained,
@@ -1249,8 +1249,8 @@ class KotlinCodeGeneratorTest {
             val recursive2: Recursive2
           )
         }
-        
-      """
+
+        """
           .trimIndent()
       )
   }
@@ -1260,27 +1260,15 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module mod
+        module mod
 
-      class Person { name: String }
+        class Person { name: String }
 
-      typealias List2<E> = List<E>
-      typealias Map2<V, K> = Map<K, V>
-      typealias StringMap<V> = Map<String, V>
-      typealias MMap<X> = Map<X, X>
+        typealias List2<E> = List<E>
+        typealias Map2<V, K> = Map<K, V>
+        typealias StringMap<V> = Map<String, V>
+        typealias MMap<X> = Map<X, X>
 
-      res1: List2<Int>
-      res2: List2<List2<String>>
-      res3: Map2<String, Int>
-      res4: StringMap<Duration>
-      res5: MMap<Person?>
-
-      res6: List2
-      res7: Map2
-      res8: StringMap
-      res9: MMap
-
-      class Foo {
         res1: List2<Int>
         res2: List2<List2<String>>
         res3: Map2<String, Int>
@@ -1291,8 +1279,20 @@ class KotlinCodeGeneratorTest {
         res7: Map2
         res8: StringMap
         res9: MMap
-      }
-    """
+
+        class Foo {
+          res1: List2<Int>
+          res2: List2<List2<String>>
+          res3: Map2<String, Int>
+          res4: StringMap<Duration>
+          res5: MMap<Person?>
+
+          res6: List2
+          res7: Map2
+          res8: StringMap
+          res9: MMap
+        }
+        """
           .trimIndent()
       )
 
@@ -1310,7 +1310,7 @@ class KotlinCodeGeneratorTest {
         |  val res7: Map2<Any?, Any?>,
         |  val res8: StringMap<Any?>,
         |  val res9: MMap<Any?>
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -1325,7 +1325,7 @@ class KotlinCodeGeneratorTest {
         |    val res7: Map2<Any?, Any?>,
         |    val res8: StringMap<Any?>,
         |    val res9: MMap<Any?>
-      """
+        """
           .trimMargin()
       )
   }
@@ -1335,10 +1335,10 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module mod
+        module mod
 
-      x: "Pigeon"|"Barn Owl"|"Parrot"
-    """
+        x: "Pigeon"|"Barn Owl"|"Parrot"
+        """
           .trimIndent()
       )
 
@@ -1349,7 +1349,7 @@ class KotlinCodeGeneratorTest {
         |data class Mod(
         |  val x: String
         |)
-      """
+        """
           .trimMargin()
       )
   }
@@ -1361,9 +1361,9 @@ class KotlinCodeGeneratorTest {
         generateKotlinCode(
           """
           module mod
-  
+
           x: "Pigeon"|Int|"Parrot"
-        """
+          """
             .trimIndent()
         )
       }
@@ -1375,17 +1375,17 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module mod
+        module mod
 
-      v1: "RELEASE"
-      v2: "RELEASE"|String
-      v3: String|"RELEASE"
-      v4: "RELEASE"|String|"LATEST"
-      v5: Version|String|"LATEST"
-      v6: (Version|String)|("LATEST"|String)
-      
-      typealias Version = "RELEASE"|String|"LATEST"
-    """
+        v1: "RELEASE"
+        v2: "RELEASE"|String
+        v3: String|"RELEASE"
+        v4: "RELEASE"|String|"LATEST"
+        v5: Version|String|"LATEST"
+        v6: (Version|String)|("LATEST"|String)
+
+        typealias Version = "RELEASE"|String|"LATEST"
+        """
           .trimIndent()
       )
 
@@ -1403,15 +1403,15 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module mod
+        module mod
 
-      typealias Version1 = "RELEASE"|String
-      typealias Version2 = String|"RELEASE"
-      typealias Version3 = "RELEASE"|String|"LATEST"
-      typealias Version4 = Version3|String|"LATEST" // ideally wouldn't be inlined
-      typealias Version5 = (Version4|String)|("LATEST"|String)
-      typealias Version6 = Version5 // not inlined
-    """
+        typealias Version1 = "RELEASE"|String
+        typealias Version2 = String|"RELEASE"
+        typealias Version3 = "RELEASE"|String|"LATEST"
+        typealias Version4 = Version3|String|"LATEST" // ideally wouldn't be inlined
+        typealias Version5 = (Version4|String)|("LATEST"|String)
+        typealias Version6 = Version5 // not inlined
+        """
           .trimIndent()
       )
 
@@ -1429,15 +1429,15 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module my.mod
+        module my.mod
 
-      server: Server
+        server: Server
 
-      class Server {
-        port: Int
-        urls: Listing<Uri>
-      }
-    """
+        class Server {
+          port: Int
+          urls: Listing<Uri>
+        }
+        """
           .trimIndent(),
         generateSpringBootConfig = true,
       )
@@ -1448,7 +1448,7 @@ class KotlinCodeGeneratorTest {
         |@ConfigurationProperties
         |data class Mod(
         |  val server: Server
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -1457,15 +1457,16 @@ class KotlinCodeGeneratorTest {
         |  data class Server(
         |    val port: Long,
         |    val urls: List<URI>
-      """
+        """
           .trimMargin()
       )
       .doesNotContain("@ConstructorBinding")
 
     // not worthwhile to add spring & spring boot dependency just so that this test can compile
     // their annotations
-    val kotlinCodeWithoutSpringAnnotations =
-      kotlinCode.deleteLines { it.contains("ConfigurationProperties") }
+    val kotlinCodeWithoutSpringAnnotations = kotlinCode.deleteLines {
+      it.contains("ConfigurationProperties")
+    }
     assertThat(kotlinCodeWithoutSpringAnnotations).compilesSuccessfully()
   }
 
@@ -1475,11 +1476,11 @@ class KotlinCodeGeneratorTest {
       PklModule(
         "library",
         """
-          module library
-    
-          class Person { name: String; age: Int }
-          
-          pigeon: Person
+        module library
+
+        class Person { name: String; age: Int }
+
+        pigeon: Person
         """
           .trimIndent(),
       )
@@ -1488,13 +1489,13 @@ class KotlinCodeGeneratorTest {
       PklModule(
         "client",
         """
-          module client
-          
-          import "library.pkl"
-          
-          lib: library
-          
-          parrot: library.Person
+        module client
+
+        import "library.pkl"
+
+        lib: library
+
+        parrot: library.Person
         """
           .trimIndent(),
       )
@@ -1514,7 +1515,7 @@ class KotlinCodeGeneratorTest {
         |  val lib: Library,
         |  val parrot: Library.Person
         |)
-      """
+        """
           .trimMargin()
       )
   }
@@ -1525,11 +1526,11 @@ class KotlinCodeGeneratorTest {
       PklModule(
         "base",
         """
-          open module base
-    
-          open class Person { name: String }
-    
-          pigeon: Person
+        open module base
+
+        open class Person { name: String }
+
+        pigeon: Person
         """
           .trimIndent(),
       )
@@ -1538,13 +1539,13 @@ class KotlinCodeGeneratorTest {
       PklModule(
         "derived",
         """
-          module derived
-          extends "base.pkl"
-          
-          class Person2 extends Person { age: Int }
-          
-          person1: Person
-          person2: Person2
+        module derived
+        extends "base.pkl"
+
+        class Person2 extends Person { age: Int }
+
+        person1: Person
+        person2: Person2
         """
           .trimIndent(),
       )
@@ -1565,7 +1566,7 @@ class KotlinCodeGeneratorTest {
         |  val person1: Base.Person,
         |  val person2: Person2
         |) : Base(pigeon)
-      """
+        """
           .trimMargin()
       )
       .contains(
@@ -1574,7 +1575,7 @@ class KotlinCodeGeneratorTest {
         |    name: String,
         |    val age: Long
         |  ) : Base.Person(name)
-      """
+        """
           .trimMargin()
       )
   }
@@ -1591,9 +1592,9 @@ class KotlinCodeGeneratorTest {
       PklModule(
         "base",
         """
-          abstract module base
-    
-          typealias Version = "LATEST"|String
+        abstract module base
+
+        typealias Version = "LATEST"|String
         """
           .trimIndent(),
       )
@@ -1602,11 +1603,11 @@ class KotlinCodeGeneratorTest {
       PklModule(
         "derived",
         """
-          module derived
-          
-          extends "base.pkl"
-          
-          v: Version = "1.2.3"
+        module derived
+
+        extends "base.pkl"
+
+        v: Version = "1.2.3"
         """
           .trimIndent(),
       )
@@ -1621,10 +1622,10 @@ class KotlinCodeGeneratorTest {
     assertThat(kotlinDerivedCode)
       .contains(
         """
-      |class Derived(
-      |  val v: Version
-      |) : Base()
-    """
+        |class Derived(
+        |  val v: Version
+        |) : Base()
+        """
           .trimMargin()
       )
   }
@@ -1635,19 +1636,19 @@ class KotlinCodeGeneratorTest {
       PklModule(
         "Mod.pkl",
         """
-          module org.pkl.Mod
-    
-          foo: Foo
-    
-          bar: Bar
-    
-          class Foo {
-            prop: String
-          }
-    
-          class Bar {
-            prop: Int
-          }
+        module org.pkl.Mod
+
+        foo: Foo
+
+        bar: Bar
+
+        class Foo {
+          prop: String
+        }
+
+        class Bar {
+          prop: Int
+        }
         """
           .trimIndent(),
       )
@@ -1667,41 +1668,41 @@ class KotlinCodeGeneratorTest {
     val kotlinCode =
       generateKotlinCode(
         """
-      module mod
+        module mod
 
-      class BigStruct {
-        boolean: Boolean
-        int: Int
-        float: Float
-        string: String
-        duration: Duration
-        dataSize: DataSize
-        pair: Pair
-        pair2: Pair<String, SmallStruct>
-        coll: Collection
-        coll2: Collection<SmallStruct>
-        list: List
-        list2: List<SmallStruct>
-        set: Set
-        set2: Set<SmallStruct>
-        map: Map
-        map2: Map<String, SmallStruct>
-        container: Mapping
-        container2: Mapping<String, SmallStruct>
-        other: SmallStruct
-        regex: Regex
-        nonNull: NonNull
-        enum: Direction
-      }
+        class BigStruct {
+          boolean: Boolean
+          int: Int
+          float: Float
+          string: String
+          duration: Duration
+          dataSize: DataSize
+          pair: Pair
+          pair2: Pair<String, SmallStruct>
+          coll: Collection
+          coll2: Collection<SmallStruct>
+          list: List
+          list2: List<SmallStruct>
+          set: Set
+          set2: Set<SmallStruct>
+          map: Map
+          map2: Map<String, SmallStruct>
+          container: Mapping
+          container2: Mapping<String, SmallStruct>
+          other: SmallStruct
+          regex: Regex
+          nonNull: NonNull
+          enum: Direction
+        }
 
-      class SmallStruct {
-        name: String
-      }
+        class SmallStruct {
+          name: String
+        }
 
-      typealias Direction = "north"|"east"|"south"|"west"
-      
-      abstract class NotSerializable
-    """
+        typealias Direction = "north"|"east"|"south"|"west"
+
+        abstract class NotSerializable
+        """
           .trimIndent(),
         implementSerializable = true,
       )
@@ -1794,22 +1795,22 @@ class KotlinCodeGeneratorTest {
     assertThat(kotlinCode)
       .contains(
         """
-      |data class Person(
-      |  val address: Address
-      |) : Serializable {
-      |  data class Address(
-      |    val street: String
-      |  ) : Serializable {
-      |    companion object {
-      |      private const val serialVersionUID: Long = 0L
-      |    }
-      |  }
-      |
-      |  companion object {
-      |    private const val serialVersionUID: Long = 0L
-      |  }
-      |}
-    """
+        |data class Person(
+        |  val address: Address
+        |) : Serializable {
+        |  data class Address(
+        |    val street: String
+        |  ) : Serializable {
+        |    companion object {
+        |      private const val serialVersionUID: Long = 0L
+        |    }
+        |  }
+        |
+        |  companion object {
+        |    private const val serialVersionUID: Long = 0L
+        |  }
+        |}
+        """
           .trimMargin()
       )
   }
@@ -1821,9 +1822,9 @@ class KotlinCodeGeneratorTest {
         PklModule(
           "FooBar.pkl",
           """
-            module `Foo*Bar`
-            
-            someProp: String
+          module `Foo*Bar`
+
+          someProp: String
           """
             .trimIndent(),
         )
@@ -1840,16 +1841,16 @@ class KotlinCodeGeneratorTest {
         .generateFiles(
           "MyModule.pkl" to
             """
-              module a.b.c.MyModule
-              
-              foo: String = "abc"
+            module a.b.c.MyModule
+
+            foo: String = "abc"
             """
               .trimIndent(),
           "AnotherModule.pkl" to
             """
-              module d.e.f.AnotherModule
-              
-              bar: Int = 123
+            module d.e.f.AnotherModule
+
+            bar: Int = 123
             """
               .trimIndent(),
         )
@@ -1875,23 +1876,23 @@ class KotlinCodeGeneratorTest {
         .generateFiles(
           "com/foo/bar/Module1" to
             """
-              module com.foo.bar.Module1
-              
-              bar: String
+            module com.foo.bar.Module1
+
+            bar: String
             """
               .trimIndent(),
           "com/Module2" to
             """
-              module com.Module2
-              
-              com: String
+            module com.Module2
+
+            com: String
             """
               .trimIndent(),
           "org/baz/Module3" to
             """
-              module org.baz.Module3
-              
-              baz: String
+            module org.baz.Module3
+
+            baz: String
             """
               .trimIndent(),
         )
@@ -1926,34 +1927,34 @@ class KotlinCodeGeneratorTest {
         .generateFiles(
           "org/foo/Module1" to
             """
-              module org.foo.Module1
-              
-              class Person {
-                name: String
-              }
+            module org.foo.Module1
+
+            class Person {
+              name: String
+            }
             """
               .trimIndent(),
           "org/bar/Module2" to
             """
-              module org.bar.Module2
-              
-              import "../../org/foo/Module1.pkl"
+            module org.bar.Module2
 
-              class Group {
-                owner: Module1.Person
-                name: String
-              }
+            import "../../org/foo/Module1.pkl"
+
+            class Group {
+              owner: Module1.Person
+              name: String
+            }
             """
               .trimIndent(),
           "org/baz/Module3" to
             """
-              module org.baz.Module3
-              
-              import "../../org/bar/Module2.pkl"
+            module org.baz.Module3
 
-              class Supergroup {
-                owner: Module2.Group
-              }
+            import "../../org/bar/Module2.pkl"
+
+            class Supergroup {
+              owner: Module2.Group
+            }
             """
               .trimIndent(),
         )
@@ -2004,16 +2005,16 @@ class KotlinCodeGeneratorTest {
         .generateFiles(
           "MyModule.pkl" to
             """
-              module a.b.c.MyModule
-              
-              foo: String = "abc"
+            module a.b.c.MyModule
+
+            foo: String = "abc"
             """
               .trimIndent(),
           "lower_module.pkl" to
             """
-              module d.e.f.lower_module 
-              
-              bar: Int = 123
+            module d.e.f.lower_module 
+
+            bar: Int = 123
             """
               .trimIndent(),
         )
@@ -2038,17 +2039,17 @@ class KotlinCodeGeneratorTest {
     assertThat(files["kotlin/com/example/MyModule.kt"])
       .isEqualTo(
         """
-      package com.example
+        package com.example
 
-      import kotlin.String
-      import org.pkl.config.java.Generated
+        import kotlin.String
+        import org.pkl.config.java.Generated
 
-      @Generated
-      data class MyModule(
-        val foo: String
-      )
+        @Generated
+        data class MyModule(
+          val foo: String
+        )
 
-    """
+        """
           .trimIndent()
       )
   }

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
@@ -192,10 +192,9 @@ data class CliBaseOptions(
       // sort modules to make cli output independent of source module order
       .sorted()
 
-  val normalizedSettingsModule: URI? =
-    settings?.let { uri ->
-      if (uri.isAbsolute) uri else IoUtils.resolve(normalizedWorkingDir.toUri(), uri)
-    }
+  val normalizedSettingsModule: URI? = settings?.let { uri ->
+    if (uri.isAbsolute) uri else IoUtils.resolve(normalizedWorkingDir.toUri(), uri)
+  }
 
   /** [modulePath] after normalization. */
   val normalizedModulePath: List<Path>? = modulePath?.map(normalizedWorkingDir::resolve)

--- a/pkl-config-kotlin/src/test/kotlin/org/pkl/config/kotlin/KotlinObjectMappingTest.kt
+++ b/pkl-config-kotlin/src/test/kotlin/org/pkl/config/kotlin/KotlinObjectMappingTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,34 +62,34 @@ class KotlinObjectMappingTest {
     val code =
       """
       module KotlinGenericTypesTest
-      
+
       class Foo {
         value: Int
       }
-      
+
       // Sets
       stringSet: Set<String> = Set("in set")
       intSet: Set<Int> = Set(1,2,4,8,16,32)
       booleanSetSet: Set<Set<Boolean>> = Set(Set(false), Set(true), Set(true, false))
-      
+
       // Lists
       stringList: List<String> = List("in list")
       intList: List<Int> = List(1,2,3,5,7,11)
       booleanListList: List<List<Boolean>> = List(List(false), List(true), List(true, false))
-      
+
       // Maps
       intStringMap: Map<Int, String> = Map(0, "in map")
       booleanIntStringMapMap: Map<Boolean, Map<Int, String>> = Map(false, Map(0, "in map in map"))
       booleanIntMapStringMap: Map<Map<Boolean, Int>, String> = Map(Map(true, 42), "in map with map keys")
-      
+
       // Listings
       stringSetListing: Listing<Set<String>> = new { Set("in set in listing") }
       intListingListing: Listing<Listing<Int>> = new { new { 1337 } new { 100 } }
-      
+
       // Mappings
       intStringMapping: Mapping<Int, String> = new { [42] = "in map" }
       stringStringSetMapping: Mapping<String, Set<String>> = new { ["key"] = Set("in set in map") }
-      
+
       // Map & Mappings with structured keys
       intSetListStringMap: Map<List<Set<Int>>, String> = Map(List(Set(27)), "in map with structured key")
       typedStringMap: Map<Foo, String> = Map(
@@ -98,7 +98,7 @@ class KotlinObjectMappingTest {
       dynamicStringMap: Map<Dynamic, String> = Map(
         new Dynamic { value = 42 }, "using Dynamics",
         new Dynamic { hello = "world" }, "also works")
-      
+
       intListingStringMapping: Mapping<Listing<Int>, String> = new {
         [new Listing { 42 1337 }] = "structured key works"
       }
@@ -109,7 +109,7 @@ class KotlinObjectMappingTest {
       thisOneGoesToEleven: Mapping<List<Set<Int>>, Map<Listing<Int>, Mapping<Int, String>>> = new {
         [List(Set(0), Set(0), Set(7))] = Map(intListing, intStringMapping)
       }
-    """
+      """
         .trimIndent()
     val result = ConfigEvaluator.preconfigured().forKotlin().evaluate(text(code))
     assertDoesNotThrow { result.to<KotlinGenericTypesTest>() }

--- a/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,11 +48,11 @@ class AnalyzerTest {
         .resolve("test.pkl")
         .writeString(
           """
-            amends "pkl:base"
+          amends "pkl:base"
 
-            import "pkl:json"
+          import "pkl:json"
 
-            myProp = import("pkl:xml")
+          myProp = import("pkl:xml")
           """
             .trimIndent()
         )
@@ -76,7 +76,7 @@ class AnalyzerTest {
         .resolve("file1.pkl")
         .writeString(
           """
-            import* "*.pkl"
+          import* "*.pkl"
           """
             .trimIndent()
         )
@@ -143,11 +143,11 @@ class AnalyzerTest {
       .resolve("PklProject")
       .writeString(
         """
-          amends "pkl:Project"
+        amends "pkl:Project"
 
-          dependencies {
-            ["birds"] { uri = "package://localhost:0/birds@0.5.0" }
-          }
+        dependencies {
+          ["birds"] { uri = "package://localhost:0/birds@0.5.0" }
+        }
         """
           .trimIndent()
       )
@@ -155,25 +155,25 @@ class AnalyzerTest {
       .resolve("PklProject.deps.json")
       .writeString(
         """
-          {
-            "schemaVersion": 1,
-            "resolvedDependencies": {
-              "package://localhost:0/birds@0": {
-                "type": "remote",
-                "uri": "projectpackage://localhost:0/birds@0.5.0",
-                "checksums": {
-                  "sha256": "${'$'}skipChecksumVerification"
-                }
-              },
-              "package://localhost:0/fruit@1": {
-                "type": "remote",
-                "uri": "projectpackage://localhost:0/fruit@1.0.5",
-                "checksums": {
-                  "sha256": "${'$'}skipChecksumVerification"
-                }
+        {
+          "schemaVersion": 1,
+          "resolvedDependencies": {
+            "package://localhost:0/birds@0": {
+              "type": "remote",
+              "uri": "projectpackage://localhost:0/birds@0.5.0",
+              "checksums": {
+                "sha256": "${'$'}skipChecksumVerification"
+              }
+            },
+            "package://localhost:0/fruit@1": {
+              "type": "remote",
+              "uri": "projectpackage://localhost:0/fruit@1.0.5",
+              "checksums": {
+                "sha256": "${'$'}skipChecksumVerification"
               }
             }
           }
+        }
         """
           .trimIndent()
       )
@@ -200,7 +200,7 @@ class AnalyzerTest {
         .resolve("file1.pkl")
         .writeString(
           """
-            import "@birds/Bird.pkl"
+          import "@birds/Bird.pkl"
           """
             .trimIndent()
         )
@@ -236,11 +236,11 @@ class AnalyzerTest {
         .createParentDirectories()
         .writeString(
           """
-            amends "pkl:Project"
+          amends "pkl:Project"
 
-            dependencies {
-              ["birds"] = import("../birds/PklProject")
-            }
+          dependencies {
+            ["birds"] = import("../birds/PklProject")
+          }
           """
             .trimIndent()
         )
@@ -250,14 +250,14 @@ class AnalyzerTest {
       .createParentDirectories()
       .writeString(
         """
-          amends "pkl:Project"
+        amends "pkl:Project"
 
-          package {
-            name = "birds"
-            version = "1.0.0"
-            packageZipUrl = "https://localhost:0/foo.zip"
-            baseUri = "package://localhost:0/birds"
-          }
+        package {
+          name = "birds"
+          version = "1.0.0"
+          packageZipUrl = "https://localhost:0/foo.zip"
+          baseUri = "package://localhost:0/birds"
+        }
         """
           .trimIndent()
       )
@@ -268,16 +268,16 @@ class AnalyzerTest {
       .resolve("PklProject.deps.json")
       .writeString(
         """
-          {
-            "schemaVersion": 1,
-            "resolvedDependencies": {
-              "package://localhost:0/birds@1": {
-                "type": "local",
-                "uri": "projectpackage://localhost:0/birds@1.0.0",
-                "path": "../birds"
-              }
+        {
+          "schemaVersion": 1,
+          "resolvedDependencies": {
+            "package://localhost:0/birds@1": {
+              "type": "local",
+              "uri": "projectpackage://localhost:0/birds@1.0.0",
+              "path": "../birds"
             }
           }
+        }
         """
           .trimIndent()
       )
@@ -286,7 +286,7 @@ class AnalyzerTest {
         .resolve("main.pkl")
         .writeString(
           """
-            import "@birds/bird.pkl"
+          import "@birds/bird.pkl"
           """
             .trimIndent()
         )

--- a/pkl-core/src/test/kotlin/org/pkl/core/ClassInheritanceTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/ClassInheritanceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,14 +27,14 @@ class ClassInheritanceTest {
       evaluator.evaluateSchema(
         ModuleSource.text(
           """
-        class Thing
-        open class Base {
-          hidden thing: Thing
-        }
-        class Derived extends Base {
-          thing {}
-        }
-        """
+          class Thing
+          open class Base {
+            hidden thing: Thing
+          }
+          class Derived extends Base {
+            thing {}
+          }
+          """
             .trimIndent()
         )
       )
@@ -54,14 +54,14 @@ class ClassInheritanceTest {
       evaluator.evaluateSchema(
         ModuleSource.text(
           """
-        class Thing
-        open class Base {
-          hidden thing: Thing
-        }
-        class Derived extends Base {
-          thing: Thing = new {}
-        }
-        """
+          class Thing
+          open class Base {
+            hidden thing: Thing
+          }
+          class Derived extends Base {
+            thing: Thing = new {}
+          }
+          """
             .trimIndent()
         )
       )

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluateExpressionTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluateExpressionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class EvaluateExpressionTest {
         res3 = 3
         res4 = 4
       }
-    """
+      """
         .trimIndent()
     assertThat(evaluate(program, "res1")).isEqualTo(1L)
     val res2 = evaluate(program, "res2")
@@ -59,10 +59,10 @@ class EvaluateExpressionTest {
     val resp =
       evaluate(
         """
-      foo {
-        bar = 2
-      }
-    """
+        foo {
+          bar = 2
+        }
+        """
           .trimIndent(),
         "foo.bar",
       )
@@ -75,14 +75,14 @@ class EvaluateExpressionTest {
     val result =
       evaluate(
         """
-      foo {
-        bar = 2
-      }
-      
-      output {
-        renderer = new YamlRenderer {}
-      }
-    """
+        foo {
+          bar = 2
+        }
+
+        output {
+          renderer = new YamlRenderer {}
+        }
+        """
           .trimIndent(),
         "output.text",
       )
@@ -90,10 +90,10 @@ class EvaluateExpressionTest {
     assertThat(result)
       .isEqualTo(
         """
-      foo:
-        bar: 2
+        foo:
+          bar: 2
 
-    """
+        """
           .trimIndent()
       )
   }

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluateMultipleFileOutputTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluateMultipleFileOutputTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class EvaluateMultipleFileOutputTest {
           }
         }
       }
-    """
+      """
         .trimIndent()
     val output = evaluator.evaluateOutputFiles(text(program))
     assertThat(output.keys).isEqualTo(setOf("foo.yml", "bar.yml", "bar/biz.yml", "bar/../bark.yml"))
@@ -74,18 +74,18 @@ class EvaluateMultipleFileOutputTest {
           }
         }
       }
-    """
+      """
         .trimIndent()
     val output = evaluator.evaluateOutputFiles(text(program))
     assertThat(output["foo.json"]?.text)
       .isEqualTo(
         """
-      {
-        "foo": "fooey",
-        "bar": "barrey"
-      }
-      
-    """
+        {
+          "foo": "fooey",
+          "bar": "barrey"
+        }
+
+        """
           .trimIndent()
       )
   }
@@ -106,7 +106,7 @@ class EvaluateMultipleFileOutputTest {
           }
         }
       }
-    """
+      """
         .trimIndent()
     val output = evaluator.evaluateOutputFiles(text(program))
     evaluator.close()

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluateSchemaTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluateSchemaTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,9 +57,9 @@ class EvaluateSchemaTest {
       evaluator.evaluateSchema(
         text(
           """
-        class Foo {}
-        local class Baz {}
-        """
+          class Foo {}
+          local class Baz {}
+          """
             .trimIndent()
         )
       )

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluateTestsTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluateTestsTest.kt
@@ -36,15 +36,15 @@ class EvaluateTestsTest {
       evaluator.evaluateTest(
         text(
           """
-      amends "pkl:test"
+          amends "pkl:test"
 
-      facts {
-        ["should pass"] {
-          1 == 1
-          "foo" == "foo"
-        }
-      }
-    """
+          facts {
+            ["should pass"] {
+              1 == 1
+              "foo" == "foo"
+            }
+          }
+          """
             .trimIndent()
         ),
         true,
@@ -64,15 +64,15 @@ class EvaluateTestsTest {
       evaluator.evaluateTest(
         text(
           """
-        amends "pkl:test"
-  
-        facts {
-          ["should fail"] {
-            1 == 2
-            "foo" == "bar"
+          amends "pkl:test"
+
+          facts {
+            ["should fail"] {
+              1 == 2
+              "foo" == "bar"
+            }
           }
-        }
-        """
+          """
             .trimIndent()
         ),
         true,
@@ -91,10 +91,10 @@ class EvaluateTestsTest {
     assertThat(fail1.message)
       .isEqualTo(
         """
-      1 == 2 (repl:text)
-        │
-        false
-      """
+        1 == 2 (repl:text)
+          │
+          false
+        """
           .trimIndent()
       )
 
@@ -102,10 +102,10 @@ class EvaluateTestsTest {
     assertThat(fail2.message)
       .isEqualTo(
         """
-      "foo" == "bar" (repl:text)
-            │
-            false
-      """
+        "foo" == "bar" (repl:text)
+              │
+              false
+        """
           .trimIndent()
       )
   }
@@ -116,15 +116,15 @@ class EvaluateTestsTest {
       evaluator.evaluateTest(
         text(
           """
-        amends "pkl:test"
-  
-        facts {
-          ["should fail"] {
-            1 == 2
-            throw("got an error")
+          amends "pkl:test"
+
+          facts {
+            ["should fail"] {
+              1 == 2
+              throw("got an error")
+            }
           }
-        }
-        """
+          """
             .trimIndent()
         ),
         true,
@@ -144,14 +144,14 @@ class EvaluateTestsTest {
     assertThat(error.exception().message)
       .isEqualTo(
         """
-      –– Pkl Error ––
-      got an error
+        –– Pkl Error ––
+        got an error
 
-      6 | throw("got an error")
-          ^^^^^^^^^^^^^^^^^^^^^
-      at text#facts["should fail"][#2] (repl:text)
+        6 | throw("got an error")
+            ^^^^^^^^^^^^^^^^^^^^^
+        at text#facts["should fail"][#2] (repl:text)
 
-    """
+        """
           .trimIndent()
       )
   }
@@ -163,7 +163,7 @@ class EvaluateTestsTest {
       file,
       """
       amends "pkl:test"
-      
+
       examples {
         ["user"] {
           new {
@@ -172,7 +172,7 @@ class EvaluateTestsTest {
           }
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -187,7 +187,7 @@ class EvaluateTestsTest {
           }
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -222,7 +222,7 @@ class EvaluateTestsTest {
           }
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -237,7 +237,7 @@ class EvaluateTestsTest {
           }
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -275,7 +275,7 @@ class EvaluateTestsTest {
           }
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -290,7 +290,7 @@ class EvaluateTestsTest {
           }
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -320,7 +320,7 @@ class EvaluateTestsTest {
       file,
       """
       amends "pkl:test"
-      
+
       examples {
         ["user"] {
           new {
@@ -329,7 +329,7 @@ class EvaluateTestsTest {
           }
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -344,7 +344,7 @@ class EvaluateTestsTest {
           }
         }
       }
-    """
+      """
         .trimIndent(),
     )
 
@@ -386,13 +386,13 @@ class EvaluateTestsTest {
       file,
       """
       amends "pkl:test"
-      
+
       examples {
         ["myStr"] {
           "my \"string\""
         }
       }
-    """
+      """
         .trimIndent(),
     )
     evaluator.evaluateTest(path(file), false)
@@ -401,13 +401,13 @@ class EvaluateTestsTest {
     assertThat(expectedFile)
       .hasContent(
         """
-      examples {
-        ["myStr"] {
-          #"my "string""#
+        examples {
+          ["myStr"] {
+            #"my "string""#
+          }
         }
-      }
 
-    """
+        """
           .trimIndent()
       )
   }
@@ -420,25 +420,25 @@ class EvaluateTestsTest {
       file,
       """
       amends "pkl:test"
-      
+
       examples {
         ["myStr"] {
           "my \"string\""
         }
       }
-    """
+      """
         .trimIndent(),
     )
     createExpected(file)
       .writeString(
         """
-      examples {
-        ["myStr"] {
-          "my \"string\""
+        examples {
+          ["myStr"] {
+            "my \"string\""
+          }
         }
-      }
 
-    """
+        """
           .trimIndent()
       )
     val result = evaluator.evaluateTest(path(file), false)

--- a/pkl-core/src/test/kotlin/org/pkl/core/PcfRendererTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/PcfRendererTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class PcfRendererTest {
             corge = List(null, 1337, null, "Hello World")
             grault = Map("garply", null, "waldo", 42, "pigeon", null)
           }
-        """
+          """
             .trimIndent(),
         false to
           """
@@ -72,7 +72,7 @@ class PcfRendererTest {
             corge = List(null, 1337, null, "Hello World")
             grault = Map("garply", null, "waldo", 42, "pigeon", null)
           }
-        """
+          """
             .trimIndent(),
       )
 
@@ -81,24 +81,24 @@ class PcfRendererTest {
         .evaluate(
           ModuleSource.text(
             """
-        foo = null
-        bar = null
-        baz {
-          qux = 42
-          quux = null
-          corge = new Listing {
-            null
-            1337
-            null
-            "Hello World"
-          }
-          grault = new Mapping {
-            ["garply"] = null
-            ["waldo"] = 42
-            ["pigeon"] = null
-          }
-        }
-      """
+            foo = null
+            bar = null
+            baz {
+              qux = 42
+              quux = null
+              corge = new Listing {
+                null
+                1337
+                null
+                "Hello World"
+              }
+              grault = new Mapping {
+                ["garply"] = null
+                ["waldo"] = 42
+                ["pigeon"] = null
+              }
+            }
+            """
               .trimIndent()
           )
         )

--- a/pkl-core/src/test/kotlin/org/pkl/core/YamlRendererTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/YamlRendererTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,25 +47,25 @@ class YamlRendererTest {
       evaluator.evaluate(
         ModuleSource.text(
           """
-        stream = new Listing {
-          new Dynamic {
-            name = "Pigeon"
-            age = 42
+          stream = new Listing {
+            new Dynamic {
+              name = "Pigeon"
+              age = 42
+            }
+            new Listing {
+              "one"
+              "two"
+              "three"
+            }
+            new Mapping {
+              ["one"] = 1
+              ["two"] = 2
+              ["three"] = 3
+            }
+            "Blue Rock Ltd."
+            12345
           }
-          new Listing {
-            "one"
-            "two"
-            "three"
-          }
-          new Mapping {
-            ["one"] = 1
-            ["two"] = 2
-            ["three"] = 3
-          }
-          "Blue Rock Ltd."
-          12345
-        }
-        """
+          """
             .trimIndent()
         )
       )
@@ -79,19 +79,19 @@ class YamlRendererTest {
     assertThat(output.trim())
       .isEqualTo(
         """
-      name: Pigeon
-      age: 42
-      ---
-      - one
-      - two
-      - three
-      ---
-      one: 1
-      two: 2
-      three: 3
-      --- Blue Rock Ltd.
-      --- 12345
-    """
+        name: Pigeon
+        age: 42
+        ---
+        - one
+        - two
+        - three
+        ---
+        one: 1
+        two: 2
+        three: 3
+        --- Blue Rock Ltd.
+        --- 12345
+        """
           .trimIndent()
       )
   }
@@ -116,13 +116,13 @@ class YamlRendererTest {
       evaluator.evaluate(
         ModuleSource.text(
           """
-        num1 = "50"
-        num2 = "50.123"
-        `60.123` = "60.123"
-        yes = "yes"
-        truth = "true"
-        octalNumber = "0777"
-        """
+          num1 = "50"
+          num2 = "50.123"
+          `60.123` = "60.123"
+          yes = "yes"
+          truth = "true"
+          octalNumber = "0777"
+          """
             .trimIndent()
         )
       )
@@ -136,13 +136,13 @@ class YamlRendererTest {
     assertThat(output.trim())
       .isEqualTo(
         """
-      num1: '50'
-      num2: '50.123'
-      '60.123': '60.123'
-      'yes': 'yes'
-      truth: 'true'
-      octalNumber: '0777'
-    """
+        num1: '50'
+        num2: '50.123'
+        '60.123': '60.123'
+        'yes': 'yes'
+        truth: 'true'
+        octalNumber: '0777'
+        """
           .trimIndent()
       )
   }
@@ -154,10 +154,10 @@ class YamlRendererTest {
       evaluator.evaluate(
         ModuleSource.text(
           """
-        res1 = Bytes()
-        res2 = Bytes(1, 2, 3)
-        res3 = IntSeq(0, 127).toList().toBytes()
-        """
+          res1 = Bytes()
+          res2 = Bytes(1, 2, 3)
+          res3 = IntSeq(0, 127).toList().toBytes()
+          """
             .trimIndent()
         )
       )
@@ -171,10 +171,10 @@ class YamlRendererTest {
     assertThat(output.trim())
       .isEqualTo(
         """
-      res1: !!binary ''
-      res2: !!binary 'AQID'
-      res3: !!binary 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn8='
-    """
+        res1: !!binary ''
+        res2: !!binary 'AQID'
+        res3: !!binary 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn8='
+        """
           .trimIndent()
       )
   }

--- a/pkl-core/src/test/kotlin/org/pkl/core/ast/builder/ImportsAndReadsParserTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/ast/builder/ImportsAndReadsParserTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ class ImportsAndReadsParserTest {
           }
         }
       }
-    """
+      """
         .trimIndent()
     val moduleKey = ModuleKeys.synthetic(URI("repl:text"), moduleText)
     val imports =
@@ -70,7 +70,7 @@ class ImportsAndReadsParserTest {
   fun `invalid syntax`() {
     val moduleText =
       """
-        not valid Pkl syntax
+      not valid Pkl syntax
       """
         .trimIndent()
     val moduleKey = ModuleKeys.synthetic(URI("repl:text"), moduleText)
@@ -81,12 +81,12 @@ class ImportsAndReadsParserTest {
     assertThat(err.toPklException(StackFrameTransformers.defaultTransformer, false))
       .hasMessage(
         """
-          –– Pkl Error ––
-          Invalid property definition. Expected a type annotation, `=` or `{`.
-          
-          1 | not valid Pkl syntax
-              ^^^
-          at text (repl:text)
+        –– Pkl Error ––
+        Invalid property definition. Expected a type annotation, `=` or `{`.
+
+        1 | not valid Pkl syntax
+            ^^^
+        at text (repl:text)
 
         """
           .trimIndent()

--- a/pkl-core/src/test/kotlin/org/pkl/core/externalreader/TestExternalModuleReader.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/externalreader/TestExternalModuleReader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ class TestExternalModuleReader : ExternalModuleReader {
     """
     name = "Pigeon"
     age = 40
-  """
+    """
       .trimIndent()
 
   override fun listElements(uri: URI): List<PathElement> = emptyList()

--- a/pkl-core/src/test/kotlin/org/pkl/core/packages/DependencyMetadataTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/packages/DependencyMetadataTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,110 +69,110 @@ class DependencyMetadataTest {
     )
   private val dependencyMetadataStr =
     """
-     {
-       "name": "my-proj-name",
-       "packageUri": "package://example.com/my-proj-name@0.10.0",
-       "version": "0.10.0",
-       "packageZipUrl": "https://example.com/foo/bar@0.5.3.zip",
-       "packageZipChecksums": {
-         "sha256": "abc123"
-       },
-       "dependencies": {
-         "foo": {
-           "uri": "package://example.com/foo@0.5.3",
-           "checksums": {
-             "sha256": "abc123"
-           }
-         }
-       },
-       "sourceCodeUrlScheme": "https://example.com/my/source/0.5.3/blob%{path}#L%{line}-L%{endLine}",
-       "sourceCode": "https://example.com/my/source",
-       "documentation": "https://example.com/my/docs",
-       "license": "MIT",
-       "licenseText": "The MIT License, you know it",
-       "authors": [
-         "birdy@bird.com"
-       ],
-       "issueTracker": "https://example.com/issues",
-       "description": "Some package description",
-       "annotations": [
-         {
-           "type": "PObject",
-           "classInfo": {
-             "moduleName": "pkl.base",
-             "class": "Unlisted",
-             "moduleUri": "pkl:base"
-           },
-           "properties": {}
-         },
-         {
-           "type": "PObject",
-           "classInfo": {
-             "moduleName": "pkl.base",
-             "class": "Deprecated",
-             "moduleUri": "pkl:base"
-           },
-           "properties": {
-             "since": "0.26.1",
-             "message": "don't use"
-           }
-         },
-         {
-           "type": "PObject",
-           "classInfo": {
-             "moduleName": "myModule",
-             "class": "MyAnnotation",
-             "moduleUri": "pkl:fake"
-           },
-           "properties": {
-             "string": "bar",
-             "boolean": true,
-             "long": 1,
-             "double": 1.66,
-             "null": null,
-             "list": [
-               "a",
-               "b"
-             ],
-             "set": {
-               "type": "Set",
-               "value": [
-                 "a",
-                 "b"
-               ]
-             },
-             "map": {
-               "type": "Map",
-               "value": [
-                 {
-                   "key": true,
-                   "value": "t"
-                 },
-                 {
-                   "key": false,
-                   "value": "f"
-                 }
-               ]
-             },
-             "dataSize": {
-               "type": "DataSize",
-               "unit": "gb",
-               "value": 1.5
-             },
-             "duration": {
-               "type": "Duration",
-               "unit": "h",
-               "value": 2.9
-             },
-             "pair": {
-               "type": "Pair",
-               "first": 1,
-               "second": "1"
-             }
-           }
-         }
-       ]
-     }
+    {
+      "name": "my-proj-name",
+      "packageUri": "package://example.com/my-proj-name@0.10.0",
+      "version": "0.10.0",
+      "packageZipUrl": "https://example.com/foo/bar@0.5.3.zip",
+      "packageZipChecksums": {
+        "sha256": "abc123"
+      },
+      "dependencies": {
+        "foo": {
+          "uri": "package://example.com/foo@0.5.3",
+          "checksums": {
+            "sha256": "abc123"
+          }
+        }
+      },
+      "sourceCodeUrlScheme": "https://example.com/my/source/0.5.3/blob%{path}#L%{line}-L%{endLine}",
+      "sourceCode": "https://example.com/my/source",
+      "documentation": "https://example.com/my/docs",
+      "license": "MIT",
+      "licenseText": "The MIT License, you know it",
+      "authors": [
+        "birdy@bird.com"
+      ],
+      "issueTracker": "https://example.com/issues",
+      "description": "Some package description",
+      "annotations": [
+        {
+          "type": "PObject",
+          "classInfo": {
+            "moduleName": "pkl.base",
+            "class": "Unlisted",
+            "moduleUri": "pkl:base"
+          },
+          "properties": {}
+        },
+        {
+          "type": "PObject",
+          "classInfo": {
+            "moduleName": "pkl.base",
+            "class": "Deprecated",
+            "moduleUri": "pkl:base"
+          },
+          "properties": {
+            "since": "0.26.1",
+            "message": "don't use"
+          }
+        },
+        {
+          "type": "PObject",
+          "classInfo": {
+            "moduleName": "myModule",
+            "class": "MyAnnotation",
+            "moduleUri": "pkl:fake"
+          },
+          "properties": {
+            "string": "bar",
+            "boolean": true,
+            "long": 1,
+            "double": 1.66,
+            "null": null,
+            "list": [
+              "a",
+              "b"
+            ],
+            "set": {
+              "type": "Set",
+              "value": [
+                "a",
+                "b"
+              ]
+            },
+            "map": {
+              "type": "Map",
+              "value": [
+                {
+                  "key": true,
+                  "value": "t"
+                },
+                {
+                  "key": false,
+                  "value": "f"
+                }
+              ]
+            },
+            "dataSize": {
+              "type": "DataSize",
+              "unit": "gb",
+              "value": 1.5
+            },
+            "duration": {
+              "type": "Duration",
+              "unit": "h",
+              "value": 2.9
+            },
+            "pair": {
+              "type": "Pair",
+              "first": 1,
+              "second": "1"
+            }
+          }
+        }
+      ]
+    }
     """
       .trimIndent()
 
@@ -210,43 +210,43 @@ class DependencyMetadataTest {
       )
     val dependencyMetadataStr =
       """
-     {
-       "name": "my-proj-name",
-       "packageUri": "package://example.com/my-proj-name@0.10.0",
-       "version": "0.10.0",
-       "packageZipUrl": "https://example.com/foo/bar@0.5.3.zip",
-       "packageZipChecksums": {
-         "sha256": "abc123"
-       },
-       "dependencies": {},
-       "sourceCodeUrlScheme": "https://example.com/my/source/0.5.3/blob%{path}#L%{line}-L%{endLine}",
-       "sourceCode": "https://example.com/my/source",
-       "documentation": "https://example.com/my/docs",
-       "license": "MIT",
-       "licenseText": "The MIT License, you know it",
-       "authors": [
-         "birdy@bird.com"
-       ],
-       "issueTracker": "https://example.com/issues",
-       "description": "Some package description",
-       "annotations": [
-         {
-           "type": "PObject",
-           "classInfo": {
-             "moduleName": "myModule",
-             "class": "MyAnnotation",
-             "moduleUri": "pkl:fake"
-           },
-           "properties": {
-             "pattern": {
-               "type": "Pattern",
-               "value": ".*"
-             }
-           }
-         }
-       ]
-     }
-    """
+      {
+        "name": "my-proj-name",
+        "packageUri": "package://example.com/my-proj-name@0.10.0",
+        "version": "0.10.0",
+        "packageZipUrl": "https://example.com/foo/bar@0.5.3.zip",
+        "packageZipChecksums": {
+          "sha256": "abc123"
+        },
+        "dependencies": {},
+        "sourceCodeUrlScheme": "https://example.com/my/source/0.5.3/blob%{path}#L%{line}-L%{endLine}",
+        "sourceCode": "https://example.com/my/source",
+        "documentation": "https://example.com/my/docs",
+        "license": "MIT",
+        "licenseText": "The MIT License, you know it",
+        "authors": [
+          "birdy@bird.com"
+        ],
+        "issueTracker": "https://example.com/issues",
+        "description": "Some package description",
+        "annotations": [
+          {
+            "type": "PObject",
+            "classInfo": {
+              "moduleName": "myModule",
+              "class": "MyAnnotation",
+              "moduleUri": "pkl:fake"
+            },
+            "properties": {
+              "pattern": {
+                "type": "Pattern",
+                "value": ".*"
+              }
+            }
+          }
+        ]
+      }
+      """
         .trimIndent()
 
     val parsed = DependencyMetadata.parse(dependencyMetadataStr)

--- a/pkl-core/src/test/kotlin/org/pkl/core/packages/PackageResolversTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/packages/PackageResolversTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,13 +87,13 @@ class PackageResolversTest {
       assertThat(bytes)
         .isEqualTo(
           """
-        Bird.pkl
-        allFruit.pkl
-        catalog
-        catalog.pkl
-        some
+          Bird.pkl
+          allFruit.pkl
+          catalog
+          catalog.pkl
+          some
 
-      """
+          """
             .trimIndent()
         )
     }
@@ -203,9 +203,9 @@ class PackageResolversTest {
       assertThat(error)
         .hasMessageContaining(
           """
-        Computed checksum: "a6bf858cdd1c09da475c2abe50525902580910ee5cc1ff624999170591bf8f69"
-        Expected checksum: "intentionally bogus checksum"
-      """
+          Computed checksum: "a6bf858cdd1c09da475c2abe50525902580910ee5cc1ff624999170591bf8f69"
+          Expected checksum: "intentionally bogus checksum"
+          """
             .trimIndent()
         )
     }

--- a/pkl-core/src/test/kotlin/org/pkl/core/parser/ShebangTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/parser/ShebangTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ class ShebangTest {
           """
           #!/usr/local/bin/pkl
           x = 1
-        """
+          """
             .trimIndent()
         )
       )

--- a/pkl-core/src/test/kotlin/org/pkl/core/parser/TrailingCommasTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/parser/TrailingCommasTest.kt
@@ -28,19 +28,19 @@ class TrailingCommasTest {
       Parser()
         .parseModule(
           """
-        class Foo<
-          Key,
-          Value,
-        >
-        
-        class Bar<
-          Key,
-          Value,
-        > {
-          baz: Key
-          buzz: Value
-        }
-      """
+          class Foo<
+            Key,
+            Value,
+          >
+
+          class Bar<
+            Key,
+            Value,
+          > {
+            baz: Key
+            buzz: Value
+          }
+          """
             .trimIndent()
         )
 
@@ -63,11 +63,11 @@ class TrailingCommasTest {
       Parser()
         .parseModule(
           """
-        function foo<
-          A,
-          B,
-        >(a: A, b: B,): Value? = "\(a):\(b)"
-      """
+          function foo<
+            A,
+            B,
+          >(a: A, b: B,): Value? = "\(a):\(b)"
+          """
             .trimIndent()
         )
 

--- a/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectDepsTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectDepsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,25 +27,25 @@ import org.pkl.core.util.EconomicMaps
 class ProjectDepsTest {
   private val projectDepsStr =
     """
-        {
-          "schemaVersion": 1,
-          "resolvedDependencies": {
-            "package://localhost:0/birds@0": {
-              "type": "remote",
-              "uri": "package://localhost:0/birds@0.5.0",
-              "checksums": {
-                "sha256": "abc123"
-              }
-            },
-            "package://localhost:0/fruit@1": {
-              "type": "local",
-              "uri": "package://localhost:0/fruit@1.1.0",
-              "path": "../fruit"
-            }
+    {
+      "schemaVersion": 1,
+      "resolvedDependencies": {
+        "package://localhost:0/birds@0": {
+          "type": "remote",
+          "uri": "package://localhost:0/birds@0.5.0",
+          "checksums": {
+            "sha256": "abc123"
           }
+        },
+        "package://localhost:0/fruit@1": {
+          "type": "local",
+          "uri": "package://localhost:0/fruit@1.1.0",
+          "path": "../fruit"
         }
-        
-      """
+      }
+    }
+
+    """
       .trimIndent()
 
   private val projectDeps = let {

--- a/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,9 +51,9 @@ class ProjectTest {
         "MIT",
         """
         # Some License text
-        
+
         This is my license text
-      """
+        """
           .trimIndent(),
         URI("https://example.com/my/issues"),
         listOf(Path.of("apiTest1.pkl"), Path.of("apiTest2.pkl")),
@@ -143,12 +143,12 @@ class ProjectTest {
         exclude { "*.exe" }
         issueTracker = "https://example.com/my/issues"
       }
-      
+
       tests {
         "test1.pkl"
         "test2.pkl"
       }
-    """
+      """
         .trimIndent()
     )
     val project = Project.loadFromPath(projectPath)
@@ -167,7 +167,7 @@ class ProjectTest {
       module com.apple.Foo
 
       foo = 1
-    """
+      """
         .trimIndent()
     )
     assertThatCode { Project.loadFromPath(projectPath, SecurityManagers.defaultManager, null) }
@@ -218,7 +218,7 @@ class ProjectTest {
         """
         –– Pkl Error ––
         Local project dependencies cannot be circular.
-        
+
         Cycle:
         ┌─>
         │  file:///org/pkl/core/project/projectCycle2/PklProject
@@ -240,23 +240,23 @@ class ProjectTest {
         """
         –– Pkl Error ––
         Local project dependencies cannot be circular.
-        
+
         The following circular imports were found.
         Not all of them are necessarily problematic.
         The problematic cycles are those declared as local dependencies.
-        
+
         Cycle 1:
         ┌─>
         │  file:///org/pkl/core/project/projectCycle2/PklProject
         │
         │  file:///org/pkl/core/project/projectCycle3/PklProject
         └─
-        
+
         Cycle 2:
         ┌─>
         │  file:///org/pkl/core/project/projectCycle4/PklProject
         └─
-        
+
         """
           .trimIndent()
       )

--- a/pkl-core/src/test/kotlin/org/pkl/core/runtime/CommandSpecParserTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/runtime/CommandSpecParserTest.kt
@@ -35,14 +35,14 @@ class CommandSpecParserTest {
       """
       extends "pkl:Command"
       import "pkl:Command"
-      
+
       options: Options
-      
+
       output {
         value = options
       }
-      
-    """
+
+      """
         .trimIndent()
 
     private val evaluator = Evaluator.preconfigured()
@@ -75,8 +75,8 @@ class CommandSpecParserTest {
       writePklFile(
         "cmd.pkl",
         """
-          extends "pkl:Command"
-          options = new {}
+        extends "pkl:Command"
+        options = new {}
         """
           .trimIndent(),
       )
@@ -92,8 +92,8 @@ class CommandSpecParserTest {
       writePklFile(
         "cmd.pkl",
         """
-          extends "pkl:Command"
-          options {}
+        extends "pkl:Command"
+        options {}
         """
           .trimIndent(),
       )
@@ -109,8 +109,8 @@ class CommandSpecParserTest {
       writePklFile(
         "cmd.pkl",
         """
-          extends "pkl:Command"
-          parent = new {}
+        extends "pkl:Command"
+        parent = new {}
         """
           .trimIndent(),
       )
@@ -126,8 +126,8 @@ class CommandSpecParserTest {
       writePklFile(
         "cmd.pkl",
         """
-          extends "pkl:Command"
-          parent {}
+        extends "pkl:Command"
+        parent {}
         """
           .trimIndent(),
       )
@@ -143,8 +143,8 @@ class CommandSpecParserTest {
       writePklFile(
         "cmd.pkl",
         """
-          extends "pkl:Command"
-          options: "nope" | "try again"
+        extends "pkl:Command"
+        options: "nope" | "try again"
         """
           .trimIndent(),
       )
@@ -163,9 +163,9 @@ class CommandSpecParserTest {
       writePklFile(
         "cmd.pkl",
         """
-          extends "pkl:Command"
-          options: Options
-          abstract class Options {}
+        extends "pkl:Command"
+        options: Options
+        abstract class Options {}
         """
           .trimIndent(),
       )
@@ -181,9 +181,9 @@ class CommandSpecParserTest {
       writePklFile(
         "cmd.pkl",
         """
-          extends "pkl:Command"
-          command = new Foo {}
-          class Foo
+        extends "pkl:Command"
+        command = new Foo {}
+        class Foo
         """
           .trimIndent(),
       )
@@ -220,7 +220,7 @@ class CommandSpecParserTest {
             @CountedFlag { shortName = "z" }
             baz: Int
           }
-        """
+          """
             .trimIndent(),
       )
 
@@ -258,12 +258,12 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Flag
-        @Argument
-        foo: String
-      }
-    """
+          class Options {
+            @Flag
+            @Argument
+            foo: String
+          }
+          """
             .trimIndent(),
       )
 
@@ -280,10 +280,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo = "bar"
-      }
-    """
+          class Options {
+            foo = "bar"
+          }
+          """
             .trimIndent(),
       )
 
@@ -299,10 +299,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: "oops" | String
-      }
-    """
+          class Options {
+            foo: "oops" | String
+          }
+          """
             .trimIndent(),
       )
 
@@ -319,11 +319,11 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        foo: String = "bar"
-      }
-    """
+          class Options {
+            @Argument
+            foo: String = "bar"
+          }
+          """
             .trimIndent(),
       )
 
@@ -339,11 +339,11 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        foo: String?
-      }
-    """
+          class Options {
+            @Argument
+            foo: String?
+          }
+          """
             .trimIndent(),
       )
 
@@ -367,7 +367,7 @@ class CommandSpecParserTest {
             qux: Map<String, String> = baz
             quux: Int = 5
           }
-        """
+          """
             .trimIndent(),
       )
 
@@ -411,10 +411,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        help: Boolean
-      }
-    """
+          class Options {
+            help: Boolean
+          }
+          """
             .trimIndent(),
       )
 
@@ -430,11 +430,11 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Flag { shortName = "h" }
-        showHelp: Boolean
-      }
-    """
+          class Options {
+            @Flag { shortName = "h" }
+            showHelp: Boolean
+          }
+          """
             .trimIndent(),
       )
 
@@ -451,10 +451,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        `root-dir`: String
-      }
-    """
+          class Options {
+            `root-dir`: String
+          }
+          """
             .trimIndent(),
       )
 
@@ -471,13 +471,13 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Argument
-        list: List<String>
-        @Argument
-        set: Set<String>
-      }
-    """
+          class Options {
+            @Argument
+            list: List<String>
+            @Argument
+            set: Set<String>
+          }
+          """
             .trimIndent(),
       )
 
@@ -495,10 +495,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: List<List<"a" | "b">>
-      }
-    """
+          class Options {
+            foo: List<List<"a" | "b">>
+          }
+          """
             .trimIndent(),
       )
 
@@ -515,10 +515,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: List<Map<String, "a" | "b">>
-      }
-    """
+          class Options {
+            foo: List<Map<String, "a" | "b">>
+          }
+          """
             .trimIndent(),
       )
 
@@ -537,10 +537,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: Map<String, List<"a" | "b">>
-      }
-    """
+          class Options {
+            foo: Map<String, List<"a" | "b">>
+          }
+          """
             .trimIndent(),
       )
 
@@ -557,10 +557,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: Map<String, Map<String, "a" | "b">>
-      }
-    """
+          class Options {
+            foo: Map<String, Map<String, "a" | "b">>
+          }
+          """
             .trimIndent(),
       )
 
@@ -579,10 +579,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: Map<Map<String, "a" | "b">, String>
-      }
-    """
+          class Options {
+            foo: Map<Map<String, "a" | "b">, String>
+          }
+          """
             .trimIndent(),
       )
 
@@ -601,10 +601,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: Map<Map<String, "a" | "b">, String>
-      }
-    """
+          class Options {
+            foo: Map<Map<String, "a" | "b">, String>
+          }
+          """
             .trimIndent(),
       )
 
@@ -623,11 +623,11 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @Flag { convert = (it) -> Pair("foo", "a") }
-        foo: Map<Map<String, "a" | "b">, String>
-      }
-    """
+          class Options {
+            @Flag { convert = (it) -> Pair("foo", "a") }
+            foo: Map<Map<String, "a" | "b">, String>
+          }
+          """
             .trimIndent(),
       )
 
@@ -641,11 +641,11 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: Foo
-      }
-      class Foo
-    """
+          class Options {
+            foo: Foo
+          }
+          class Foo
+          """
             .trimIndent(),
       )
 
@@ -661,16 +661,16 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        a: String(true)
-        b: String?(true)
-        c: String(true)?
-        d: List<String(true)>
-        e: List<String(true)>(true)
-        f: List<String(true)>(true)?(true)
-        g: (Map<String(true), String(true)>(true)?(true))(true)
-      }
-    """
+          class Options {
+            a: String(true)
+            b: String?(true)
+            c: String(true)?
+            d: List<String(true)>
+            e: List<String(true)>(true)
+            f: List<String(true)>(true)?(true)
+            g: (Map<String(true), String(true)>(true)?(true))(true)
+          }
+          """
             .trimIndent(),
       )
 
@@ -683,17 +683,17 @@ class CommandSpecParserTest {
       writePklFile(
         "cmd.pkl",
         """
-      extends "pkl:Command"
-      import "pkl:Command"
-      command {
-        subcommands {
-          new Sub { command { name = "foo" } }
-          new Sub { command { name = "foo" } }
+        extends "pkl:Command"
+        import "pkl:Command"
+        command {
+          subcommands {
+            new Sub { command { name = "foo" } }
+            new Sub { command { name = "foo" } }
+          }
         }
-      }
-      
-      class Sub extends Command
-    """
+
+        class Sub extends Command
+        """
           .trimIndent(),
       )
 
@@ -731,10 +731,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        foo: Map
-      }
-    """
+          class Options {
+            foo: Map
+          }
+          """
             .trimIndent(),
       )
 
@@ -751,11 +751,11 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @BooleanFlag
-        foo: String
-      }
-    """
+          class Options {
+            @BooleanFlag
+            foo: String
+          }
+          """
             .trimIndent(),
       )
 
@@ -773,11 +773,11 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        @CountedFlag
-        foo: String
-      }
-    """
+          class Options {
+            @CountedFlag
+            foo: String
+          }
+          """
             .trimIndent(),
       )
 
@@ -795,10 +795,10 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      class Options {
-        format: "json" | "yaml" | "toml"
-      }
-    """
+          class Options {
+            format: "json" | "yaml" | "toml"
+          }
+          """
             .trimIndent(),
       )
 
@@ -822,11 +822,11 @@ class CommandSpecParserTest {
         "cmd.pkl",
         renderOptions +
           """
-      typealias OptionalString = String?
-      class Options {
-        foo: OptionalString
-      }
-    """
+          typealias OptionalString = String?
+          class Options {
+            foo: OptionalString
+          }
+          """
             .trimIndent(),
       )
 

--- a/pkl-core/src/test/kotlin/org/pkl/core/runtime/StackTraceRendererTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/runtime/StackTraceRendererTest.kt
@@ -41,8 +41,8 @@ class StackTraceRendererTest {
           evaluator.evaluate(
             ModuleSource.text(
               """
-          self: String = "Strings; if they were lazy, you could tie the knot on \(self.take(7))"
-          """
+              self: String = "Strings; if they were lazy, you could tie the knot on \(self.take(7))"
+              """
                 .trimIndent()
             )
           )
@@ -71,7 +71,7 @@ class StackTraceRendererTest {
               bar: String = "BAR:" + baz
               baz: String = "BAZ:" + qux
               qux: String = "QUX:" + foo
-            """
+              """
                 .trimIndent()
             )
           )
@@ -108,35 +108,35 @@ class StackTraceRendererTest {
   fun `reduce stack overflow from actual Pkl code`() {
     val pklCode =
       """
-        function suffix(n: UInt): UInt =
-          if (n == 0)
-            0
-          else
-            suffix(n - 1)
+      function suffix(n: UInt): UInt =
+        if (n == 0)
+          0
+        else
+          suffix(n - 1)
 
-        function loopBody4(n: UInt): UInt =
-          if (n == 0)
-            loop()
-          else
-            loopBody1(n - 1)
+      function loopBody4(n: UInt): UInt =
+        if (n == 0)
+          loop()
+        else
+          loopBody1(n - 1)
 
-        function loopBody3(n: UInt) = loopBody4(n)
-        function loopBody2(n: UInt) = loopBody3(n)
-        function loopBody1(n: UInt) = loopBody2(n)
+      function loopBody3(n: UInt) = loopBody4(n)
+      function loopBody2(n: UInt) = loopBody3(n)
+      function loopBody1(n: UInt) = loopBody2(n)
 
-        function loop(): UInt =
-          if (suffix(100) > 0)
-            1
-          else
-            loopBody1(5)
+      function loop(): UInt =
+        if (suffix(100) > 0)
+          1
+        else
+          loopBody1(5)
 
-        function prefix(n: UInt): UInt =
-          if (n == 0)
-            loop()
-          else
-            prefix(n - 1)
+      function prefix(n: UInt): UInt =
+        if (n == 0)
+          loop()
+        else
+          prefix(n - 1)
 
-        result = prefix(13)
+      result = prefix(13)
       """
         .trimIndent()
     val message =
@@ -197,27 +197,27 @@ class StackTraceRendererTest {
     assertThat(renderedFrames)
       .isEqualTo(
         """
-      1 | foo
-          ^
-      at <unknown> (file:bar)
+        1 | foo
+            ^
+        at <unknown> (file:bar)
 
-      2 | foo
-          ^
-      at <unknown> (file:baz)
+        2 | foo
+            ^
+        at <unknown> (file:baz)
 
-      1 | foo
-          ^
-      at <unknown> (file:foo)
+        1 | foo
+            ^
+        at <unknown> (file:foo)
 
-      2 | foo
-          ^
-      at <unknown> (file:foo)
+        2 | foo
+            ^
+        at <unknown> (file:foo)
 
-      3 | foo
-          ^
-      at <unknown> (file:foo)
+        3 | foo
+            ^
+        at <unknown> (file:foo)
 
-    """
+        """
           .trimIndent()
       )
   }

--- a/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/settings/PklSettingsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,15 +128,15 @@ class PklSettingsTest {
       evaluator.evaluate(
         ModuleSource.text(
           """
-        import "pkl:settings"
-  
-        system = settings.System
-        idea = settings.Idea
-        textMate = settings.TextMate
-        sublime = settings.Sublime
-        atom = settings.Atom
-        vsCode = settings.VsCode
-        """
+          import "pkl:settings"
+
+          system = settings.System
+          idea = settings.Idea
+          textMate = settings.TextMate
+          sublime = settings.Sublime
+          atom = settings.Atom
+          vsCode = settings.VsCode
+          """
             .trimIndent()
         )
       )

--- a/pkl-core/src/test/kotlin/org/pkl/core/stdlib/SimpleReportTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/stdlib/SimpleReportTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,8 @@ class SimpleReportTest {
 
     val expectedOutput =
       """
-            0.0% tests pass [2/2 failed], 99.9% asserts pass [2/754444 failed]
-            """
+      0.0% tests pass [2/2 failed], 99.9% asserts pass [2/754444 failed]
+      """
         .trimIndent()
 
     assertThat(writer.toString().trimIndent()).isEqualTo(expectedOutput)

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/MainPageGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/MainPageGenerator.kt
@@ -69,13 +69,12 @@ internal class MainPageGenerator(
   private fun HtmlBlockTag.renderPackages() {
     if (packagesData.isEmpty()) return
 
-    val sortedPackages =
-      packagesData.sortedWith { pkg1, pkg2 ->
-        when {
-          pkg1.ref.pkg == "pkl" -> -1 // always sort the stdlib first
-          else -> pkg1.ref.pkg.compareTo(pkg2.ref.pkg)
-        }
+    val sortedPackages = packagesData.sortedWith { pkg1, pkg2 ->
+      when {
+        pkg1.ref.pkg == "pkl" -> -1 // always sort the stdlib first
+        else -> pkg1.ref.pkg.compareTo(pkg2.ref.pkg)
       }
+    }
 
     div {
       classes = setOf("member-group")

--- a/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
+++ b/pkl-doc/src/main/kotlin/org/pkl/doc/PageGenerator.kt
@@ -723,11 +723,13 @@ internal abstract class PageGenerator<out S>(
           ?.let { markdownRenderer.render(markdownParser.parse(it)).trim().ifEmpty { null } }
       }
 
-    private val deprecatedAnnotation: PObject? =
-      annotations.find { it.classInfo == PClassInfo.Deprecated }
+    private val deprecatedAnnotation: PObject? = annotations.find {
+      it.classInfo == PClassInfo.Deprecated
+    }
 
-    private val alsoKnownAsAnnotation: PObject? =
-      annotations.find { it.classInfo == PClassInfo.AlsoKnownAs }
+    private val alsoKnownAsAnnotation: PObject? = annotations.find {
+      it.classInfo == PClassInfo.AlsoKnownAs
+    }
 
     val isDeprecatedMember: Boolean = deprecatedAnnotation != null
 

--- a/pkl-doc/src/test/kotlin/org/pkl/doc/DocMigratorTest.kt
+++ b/pkl-doc/src/test/kotlin/org/pkl/doc/DocMigratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,10 +96,10 @@ class DocMigratorTest {
       tempDir.resolve("index.js").also { f ->
         f.writeText(
           """
-        runtimeData.links('known-versions','[{"text":"1.2.3","classes":"current-version"}]');
-        runtimeData.links('known-usages','[{"text":"Foo","href":"../moduleTypes2/Foo.html"},{"text":"moduleTypes2","href":"../moduleTypes2/index.html"}]');
-        runtimeData.links('known-subtypes','[{"text":"Foo","href":"../moduleTypes2/Foo.html"}]');
-      """
+          runtimeData.links('known-versions','[{"text":"1.2.3","classes":"current-version"}]');
+          runtimeData.links('known-usages','[{"text":"Foo","href":"../moduleTypes2/Foo.html"},{"text":"moduleTypes2","href":"../moduleTypes2/index.html"}]');
+          runtimeData.links('known-subtypes','[{"text":"Foo","href":"../moduleTypes2/Foo.html"}]');
+          """
             .trimIndent()
         )
       }

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/AnalyzeImportsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/AnalyzeImportsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,19 +25,19 @@ class AnalyzeImportsTest : AbstractTest() {
     writeFile(
       "build.gradle",
       """
-        plugins {
-          id "org.pkl-lang"
-        }
+      plugins {
+        id "org.pkl-lang"
+      }
 
-        pkl {
-          analyzers {
-            imports {
-              analyzeMyImports {
-                sourceModules = ["input.pkl"]
-              }
+      pkl {
+        analyzers {
+          imports {
+            analyzeMyImports {
+              sourceModules = ["input.pkl"]
             }
           }
         }
+      }
       """
         .trimIndent(),
     )
@@ -51,20 +51,20 @@ class AnalyzeImportsTest : AbstractTest() {
     writeFile(
       "build.gradle",
       """
-        plugins {
-          id "org.pkl-lang"
-        }
+      plugins {
+        id "org.pkl-lang"
+      }
 
-        pkl {
-          analyzers {
-            imports {
-              analyzeMyImports {
-                sourceModules = ["input.pkl"]
-                outputFile = file("myFile.pcf")
-              }
+      pkl {
+        analyzers {
+          imports {
+            analyzeMyImports {
+              sourceModules = ["input.pkl"]
+              outputFile = file("myFile.pcf")
             }
           }
         }
+      }
       """
         .trimIndent(),
     )
@@ -78,20 +78,20 @@ class AnalyzeImportsTest : AbstractTest() {
     writeFile(
       "build.gradle",
       """
-        plugins {
-          id "org.pkl-lang"
-        }
+      plugins {
+        id "org.pkl-lang"
+      }
 
-        pkl {
-          analyzers {
-            imports {
-              analyzeMyImports {
-                sourceModules = ["input.pkl"]
-                outputFormat = "json"
-              }
+      pkl {
+        analyzers {
+          imports {
+            analyzeMyImports {
+              sourceModules = ["input.pkl"]
+              outputFormat = "json"
             }
           }
         }
+      }
       """
         .trimIndent(),
     )
@@ -99,8 +99,8 @@ class AnalyzeImportsTest : AbstractTest() {
     assertThat(result.output)
       .contains(
         """
-          {
-            "imports": {
+        {
+          "imports": {
         """
           .trimIndent()
       )

--- a/pkl-server/src/main/kotlin/org/pkl/server/Utils.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/Utils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,19 +36,19 @@ internal fun AutoCloseable.closeQuietly() {
   }
 }
 
-internal val threadLocalBufferPacker: ThreadLocal<MessageBufferPacker> =
-  ThreadLocal.withInitial { MessagePack.newDefaultBufferPacker() }
+internal val threadLocalBufferPacker: ThreadLocal<MessageBufferPacker> = ThreadLocal.withInitial {
+  MessagePack.newDefaultBufferPacker()
+}
 
-private val threadLocalEncoder: ThreadLocal<(Message) -> ByteArray> =
-  ThreadLocal.withInitial {
-    val packer = threadLocalBufferPacker.get()
-    val encoder = ServerMessagePackEncoder(packer);
-    { message: Message ->
-      packer.clear()
-      encoder.encode(message)
-      packer.toByteArray()
-    }
+private val threadLocalEncoder: ThreadLocal<(Message) -> ByteArray> = ThreadLocal.withInitial {
+  val packer = threadLocalBufferPacker.get()
+  val encoder = ServerMessagePackEncoder(packer);
+  { message: Message ->
+    packer.clear()
+    encoder.encode(message)
+    packer.toByteArray()
   }
+}
 
 @Suppress("unused")
 internal fun encode(message: Message): ByteArray {

--- a/pkl-server/src/test/kotlin/org/pkl/server/AbstractServerTest.kt
+++ b/pkl-server/src/test/kotlin/org/pkl/server/AbstractServerTest.kt
@@ -105,7 +105,7 @@ abstract class AbstractServerTest {
         foo {
           bar = "bar"
         }
-      """
+        """
           .trimIndent(),
         null,
       )
@@ -132,7 +132,7 @@ abstract class AbstractServerTest {
         URI("repl:text"),
         """
         foo = trace(1 + 2 + 3)
-      """
+        """
           .trimIndent(),
         null,
       )
@@ -159,7 +159,7 @@ abstract class AbstractServerTest {
         function foo() = 5
 
         result = foo()
-      """
+        """
           .trimIndent(),
         null,
       )
@@ -286,7 +286,7 @@ abstract class AbstractServerTest {
         URI("repl:text"),
         """
         res = read*("bird:/**.txt").keys
-      """
+        """
           .trimIndent(),
         "res",
       )
@@ -315,11 +315,11 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.result?.debugRendering)
       .isEqualTo(
         """
-      - 6
-      - 
-        - 'bird:/foo.txt'
-        - 'bird:/subdir/bar.txt'
-    """
+        - 6
+        - 
+          - 'bird:/foo.txt'
+          - 'bird:/subdir/bar.txt'
+        """
           .trimIndent()
       )
   }
@@ -335,7 +335,7 @@ abstract class AbstractServerTest {
         URI("repl:text"),
         """
         res = read*("bird:/**.txt").keys
-      """
+        """
           .trimIndent(),
         "res",
       )
@@ -371,7 +371,7 @@ abstract class AbstractServerTest {
         URI("repl:text"),
         """
         res = read*("bird:/**.txt").keys
-      """
+        """
           .trimIndent(),
         "res",
       )
@@ -390,19 +390,19 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.error)
       .isEqualTo(
         """
-      –– Pkl Error ––
-      I/O error resolving glob pattern `bird:/**.txt`.
-      IOException: didnt work
+        –– Pkl Error ––
+        I/O error resolving glob pattern `bird:/**.txt`.
+        IOException: didnt work
 
-      1 | res = read*("bird:/**.txt").keys
-                ^^^^^^^^^^^^^^^^^^^^^
-      at text#res (repl:text)
+        1 | res = read*("bird:/**.txt").keys
+                  ^^^^^^^^^^^^^^^^^^^^^
+        at text#res (repl:text)
 
-      1 | res
-          ^^^
-      at  (repl:text)
-      
-      """
+        1 | res
+            ^^^
+        at  (repl:text)
+
+        """
           .trimIndent()
       )
   }
@@ -549,14 +549,14 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.result?.debugRendering)
       .isEqualTo(
         """
-      - 6
-      - 
-        - 'bird:/Person.pkl'
-        - 'bird:/birds/parrot.pkl'
-        - 'bird:/birds/pigeon.pkl'
-        - 'bird:/majesticBirds/barnOwl.pkl'
-        - 'bird:/majesticBirds/elfOwl.pkl'
-    """
+        - 6
+        - 
+          - 'bird:/Person.pkl'
+          - 'bird:/birds/parrot.pkl'
+          - 'bird:/birds/pigeon.pkl'
+          - 'bird:/majesticBirds/barnOwl.pkl'
+          - 'bird:/majesticBirds/elfOwl.pkl'
+        """
           .trimIndent()
       )
   }
@@ -582,9 +582,9 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.result?.debugRendering)
       .isEqualTo(
         """
-      - 6
-      - []
-    """
+        - 6
+        - []
+        """
           .trimIndent()
       )
   }
@@ -612,19 +612,19 @@ abstract class AbstractServerTest {
     assertThat(evaluateResponse.error)
       .isEqualTo(
         """
-      –– Pkl Error ––
-      I/O error resolving glob pattern `bird:/**.pkl`.
-      IOException: nope
+        –– Pkl Error ––
+        I/O error resolving glob pattern `bird:/**.pkl`.
+        IOException: nope
 
-      1 | res = import*("bird:/**.pkl").keys
-                ^^^^^^^^^^^^^^^^^^^^^^^
-      at text#res (repl:text)
+        1 | res = import*("bird:/**.pkl").keys
+                  ^^^^^^^^^^^^^^^^^^^^^^^
+        at text#res (repl:text)
 
-      1 | res
-          ^^^
-      at  (repl:text)
-      
-      """
+        1 | res
+            ^^^
+        at  (repl:text)
+
+        """
           .trimIndent()
       )
   }
@@ -688,9 +688,9 @@ abstract class AbstractServerTest {
         URI("bird:/foo/bar/baz.pkl"),
         """
         import ".../buz.pkl"
-        
+
         res = buz.res
-      """
+        """
           .trimIndent(),
         "res",
       )
@@ -747,9 +747,9 @@ abstract class AbstractServerTest {
         readModuleRequest.requestId,
         evaluatorId,
         """
-          firstName = "Pigeon"
-          lastName = "Bird"
-          fullName = firstName + " " + lastName
+        firstName = "Pigeon"
+        lastName = "Bird"
+        fullName = firstName + " " + lastName
         """
           .trimIndent(),
         null,
@@ -766,7 +766,7 @@ abstract class AbstractServerTest {
           lastName = "Bird"
           fullName = "Pigeon Bird"
 
-      """
+        """
           .trimIndent()
       )
   }
@@ -788,9 +788,9 @@ abstract class AbstractServerTest {
         response11.requestId,
         evaluatorId,
         """
-          firstName = "Pigeon"
-          lastName = "Bird"
-          fullName = firstName + " " + lastName
+        firstName = "Pigeon"
+        lastName = "Bird"
+        fullName = firstName + " " + lastName
         """
           .trimIndent(),
         null,
@@ -807,7 +807,7 @@ abstract class AbstractServerTest {
           lastName = "Bird"
           fullName = "Pigeon Bird"
 
-      """
+        """
           .trimIndent()
       )
 
@@ -819,9 +819,9 @@ abstract class AbstractServerTest {
         response21.requestId,
         evaluatorId,
         """
-          firstName = "Parrot"
-          lastName = "Bird"
-          fullName = firstName + " " + lastName
+        firstName = "Parrot"
+        lastName = "Bird"
+        fullName = firstName + " " + lastName
         """
           .trimIndent(),
         null,
@@ -838,7 +838,7 @@ abstract class AbstractServerTest {
           lastName = "Bird"
           fullName = "Parrot Bird"
 
-      """
+        """
           .trimIndent()
       )
   }
@@ -948,23 +948,23 @@ abstract class AbstractServerTest {
       .resolve("lib.pkl")
       .writeText(
         """
-      text = "This is from lib"
-    """
+        text = "This is from lib"
+        """
           .trimIndent()
       )
     libDir
       .resolve("PklProject")
       .writeText(
         """
-      amends "pkl:Project"
-      
-      package {
-        name = "lib"
-        baseUri = "package://localhost:0/lib"
-        version = "5.0.0"
-        packageZipUrl = "https://localhost:0/lib.zip"
-      }
-    """
+        amends "pkl:Project"
+
+        package {
+          name = "lib"
+          baseUri = "package://localhost:0/lib"
+          version = "5.0.0"
+          packageZipUrl = "https://localhost:0/lib.zip"
+        }
+        """
           .trimIndent()
       )
     val projectDir = tempDir.resolve("proj/").createDirectories()
@@ -973,14 +973,14 @@ abstract class AbstractServerTest {
       """
       import "@birds/Bird.pkl"
       import "@lib/lib.pkl"
-      
+
       res: Bird = new {
         name = "Birdie"
         favoriteFruit { name = "dragonfruit" }
       }
-      
+
       libContents = lib
-    """
+      """
         .trimIndent()
     )
     val dollar = '$'


### PR DESCRIPTION
ktfmt has much improved how it formats Kotlin code. Unfortunately, this means that whenever we touch a single line in a Kotlin file, we get a _lot_ more changes thanks to ratcheting now picking up this file for formatting.

This PR just reformats every single Kotlin file so we don't have to deal with this churn in future PRs that touch Kotlin code.