### PR TITLE
Fix deploy build

### DIFF
--- a/pkl-core/pkl-core.gradle.kts
+++ b/pkl-core/pkl-core.gradle.kts
@@ -171,6 +171,8 @@ sourceSets.main { java.srcDir(layout.buildDirectory.dir("generated/sources/baseM
 
 tasks.compileJava { dependsOn(generateBaseModuleMembers) }
 
+tasks.sourcesJar { dependsOn(generateBaseModuleMembers) }
+
 val testJavaExecutable by
   tasks.registering(Test::class) {
     configureExecutableTest("LanguageSnippetTestsEngine")


### PR DESCRIPTION
Fixes the following error:

```
A problem was found with the configuration of task ':pkl-core:sourcesJar' (type 'Jar').
Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
  - Gradle detected a problem with the following location: '/home/runner/work/pkl/pkl/pkl-core/build/generated/sources/baseModuleMembers'.

    
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
    Reason: Task ':pkl-core:sourcesJar' uses this output of task ':pkl-core:generateBaseModuleMembers' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    
For more on this, please refer to https://docs.gradle.org/9.5.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
    Possible solutions:
94 actionable tasks: 76 executed, 18 from cache
      1. Declare task ':pkl-core:generateBaseModuleMembers' as an input of ':pkl-core:sourcesJar'.
      2. Declare an explicit dependency on ':pkl-core:generateBaseModuleMembers' from ':pkl-core:sourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':pkl-core:generateBaseModuleMembers' from ':pkl-core:sourcesJar' using Task#mustRunAfter.
```