### PR TITLE
Fix VmIntSeq.length

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmIntSeq.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmIntSeq.java
@@ -50,6 +50,7 @@ public final class VmIntSeq extends VmValue implements Iterable<Long> {
   }
 
   public long getLength() {
+    if (isEmpty()) return 0;
     return (Math.abs((end - start) / step)) + 1;
   }
 


### PR DESCRIPTION
This fixes an internal optimization.

No language-observable change results from this fix, so no tests are introduced.