### PR TITLE
Fix String.padStart/padEnd

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/StringNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/StringNodes.java
@@ -745,13 +745,12 @@ public final class StringNodes {
     @TruffleBoundary
     @Specialization
     protected String eval(String self, long width, String ch) {
-      var length = self.length();
+      var length = self.codePointCount(0, self.length());
       if (length >= width) return self;
 
       var result = new StringBuilder(VmSafeMath.toInt32(width));
-      var c = ch.charAt(0);
       for (var i = 0; i < width - length; i++) {
-        result.append(c);
+        result.append(ch);
       }
       result.append(self);
       return result.toString();
@@ -762,14 +761,13 @@ public final class StringNodes {
     @TruffleBoundary
     @Specialization
     protected String eval(String self, long width, String ch) {
-      var length = self.length();
+      var length = self.codePointCount(0, self.length());
       if (length >= width) return self;
 
       var result = new StringBuilder(VmSafeMath.toInt32(width));
       result.append(self);
-      var c = ch.charAt(0);
       for (var i = 0; i < width - length; i++) {
-        result.append(c);
+        result.append(ch);
       }
       return result.toString();
     }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/string.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/string.pkl
@@ -452,6 +452,9 @@ examples {
     str1.padStart(10, " ")
     module.catch(() -> str1.padStart(10, ""))
     module.catch(() -> str1.padStart(10, "aa"))
+    "🙃".padStart(5, "h")
+    "🙃".padStart(5, "🏀")
+    "hi".padStart(5, "🏀")
   }
 
   ["padEnd()"] {
@@ -463,6 +466,9 @@ examples {
     str1.padEnd(10, " ")
     module.catch(() -> str1.padEnd(10, ""))
     module.catch(() -> str1.padEnd(10, "aa"))
+    "🙃".padEnd(5, "h")
+    "🙃".padEnd(5, "🏀")
+    "hi".padEnd(5, "🏀")
   }
 
   ["toBooleanOrNull()"] {

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/string.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/string.pcf
@@ -386,6 +386,9 @@ examples {
     "   abcdefg"
     "Type constraint `length == 1` violated. Value: \"\""
     "Type constraint `length == 1` violated. Value: \"aa\""
+    "hhhh🙃"
+    "🏀🏀🏀🏀🙃"
+    "🏀🏀🏀hi"
   }
   ["padEnd()"] {
     ""
@@ -396,6 +399,9 @@ examples {
     "abcdefg   "
     "Type constraint `length == 1` violated. Value: \"\""
     "Type constraint `length == 1` violated. Value: \"aa\""
+    "🙃hhhh"
+    "🙃🏀🏀🏀🏀"
+    "hi🏀🏀🏀"
   }
   ["toBooleanOrNull()"] {
     true


### PR DESCRIPTION
Fixes the following two bugs:

* Pads to incorrect string length
* Does not append full code point

Closes #1661