### PR TITLE
Revert "Reject abstract members in non-abstract classes"

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
@@ -1476,8 +1476,6 @@ public class AstBuilder extends AbstractAstBuilder<Object> {
     var scope = (ModuleScope) symbolTable.getCurrentScope();
     scope.setModifiers(modifiers);
 
-    checkAbstractMembersAllowed(modifiers, mod.getProperties(), mod.getMethods());
-
     // visit imports first so that we already have the object member name available
     var imports = mod.getImports();
     var importMembers = new ObjectMember[imports.size()];
@@ -1722,7 +1720,6 @@ public class AstBuilder extends AbstractAstBuilder<Object> {
           List<ClassProperty> properties = bodyNode != null ? bodyNode.getProperties() : List.of();
           List<ClassMethod> methods = bodyNode != null ? bodyNode.getMethods() : List.of();
           registerClassScopeNames(scope, properties, methods);
-          checkAbstractMembersAllowed(modifiers, properties, methods);
 
           var supertypeCtx = clazz.getSuperClass();
 
@@ -1811,30 +1808,6 @@ public class AstBuilder extends AbstractAstBuilder<Object> {
       case FIXED -> VmModifier.FIXED;
       case CONST -> VmModifier.CONST;
     };
-  }
-
-  private void checkAbstractMembersAllowed(
-      int enclosingModifiers, List<ClassProperty> properties, List<ClassMethod> methods) {
-    if (VmModifier.isAbstract(enclosingModifiers)) {
-      return;
-    }
-    for (var property : properties) {
-      checkMemberNotAbstract(property.getModifiers());
-    }
-    for (var method : methods) {
-      checkMemberNotAbstract(method.getModifiers());
-    }
-  }
-
-  private void checkMemberNotAbstract(List<Modifier> modifiers) {
-    for (var modifier : modifiers) {
-      if (modifier.getValue() == ModifierValue.ABSTRACT) {
-        throw exceptionBuilder()
-            .evalError("abstractMemberInNonAbstractClass")
-            .withSourceSection(createSourceSection(modifier.span()))
-            .build();
-      }
-    }
   }
 
   private UnresolvedPropertyNode[] doVisitClassProperties(

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -286,11 +286,6 @@ External members cannot have a body.
 abstractMemberCannotHaveBody=\
 Abstract members cannot have a body.
 
-abstractMemberInNonAbstractClass=\
-Cannot define an abstract member in a non-abstract class.\n\
-\n\
-A member can only be `abstract` if its enclosing class is also `abstract`.
-
 methodNotDefined1=\
 Method `{0}` is not defined for argument type `{1}`.
 

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMemberInNonAbstractClass.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMemberInNonAbstractClass.pkl
@@ -1,5 +1,0 @@
-class Foo {
-  abstract bar: Int
-}
-
-res = new Foo { bar = 5 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMemberInNonAbstractModule.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMemberInNonAbstractModule.pkl
@@ -1,1 +1,0 @@
-abstract foo: Int

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodInNonAbstractClass.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodInNonAbstractClass.pkl
@@ -1,5 +1,0 @@
-class Foo {
-  abstract function bar(): Int
-}
-
-res = new Foo {}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMemberInNonAbstractClass.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMemberInNonAbstractClass.err
@@ -1,8 +1,0 @@
-–– Pkl Error ––
-Cannot define an abstract member in a non-abstract class.
-
-x | abstract bar: Int
-    ^^^^^^^^
-at abstractMemberInNonAbstractClass#Foo (file:///$snippetsDir/input/errors/abstractMemberInNonAbstractClass.pkl)
-
-A member can only be `abstract` if its enclosing class is also `abstract`.

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMemberInNonAbstractModule.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMemberInNonAbstractModule.err
@@ -1,8 +1,0 @@
-–– Pkl Error ––
-Cannot define an abstract member in a non-abstract class.
-
-x | abstract foo: Int
-    ^^^^^^^^
-at abstractMemberInNonAbstractModule (file:///$snippetsDir/input/errors/abstractMemberInNonAbstractModule.pkl)
-
-A member can only be `abstract` if its enclosing class is also `abstract`.

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodInNonAbstractClass.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodInNonAbstractClass.err
@@ -1,8 +1,0 @@
-–– Pkl Error ––
-Cannot define an abstract member in a non-abstract class.
-
-x | abstract function bar(): Int
-    ^^^^^^^^
-at abstractMethodInNonAbstractClass#Foo (file:///$snippetsDir/input/errors/abstractMethodInNonAbstractClass.pkl)
-
-A member can only be `abstract` if its enclosing class is also `abstract`.

--- a/pkl-doc/src/test/files/DocGeneratorTest/input/com.package1/moduleMethodModifiers.pkl
+++ b/pkl-doc/src/test/files/DocGeneratorTest/input/com.package1/moduleMethodModifiers.pkl
@@ -1,5 +1,5 @@
 /// Module methods with different modifiers.
-abstract module com.package1.moduleMethodModifiers
+module com.package1.moduleMethodModifiers
 
 /// Method with `abstract` modifier.
 abstract function method1(arg: String): Boolean

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/run-1/com.package1/1.2.3/moduleMethodModifiers/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/run-1/com.package1/1.2.3/moduleMethodModifiers/index.html
@@ -32,7 +32,7 @@
       </ul>
       <div id="_overview" class="anchor"> </div>
       <div id="_declaration" class="member">
-        <div class="member-signature">abstract module <span class="name-decl">com.package1.moduleMethodModifiers</span></div>
+        <div class="member-signature">module <span class="name-decl">com.package1.moduleMethodModifiers</span></div>
         <div class="doc-comment"><p>Module methods with different modifiers.</p></div>
         <dl class="member-info">
           <dt class="">Module URI:</dt>

--- a/pkl-doc/src/test/files/DocGeneratorTest/output/run-2/com.package1/1.2.3/moduleMethodModifiers/index.html
+++ b/pkl-doc/src/test/files/DocGeneratorTest/output/run-2/com.package1/1.2.3/moduleMethodModifiers/index.html
@@ -32,7 +32,7 @@
       </ul>
       <div id="_overview" class="anchor"> </div>
       <div id="_declaration" class="member">
-        <div class="member-signature">abstract module <span class="name-decl">com.package1.moduleMethodModifiers</span></div>
+        <div class="member-signature">module <span class="name-decl">com.package1.moduleMethodModifiers</span></div>
         <div class="doc-comment"><p>Module methods with different modifiers.</p></div>
         <dl class="member-info">
           <dt class="">Module URI:</dt>


### PR DESCRIPTION
The changes made in this commit are good, but we're going to kick this out to the next release.
This is because:

1. There's a couple more issues around the `abstract` modifier that is not implemented yet, and need design considerations:
    * possibly remove `abstract` properties (properties already don't require an implementation)
    * possibly introduce `override` modifier as a required keyword when overriding properties
    * if keeping abstract properties, decide what to do in the case of overriding property definitions without type annotations (e.g. `foo = bar`)
3. These are breaking changes, and we want to minimize the number of breakages for users (better to break everything all at once in a single release).
4. The main branch is still the develop branch for Pkl 0.32

We will apply a re-revert of this commit after Pkl 0.32 is released.

FYI @vinayakj592 