### PR TITLE
Fix `pkl:test` fact power assertions when member source section is unavailable

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/PowerAssertions.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/PowerAssertions.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.pkl.core.PklBugException;
 import org.pkl.core.ast.ConstantValueNode;
 import org.pkl.core.ast.expression.member.InferParentWithinMethodNode;
 import org.pkl.core.ast.expression.member.InferParentWithinObjectMethodNode;
@@ -83,6 +84,10 @@ public class PowerAssertions {
       SourceSection sourceSection,
       Map<Node, List<Object>> trackedValues,
       @Nullable Consumer<AnsiStringBuilder> firstFrameSuffix) {
+    if (!sourceSection.isAvailable()) {
+      throw new PklBugException("Power assertions require an available source section");
+    }
+
     out.appendSandboxed(
         () -> {
           var lines = lines(sourceSection);

--- a/pkl-core/src/main/java/org/pkl/core/runtime/TestRunner.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/TestRunner.java
@@ -102,7 +102,7 @@ public final class TestRunner {
                 try {
                   var factValue = VmUtils.readMember(listing, idx);
                   if (factValue == Boolean.FALSE) {
-                    if (PowerAssertions.isEnabled()) {
+                    if (PowerAssertions.isEnabled() && member.getSourceSection().isAvailable()) {
                       try (var valueTracker = valueTrackerFactory.create()) {
                         listing.cachedValues.clear();
                         VmUtils.readMember(listing, idx);

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorTest.kt
@@ -32,6 +32,7 @@ import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
@@ -691,6 +692,32 @@ class EvaluatorTest {
           """
             .trimIndent()
         )
+      )
+    }
+  }
+
+  @Test
+  fun `power assertions work with test facts with unavailable source section`() {
+    val evaluator =
+      with(EvaluatorBuilder.preconfigured()) {
+        powerAssertionsEnabled = true
+        build()
+      }
+
+    assertDoesNotThrow {
+      evaluator.evaluateTest(
+        text(
+          """
+          amends "pkl:test"
+          facts {
+            ["foo"] {
+              ...List(false)
+            }
+          }
+          """
+            .trimIndent()
+        ),
+        false,
       )
     }
   }


### PR DESCRIPTION
Power assertions only work when the source section is available. If it is unavailable, power assertions throw a ParserError (unexpected EOF on an empty input) when re-parsing the expression for presentation.