### PR TITLE
Implement `toString()` on `VmReference`

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmReference.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmReference.java
@@ -16,6 +16,7 @@
 package org.pkl.core.runtime;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.nodes.DirectCallNode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -469,5 +470,15 @@ public final class VmReference extends VmValue {
     result = 31 * result + path.hashCode();
     result = 31 * result + referentType.hashCode();
     return result;
+  }
+
+  // in-language calls _should_ all go through `ToStringNode`.
+  // however, some calls escape through to here currently (e.g. `Listing.join`).
+  @Override
+  public String toString() {
+    var toStringMethod = getVmClass().getDeclaredMethod(Identifier.TO_STRING);
+    assert toStringMethod != null;
+    var callNode = DirectCallNode.create(toStringMethod.getCallTarget());
+    return (String) callNode.call(this, getVmClass().getPrototype());
   }
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/reference.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/reference.pkl
@@ -117,7 +117,7 @@ j: K = new {
 
 refInterpolation = "\(aRef.outputs.someListing[1])"
 kInterpolation = "\(k)"
-aValuesJoined = k.aValues.join("\n").replaceAll(Regex("@[a-z0-9]+"), "@<addr>")
+aValuesJoined = k.aValues.join("\n")
 
 // ensure that type arguments that are unions are handled correctly
 typeArgs = ref.Reference(d, TypeHolder, null).prop as Ref<Listing<Number | Boolean | String>>

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/reference.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/reference.pcf
@@ -50,11 +50,11 @@ j {
 refInterpolation = "${a.outputs.someListing[1]}"
 kInterpolation = "new K { aId = Reference(new D {}, String, new A { name = \"a\"; id = \"some-a-value\" }).id; bId = Reference(new D {}, String, new B { name = \"b\"; id = \"some-b-value\" }).id; aProperties = Reference(new D {}, reference#AProperties, new A { name = \"a\"; id = \"some-a-value\" }).outputs; bProperties = Reference(new D {}, reference#BProperties, new B { name = \"b\"; id = \"some-b-value\" }).outputs; aValues { Reference(new D {}, Int, new A { name = \"a\"; id = \"some-a-value\" }).outputs.foo; Reference(new D {}, Int | Null, new A { name = \"a\"; id = \"some-a-value\" }).outputs.someMapping[\"key\"]; Reference(new D {}, Int, new A { name = \"a\"; id = \"some-a-value\" }).outputs.someMap[new MapKey { k = 123 }]; Reference(new D {}, Int, new A { name = \"a\"; id = \"some-a-value\" }).outputs.someListing[0]; Reference(new D {}, Int, new A { name = \"a\"; id = \"some-a-value\" }).outputs.someList[9223372036854775807]; Reference(new D {}, Int, new B { name = \"b\"; id = \"some-b-value\" }).outputs.nonString }; bValues { Reference(new D {}, String, new B { name = \"b\"; id = \"some-b-value\" }).outputs.foo; Reference(new D {}, Null | String, new B { name = \"b\"; id = \"some-b-value\" }).outputs.someMapping[\"key\"]; Reference(new D {}, String, new B { name = \"b\"; id = \"some-b-value\" }).outputs.someMap[new MapKey { k = 123 }]; Reference(new D {}, String, new B { name = \"b\"; id = \"some-b-value\" }).outputs.someListing[0]; Reference(new D {}, String, new B { name = \"b\"; id = \"some-b-value\" }).outputs.someList[9223372036854775807]; Reference(new D {}, String, new A { name = \"a\"; id = \"some-a-value\" }).outputs.nonInt }; splitUnion = null }"
 aValuesJoined = """
-  org.pkl.core.runtime.VmReference@<addr>
-  org.pkl.core.runtime.VmReference@<addr>
-  org.pkl.core.runtime.VmReference@<addr>
-  org.pkl.core.runtime.VmReference@<addr>
-  org.pkl.core.runtime.VmReference@<addr>
-  org.pkl.core.runtime.VmReference@<addr>
+  ${a.outputs.foo}
+  ${a.outputs.someMapping[key]}
+  ${a.outputs.someMap[key:123]}
+  ${a.outputs.someListing[0]}
+  ${a.outputs.someList[9223372036854775807]}
+  ${b.outputs.nonString}
   """
 typeArgs = "${null.prop}"


### PR DESCRIPTION
This is still needed right now, because some methods call through to `toString()`.