### PR TITLE
Fix visiting element type node of Collection

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
@@ -1217,6 +1217,9 @@ public abstract class TypeNode extends PklNode {
 
     @Override
     protected boolean acceptTypeNode(boolean visitTypeArguments, TypeNodeConsumer consumer) {
+      if (visitTypeArguments) {
+        return consumer.accept(this) && elementTypeNode.acceptTypeNode(true, consumer);
+      }
       return consumer.accept(this);
     }
 


### PR DESCRIPTION
This is a bug in the visitor logic, but currently doesn't impact any language behavior.