### PR TITLE
Ensure local dependency matches PklProject.dep.json version

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/module/ProjectDependenciesManager.java
+++ b/pkl-core/src/main/java/org/pkl/core/module/ProjectDependenciesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.pkl.core.PklBugException;
 import org.pkl.core.SecurityManager;
 import org.pkl.core.SecurityManagerException;
 import org.pkl.core.packages.Dependency;
+import org.pkl.core.packages.Dependency.LocalDependency;
 import org.pkl.core.packages.DependencyMetadata;
 import org.pkl.core.packages.PackageLoadError;
 import org.pkl.core.packages.PackageUri;
@@ -111,6 +112,16 @@ public final class ProjectDependenciesManager {
 
   private void checkProjectDependencyOutOfDate(
       URI projectFileUri, PackageUri declaredPackage, Dependency resolvedDependency) {
+    // local dependencies must match up exactly (they are expected to always stay in sync).
+    if (resolvedDependency instanceof LocalDependency localDependency) {
+      if (!declaredPackage.getVersion().equals(localDependency.getVersion())) {
+        throw new PackageLoadError(
+            "projectDependenciesLocalDependencyOutOfSync",
+            projectFileUri,
+            declaredPackage.getDisplayName(),
+            resolvedDependency.getPackageUri().getDisplayName());
+      }
+    }
     if (resolvedDependency.getVersion().compareTo(declaredPackage.getVersion()) < 0) {
       throw new PackageLoadError(
           "projectDependenciesOutOfDateInProject",

--- a/pkl-core/src/main/java/org/pkl/core/module/ProjectDependenciesManager.java
+++ b/pkl-core/src/main/java/org/pkl/core/module/ProjectDependenciesManager.java
@@ -113,14 +113,13 @@ public final class ProjectDependenciesManager {
   private void checkProjectDependencyOutOfDate(
       URI projectFileUri, PackageUri declaredPackage, Dependency resolvedDependency) {
     // local dependencies must match up exactly (they are expected to always stay in sync).
-    if (resolvedDependency instanceof LocalDependency localDependency) {
-      if (!declaredPackage.getVersion().equals(localDependency.getVersion())) {
-        throw new PackageLoadError(
-            "projectDependenciesLocalDependencyOutOfSync",
-            projectFileUri,
-            declaredPackage.getDisplayName(),
-            resolvedDependency.getPackageUri().getDisplayName());
-      }
+    if (resolvedDependency instanceof LocalDependency localDependency
+        && !declaredPackage.getVersion().equals(localDependency.getVersion())) {
+      throw new PackageLoadError(
+          "projectDependenciesLocalDependencyOutOfSync",
+          projectFileUri,
+          declaredPackage.getDisplayName(),
+          resolvedDependency.getPackageUri().getDisplayName());
     }
     if (resolvedDependency.getVersion().compareTo(declaredPackage.getVersion()) < 0) {
       throw new PackageLoadError(

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -888,6 +888,14 @@ Resolved: `{2}`\n\
 \n\
 Run `pkl project resolve` to update resolved dependencies.
 
+projectDependenciesLocalDependencyOutOfSync=\
+Project `{0}` declares a dependency on a local package whose version doesn''t match what is declared in `PklProject.deps.json`.\n\
+\n\
+Declared: `{1}`\n\
+Resolved: `{2}`\n\
+\n\
+Run `pkl project resolve` to update resolved dependencies.
+
 invalidPackageZipChecksum=\
 Cannot download package `{0}` because the computed checksum does not match the expected checksum.\n\
 \n\

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/projects/badProjectDeps7/PklProject
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/projects/badProjectDeps7/PklProject
@@ -1,0 +1,7 @@
+amends "pkl:Project"
+
+dependencies {
+  // version declared in PklProject.deps.json does not line up with what this local dependency
+  // tells us its version is
+  ["project6"] = import("../project6/PklProject")
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/projects/badProjectDeps7/PklProject.deps.json
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/projects/badProjectDeps7/PklProject.deps.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "resolvedDependencies": {
+    "package://localhost:0/project6@1": {
+      "type": "local",
+      "uri": "projectpackage://localhost:0/project6@1.5.0",
+      "path": "../project6/"
+    }
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/projects/badProjectDeps7/bug.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/projects/badProjectDeps7/bug.pkl
@@ -1,0 +1,3 @@
+import "@project6/children.pkl"
+
+res = children

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project1/PklProject.deps.json
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project1/PklProject.deps.json
@@ -20,9 +20,9 @@
       "uri": "projectpackage://localhost:0/project2@1.0.0",
       "path": "../project2/"
     },
-    "package://localhost:12110/project6@1": {
+    "package://localhost:0/project6@1": {
       "type": "local",
-      "uri": "projectpackage://localhost:12110/project6@1.0.0",
+      "uri": "projectpackage://localhost:0/project6@1.0.0",
       "path": "../project6/"
     },
     "package://localhost:0/badImportsWithinPackage@1": {

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project3/PklProject.deps.json
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project3/PklProject.deps.json
@@ -20,9 +20,9 @@
       "uri": "projectpackage://localhost:0/project2@1.0.0",
       "path": "../project2/"
     },
-    "package://localhost:12110/project6@1": {
+    "package://localhost:0/project6@1": {
       "type": "local",
-      "uri": "projectpackage://localhost:12110/project6@1.0.0",
+      "uri": "projectpackage://localhost:0/project6@1.0.0",
       "path": "../project6/"
     },
     "package://localhost:0/badImportsWithinPackage@1": {

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project6/PklProject
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project6/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 package {
   name = "project6"
-  baseUri = "package://localhost:12110/project6"
+  baseUri = "package://localhost:0/project6"
   version = "1.0.0"
-  packageZipUrl = "https://localhost:12110/project6/project6-\(version).zip"
+  packageZipUrl = "https://localhost:0/project6/project6-\(version).zip"
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/projects/badProjectDeps7/bug.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/projects/badProjectDeps7/bug.err
@@ -1,0 +1,11 @@
+–– Pkl Error ––
+Project `file:///$snippetsDir/input/projects/badProjectDeps7/PklProject` declares a dependency on a local package whose version doesn't match what is declared in `PklProject.deps.json`.
+
+Declared: `package://localhost:0/project6@1.0.0`
+Resolved: `package://localhost:0/project6@1.5.0`
+
+Run `pkl project resolve` to update resolved dependencies.
+
+x | import "@project6/children.pkl"
+           ^^^^^^^^^^^^^^^^^^^^^^^^
+at bug (file:///$snippetsDir/input/projects/badProjectDeps7/bug.pkl)


### PR DESCRIPTION
The version of local project dependencies should _always_ exactly match up with what's declared in a PklProject.deps.json; any package in the transitive dependency tree should always be delcaring the same import too.

Closes #1591
