### PR TITLE
Handle modulo by 0

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmSafeMath.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmSafeMath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,10 +90,18 @@ public final class VmSafeMath {
   }
 
   public static long remainder(long x, long y) {
+    if (y == 0) {
+      CompilerDirectives.transferToInterpreter();
+      throw divisionByZero();
+    }
     return x % y;
   }
 
   public static double remainder(double x, double y) {
+    if (y == 0) {
+      CompilerDirectives.transferToInterpreter();
+      throw divisionByZero();
+    }
     return x % y;
   }
 

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/basic/float.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/basic/float.pkl
@@ -106,6 +106,7 @@ examples {
   ["division"] {
     4.4 / 5.5
     4.4 / 5
+    4.4 / 0
   }
 
   ["integer division"] {
@@ -114,11 +115,14 @@ examples {
     5 ~/ 3.0
     5.0 ~/ 3.0
     5.1 ~/ 3.1
+    module.catch(() -> 5.0 ~/ 0)
   }
 
   ["remainder"] {
     5.5 % 6.5
     5 % 6.5
+    module.catch(() -> 5.5 % 0)
+    module.catch(() -> 5 % 0.0)
   }
 
   ["negation"] {

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/basic/int.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/basic/int.pkl
@@ -130,16 +130,19 @@ examples {
   ["division"] {
     4 / 3
     0x4 / 0b11
+    4 / 0
   }
 
   ["integer division"] {
     4 ~/ 3
     0x4 ~/ 0b11
+    module.catch(() -> 4 ~/ 0)
   }
 
   ["remainder"] {
     5 % 6
     0x5 % 0b110
+    module.catch(() -> 5 % 0)
   }
 
   ["negation"] {

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/basic/float.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/basic/float.pcf
@@ -83,6 +83,7 @@ examples {
   ["division"] {
     0.8
     0.8800000000000001
+    Infinity
   }
   ["integer division"] {
     1
@@ -90,10 +91,13 @@ examples {
     1
     1
     1
+    "Cannot convert Float `5.0` to Int because it is too large."
   }
   ["remainder"] {
     5.5
     5.0
+    "Division by zero."
+    "Division by zero."
   }
   ["negation"] {
     -1.2

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/basic/int.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/basic/int.pcf
@@ -107,14 +107,17 @@ examples {
   ["division"] {
     1.3333333333333333
     1.3333333333333333
+    Infinity
   }
   ["integer division"] {
     1
     1
+    "Division by zero."
   }
   ["remainder"] {
     5
     5
+    "Division by zero."
   }
   ["negation"] {
     -1


### PR DESCRIPTION
Treat modulo by zero as division by zero

NOTE: This copies the behavior of int div, but not division.

```
pkl0> 5 / 0
Infinity
pkl1> 5 ~/ 0
–– Pkl Error ––
Division by zero.

1 | 5 ~/ 0
    ^^^^^^
at  (repl:pkl1)
```

Should we copy division or integer division?

My sense is that throw is the better behavior here. I'm not sure when `5 % 0` resulting in `Infinity` is meaningful.

Perhaps we should fix the division case too.

Fixes #1660