### PR TITLE
Remove public modifier on LazyHttpClient and RequestRewritingClient

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/http/LazyHttpClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/LazyHttpClient.java
@@ -29,9 +29,8 @@ import org.jspecify.annotations.Nullable;
  * An {@code HttpClient} decorator that defers creating the underlying HTTP client until the first
  * send.
  */
-// visible for testing
 @ThreadSafe
-public final class LazyHttpClient implements HttpClient {
+final class LazyHttpClient implements HttpClient {
   private final Supplier<HttpClient> supplier;
   private final Object lock = new Object();
 

--- a/pkl-core/src/main/java/org/pkl/core/http/RequestRewritingClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/RequestRewritingClient.java
@@ -50,17 +50,16 @@ import org.pkl.core.util.Pair;
  * <p>Both {@code User-Agent} header and default request timeout are configurable through {@link
  * HttpClient.Builder}.
  */
-// visible for testing
 @ThreadSafe
-public final class RequestRewritingClient implements HttpClient {
+final class RequestRewritingClient implements HttpClient {
   // non-private for testing
   final String userAgent;
   final Duration requestTimeout;
   final int testPort;
   final HttpClient delegate;
-  private final Map<URI, URI> rewritesMap;
+  final Map<URI, URI> rewritesMap;
+  final Map<Pattern, Map<String, List<String>>> headers;
   private final List<Entry<URI, URI>> rewrites;
-  private final Map<Pattern, Map<String, List<String>>> headers;
 
   private final AtomicBoolean closed = new AtomicBoolean();
 
@@ -266,15 +265,5 @@ public final class RequestRewritingClient implements HttpClient {
       throw new IllegalStateException(
           "Cannot send request " + request + " because this client has already been closed.");
     }
-  }
-
-  // visible for testing
-  public Map<URI, URI> getRewritesMap() {
-    return rewritesMap;
-  }
-
-  // visible for testing
-  public Map<Pattern, Map<String, List<String>>> getHeaders() {
-    return headers;
   }
 }

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorBuilderTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorBuilderTest.kt
@@ -21,8 +21,7 @@ import java.time.Duration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.pkl.core.http.LazyHttpClient
-import org.pkl.core.http.RequestRewritingClient
+import org.pkl.core.http.getConfiguredSettings
 import org.pkl.core.project.Project
 import org.pkl.core.resource.TestResourceReader
 import org.pkl.core.util.IoUtils
@@ -97,10 +96,10 @@ class EvaluatorBuilderTest {
       .isEqualTo(3) // two external readers, one module path
     assertThat(builder.resourceReaders.find { it.uriScheme == "scheme3" }).isNotNull
     assertThat(builder.resourceReaders.find { it.uriScheme == "scheme4" }).isNotNull
-    val client = (builder.httpClient as LazyHttpClient).orCreateClient as RequestRewritingClient
-    assertThat(client.headers)
+    val settings = builder.httpClient.getConfiguredSettings()
+    assertThat(settings.headers)
       .isEqualTo(mapOf(IoUtils.doubleStarGlob to mapOf("X-Foo" to listOf("Foo"))))
-    assertThat(client.rewritesMap)
+    assertThat(settings.rewritesMap)
       .isEqualTo(mapOf(URI("https://foo.com/") to URI("https://bar.com/")))
   }
 }

--- a/pkl-core/src/test/kotlin/org/pkl/core/http/util.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/http/util.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core.http
+
+import java.net.URI
+import java.util.regex.Pattern
+
+data class HttpSettings(
+  val headers: Map<Pattern, Map<String, List<String>>>,
+  val rewritesMap: Map<URI, URI>,
+)
+
+fun HttpClient.getConfiguredSettings(): HttpSettings {
+  this as LazyHttpClient
+  val requestRewritingClient = this.orCreateClient as RequestRewritingClient
+  return HttpSettings(requestRewritingClient.headers, requestRewritingClient.rewritesMap)
+}


### PR DESCRIPTION
This introduces a test helper to expose configured HTTP settings, and makes the underlying classes package-private again.