### PR TITLE
Fix `doIsEquivalentTo` for `IntMaskSlotTypeNode`

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
@@ -2381,7 +2381,7 @@ public abstract class TypeNode extends PklNode {
 
     @Override
     public final boolean doIsEquivalentTo(TypeNode other) {
-      return other instanceof UIntTypeAliasTypeNode aliasTypeNode && mask == aliasTypeNode.mask;
+      return other instanceof IntMaskSlotTypeNode typeNode && mask == typeNode.mask;
     }
 
     @Override


### PR DESCRIPTION
This fixes an internal optimization; doesn't result in a language-observable change, so no test case is introduced.