### PR TITLE
Fixes #1617 : Use Locale.ROOT when lowercasing rewrite URIs

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/http/RequestRewritingClient.java
+++ b/pkl-core/src/main/java/org/pkl/core/http/RequestRewritingClient.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -205,9 +206,9 @@ final class RequestRewritingClient implements HttpClient {
   private URI normalizeRewrite(URI uri) {
     try {
       return new URI(
-          uri.getScheme().toLowerCase(),
+          uri.getScheme().toLowerCase(Locale.ROOT),
           uri.getUserInfo(),
-          uri.getHost().toLowerCase(),
+          uri.getHost().toLowerCase(Locale.ROOT),
           uri.getPort(),
           uri.getPath(),
           uri.getQuery(),

--- a/pkl-core/src/test/kotlin/org/pkl/core/http/RequestRewritingClientTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/http/RequestRewritingClientTest.kt
@@ -21,6 +21,7 @@ import java.net.http.HttpRequest
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.HttpResponse.BodyHandlers
 import java.time.Duration
+import java.util.Locale
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatList
 import org.junit.jupiter.api.Test
@@ -319,6 +320,24 @@ class RequestRewritingClientTest {
         )
       )
       .isEqualTo("https://bar.com/bar/baz")
+  }
+
+  @Test
+  fun `rewrites URIs - host with capital I under tr_TR locale`() {
+    // Under tr_TR, "INDEX.COM".toLowerCase() becomes "ındex.com".
+    val previous = Locale.getDefault()
+    Locale.setDefault(Locale.forLanguageTag("tr-TR"))
+    try {
+      assertThat(
+          rewrittenRequest(
+            "https://INDEX.COM/foo/bar",
+            mapOf(URI("https://index.com/") to URI("https://bar.com/")),
+          )
+        )
+        .isEqualTo("https://bar.com/foo/bar")
+    } finally {
+      Locale.setDefault(previous)
+    }
   }
 
   private fun rewrittenRequest(uri: String, rules: Map<URI, URI>): String {


### PR DESCRIPTION
Use Locale.ROOT to apply the lowecase format. For URI scheme and host locale-neutral casing is the semantically the correct choice. Added a unit test that sets the default locale to tr-TR and that would fail without the fix.

Fixes #1617 .