### PR TITLE
Improve error message when parsing truncated let expressions

### DIFF
--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/letExpressionError3.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/letExpressionError3.pkl
@@ -1,0 +1,3 @@
+foo {
+  bar = let (qux = 1)
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/letExpressionError3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/letExpressionError3.err
@@ -1,0 +1,6 @@
+–– Pkl Error ––
+Unexpected token `}`.
+
+x | }
+    ^
+at letExpressionError3 (file:///$snippetsDir/input/errors/letExpressionError3.pkl)

--- a/pkl-parser/src/main/java/org/pkl/parser/GenericParserImpl.java
+++ b/pkl-parser/src/main/java/org/pkl/parser/GenericParserImpl.java
@@ -888,7 +888,7 @@ class GenericParserImpl {
             expect(Token.RPAREN, paramDef, "unexpectedToken", ")");
             children.add(new Node(NodeType.LET_PARAMETER_DEFINITION, paramDef));
             ff(children);
-            children.add(parseExpr(expectation));
+            children.add(parseExpr());
             yield new Node(NodeType.LET_EXPR, children);
           }
           case TRUE, FALSE -> new Node(NodeType.BOOL_LITERAL_EXPR, next().span);

--- a/pkl-parser/src/main/java/org/pkl/parser/ParserImpl.java
+++ b/pkl-parser/src/main/java/org/pkl/parser/ParserImpl.java
@@ -1009,7 +1009,7 @@ final class ParserImpl {
             expect(Token.ASSIGN, "unexpectedToken", "=");
             var bindExpr = parseExpr(")");
             expect(Token.RPAREN, "unexpectedToken", ")");
-            var exp = parseExpr(expectation);
+            var exp = parseExpr();
             yield new LetExpr(param, bindExpr, exp, start.endWith(exp.span()));
           }
           case TRUE -> new BoolLiteralExpr(true, next().span);

--- a/pkl-parser/src/test/kotlin/org/pkl/parser/ParserComparisonTest.kt
+++ b/pkl-parser/src/test/kotlin/org/pkl/parser/ParserComparisonTest.kt
@@ -99,6 +99,7 @@ class ParserComparisonTest {
         "errors/invalidCharacterEscape.pkl",
         "errors/invalidCharacterEscape2.pkl",
         "errors/invalidUnicodeEscape.pkl",
+        "errors/letExpressionError3.pkl",
         "errors/unterminatedUnicodeEscape.pkl",
         "errors/keywordNotAllowedHere1.pkl",
         "errors/keywordNotAllowedHere2.pkl",


### PR DESCRIPTION
This previously yielded
```
Unexpected token `}`. Expected `}`.
```
Pretty confusing, no?

Now it's just
```
Unexpected token `}`.
```

Resolves #1638