### PR TITLE
Add resource readers from service providers in CLI

### DIFF
--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -307,6 +307,7 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
       add(ResourceReaders.modulePath(modulePathResolver))
       add(ResourceReaders.pkg())
       add(ResourceReaders.projectpackage())
+      addAll(ResourceReaders.fromServiceProviders())
       add(ResourceReaders.file())
       add(ResourceReaders.http())
       add(ResourceReaders.https())


### PR DESCRIPTION
This omission, in particular, prevents Gradle plugins (which rely on CLI classes) from adding custom resource readers via the service loading mechanism. This change seems benign, especially since this is already done for module key factories.