### PR TITLE
Fix CRLF handling in line continuation escapes

### DIFF
--- a/pkl-parser/src/main/java/org/pkl/parser/Lexer.java
+++ b/pkl-parser/src/main/java/org/pkl/parser/Lexer.java
@@ -461,11 +461,17 @@ public final class Lexer {
       }
       case 'u' -> lexUnicodeEscape();
       case '\n' -> Token.STRING_ESCAPE_CONTINUATION;
+      case '\r' -> {
+        if (lookahead == '\n') {
+          nextChar();
+        }
+        yield Token.STRING_ESCAPE_CONTINUATION;
+      }
       case ' ', '\t' -> {
         var c = cursor;
         var next = nextChar();
         while (next == ' ' || next == '\t') next = nextChar();
-        if (next == '\n')
+        if (next == '\n' || next == '\r')
           throw lexError(
               ErrorMessages.create("invalidLineContinuationEscapeSequenceWhitespace"),
               c - 2,

--- a/pkl-parser/src/test/kotlin/org/pkl/parser/LexerTest.kt
+++ b/pkl-parser/src/test/kotlin/org/pkl/parser/LexerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,56 @@ class LexerTest {
     assertThat(lexerFFFF.next()).isEqualTo(Token.CLASS)
     val thrown = assertThrows<ParserError> { lexerFFFF.next() }
     assertThat(thrown).hasMessageContaining("Invalid identifier")
+  }
+
+  @Test
+  fun lineContinuationWithCRLF() {
+    // \r\n line endings must be handled the same as \n for line continuations
+    val input = "x = \"\"\"\n  hello \\\r\n  world\r\n  \"\"\""
+    val lexer = Lexer(input)
+    assertThat(lexer.next()).isEqualTo(Token.IDENTIFIER) // x
+    assertThat(lexer.next()).isEqualTo(Token.ASSIGN)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_MULTI_START) // """
+    assertThat(lexer.next()).isEqualTo(Token.STRING_NEWLINE)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_PART) // "  hello "
+    assertThat(lexer.next()).isEqualTo(Token.STRING_ESCAPE_CONTINUATION) // \<CRLF> consumed
+    assertThat(lexer.next()).isEqualTo(Token.STRING_PART) // "  world"
+    assertThat(lexer.next()).isEqualTo(Token.STRING_NEWLINE)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_PART) // "  "
+    assertThat(lexer.next()).isEqualTo(Token.STRING_END) // """
+    assertThat(lexer.next()).isEqualTo(Token.EOF)
+  }
+
+  @Test
+  fun lineContinuationWithCR() {
+    // bare \r should also work as a line continuation
+    val input = "x = \"\"\"\n  hello \\\r  world\n  \"\"\""
+    val lexer = Lexer(input)
+    assertThat(lexer.next()).isEqualTo(Token.IDENTIFIER)
+    assertThat(lexer.next()).isEqualTo(Token.ASSIGN)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_MULTI_START)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_NEWLINE)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_PART)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_ESCAPE_CONTINUATION) // \<CR> consumed
+    assertThat(lexer.next()).isEqualTo(Token.STRING_PART)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_NEWLINE)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_PART)
+    assertThat(lexer.next()).isEqualTo(Token.STRING_END)
+    assertThat(lexer.next()).isEqualTo(Token.EOF)
+  }
+
+  @Test
+  fun lineContinuationWhitespaceErrorWithCRLF() {
+    // whitespace between \ and \r\n should give the same error as \ and \n
+    val input = "x = \"\"\"\n  hello \\ \r\n  world\n  \"\"\""
+    val thrown =
+      assertThrows<ParserError> {
+        val lexer = Lexer(input)
+        while (lexer.next() != Token.EOF) {
+          /* consume all tokens */
+        }
+      }
+    assertThat(thrown.message).contains("Whitespace")
   }
 
   @Test


### PR DESCRIPTION
This is only really an issue if you're using Windows, or save a file using CRLF line endings.

Also fix the "whitespace before continuation" error to detect `\r` as a newline.

## Example programs

```pkl
x = """
  hello \
  world
  """

y = #"""
  hello \#
  world
  """#
```