### PR TITLE
Fix type argument lost in constraint expressions within generic typea…

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/member/UnresolvedFunctionNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/UnresolvedFunctionNode.java
@@ -31,7 +31,7 @@ public final class UnresolvedFunctionNode extends PklNode {
   private final int parameterCount;
   @Children private final @Nullable UnresolvedTypeNode[] unresolvedParameterTypeNodes;
   @Child private @Nullable UnresolvedTypeNode unresolvedReturnTypeNode;
-  private final ExpressionNode bodyNode;
+  @Child private ExpressionNode bodyNode;
 
   public UnresolvedFunctionNode(
       VmLanguage language,

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
@@ -457,8 +457,6 @@ public abstract class UnresolvedTypeNode extends PklNode {
 
     @Override
     public TypeNode execute(VirtualFrame frame) {
-      CompilerDirectives.transferToInterpreter();
-
       return typeNode;
     }
   }

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
@@ -448,7 +448,7 @@ public abstract class UnresolvedTypeNode extends PklNode {
    * with the corresponding concrete type argument.
    */
   public static final class Resolved extends UnresolvedTypeNode {
-    private final TypeNode typeNode;
+    @Child private TypeNode typeNode;
 
     public Resolved(SourceSection sourceSection, TypeNode typeNode) {
       super(sourceSection);

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
@@ -442,10 +442,9 @@ public abstract class UnresolvedTypeNode extends PklNode {
   }
 
   /**
-   * An unresolved type node that is pre-resolved to a concrete type node.
-   * Used during type alias instantiation to replace type variable references
-   * inside constraint expressions (e.g., {@code every((it) -> it is T)})
-   * with the corresponding concrete type argument.
+   * An unresolved type node that is pre-resolved to a concrete type node. Used during type alias
+   * instantiation to replace type variable references inside constraint expressions (e.g., {@code
+   * every((it) -> it is T)}) with the corresponding concrete type argument.
    */
   public static final class Resolved extends UnresolvedTypeNode {
     @Child private TypeNode typeNode;

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
@@ -429,11 +429,37 @@ public abstract class UnresolvedTypeNode extends PklNode {
       this.typeParameter = typeParameter;
     }
 
+    public int getTypeParameterIndex() {
+      return typeParameter.getIndex();
+    }
+
     @Override
     public TypeNode execute(VirtualFrame frame) {
       CompilerDirectives.transferToInterpreter();
 
       return new TypeVariableNode(sourceSection, typeParameter);
+    }
+  }
+
+  /**
+   * An unresolved type node that is pre-resolved to a concrete type node.
+   * Used during type alias instantiation to replace type variable references
+   * inside constraint expressions (e.g., {@code every((it) -> it is T)})
+   * with the corresponding concrete type argument.
+   */
+  public static final class Resolved extends UnresolvedTypeNode {
+    private final TypeNode typeNode;
+
+    public Resolved(SourceSection sourceSection, TypeNode typeNode) {
+      super(sourceSection);
+      this.typeNode = typeNode;
+    }
+
+    @Override
+    public TypeNode execute(VirtualFrame frame) {
+      CompilerDirectives.transferToInterpreter();
+
+      return typeNode;
     }
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmTypeAlias.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmTypeAlias.java
@@ -209,7 +209,7 @@ public final class VmTypeAlias extends VmValue {
             // Type variables inside constraint expressions (e.g. `every((it) -> it is T)`)
             // are still unresolved at instantiation time. Replace them with a resolved
             // unresolved type node that returns the concrete type argument.
-            int index = unresolvedTypeVar.getTypeParameterIndex();
+            var index = unresolvedTypeVar.getTypeParameterIndex();
             node.replace(
                 typeArgumentNodes.length == 0
                     ? new UnresolvedTypeNode.Unknown(sourceSection)

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmTypeAlias.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmTypeAlias.java
@@ -34,6 +34,7 @@ import org.pkl.core.ast.type.TypeNode;
 import org.pkl.core.ast.type.TypeNode.ConstrainedTypeNode;
 import org.pkl.core.ast.type.TypeNode.TypeVariableNode;
 import org.pkl.core.ast.type.TypeNode.UnknownTypeNode;
+import org.pkl.core.ast.type.UnresolvedTypeNode;
 
 public final class VmTypeAlias extends VmValue {
   private final SourceSection sourceSection;
@@ -204,6 +205,15 @@ public final class VmTypeAlias extends VmValue {
                 typeArgumentNodes.length == 0
                     ? new UnknownTypeNode(sourceSection)
                     : typeArgumentNodes[index]);
+          } else if (node instanceof UnresolvedTypeNode.TypeVariable unresolvedTypeVar) {
+            // Type variables inside constraint expressions (e.g. `every((it) -> it is T)`)
+            // are still unresolved at instantiation time. Replace them with a resolved
+            // unresolved type node that returns the concrete type argument.
+            int index = unresolvedTypeVar.getTypeParameterIndex();
+            node.replace(
+                typeArgumentNodes.length == 0
+                    ? new UnresolvedTypeNode.Unknown(sourceSection)
+                    : new UnresolvedTypeNode.Resolved(sourceSection, typeArgumentNodes[index]));
           }
           return true;
         });

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAliasConstraint3.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAliasConstraint3.pkl
@@ -1,0 +1,3 @@
+typealias MyList<T> = List(this[0] is T)
+
+foo: MyList<Int> = List("uh oh")

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAliasConstraint3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAliasConstraint3.err
@@ -1,0 +1,25 @@
+–– Pkl Error ––
+Type constraint `this[0] is T` violated.
+Value: List("uh oh")
+
+    this[0] is T
+    │   │   │
+    │   │   false
+    │   "uh oh"
+    List("uh oh")
+
+x | typealias MyList<T> = List(this[0] is T)
+                               ^^^^^^^^^^^^
+at typeAliasConstraint3#foo (file:///$snippetsDir/input/types/typeAliasConstraint3.pkl)
+
+x | foo: MyList<Int> = List("uh oh")
+                       ^^^^^^^^^^^^^
+at typeAliasConstraint3#foo (file:///$snippetsDir/input/types/typeAliasConstraint3.pkl)
+
+xxx | renderer.renderDocument(value)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (pkl:base)
+
+xxx | if (renderer is BytesRenderer) renderer.renderDocument(value) else text.encodeToBytes("UTF-8")
+                                                                         ^^^^
+at pkl.base#Module.output.bytes (pkl:base)


### PR DESCRIPTION
# Description

When using a generic type alias with a constraint such as `every((it) -> it is T)`, the type argument (for example, `Int`) was not being substituted into the constraint expression. As a result, the `it is T` check silently accepted any value instead of performing an actual type check.

Fixes #1705

## Before

```text
typealias MyList<T> = List(every((it) -> it is T))
foo: MyList<Int> = List("uhoh")  // accepted — incorrect
```

## After

```text
typealias MyList<T> = List(every((it) -> it is T))
foo: MyList<Int> = List("uhoh")  // rejected — correct
```

## Root Cause

1. The lambda body inside constraint expressions (`it is T`) was stored without Truffle's `@Child` annotation. Consequently, the tree-walking logic responsible for substituting type parameters could not traverse into the lambda body.
2. The instantiation logic only replaced resolved type variable nodes. However, inside constraint expressions, the type variable still exists in its unresolved form when substitution occurs.

## Fix

* Marked the lambda body expression as `@Child` so it can be properly traversed and deep-copied during type alias instantiation.
* Extended the instantiation logic to also handle unresolved type variables and replace them with concrete type arguments.
* Added a lightweight wrapper type that carries a pre-resolved type node into constraint expressions.

## Validation

* `List("uhoh")` used as `MyList<Int>` now correctly produces a type constraint violation error.
* `List(1, 2, 3)` used as `MyList<Int>` continues to pass.
* Non-generic constrained type aliases (for example, `typealias MyList = List(every((it) -> it is Int))`) continue to work correctly.
* All existing `LanguageSnippetTests`, `pkl-codegen-java`, `pkl-codegen-kotlin`, and `pkl-cli` tests pass.