### PR TITLE
Invalidate cached noop typechecks during typealias instantiation

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
@@ -70,16 +70,6 @@ public abstract class TypeNode extends PklNode {
     super(sourceSection);
   }
 
-  /**
-   * Invalidate any cached state and recalculate it.
-   *
-   * <p>Subclasses should override this and call invalidate on each child before invalidating its
-   * own state.
-   */
-  protected void invalidate() {
-    // noop by default
-  }
-
   public boolean isNoopTypeCheck() {
     return false;
   }
@@ -821,11 +811,6 @@ public abstract class TypeNode extends PklNode {
     }
 
     @Override
-    protected final void invalidate() {
-      elementTypeNode.invalidate();
-    }
-
-    @Override
     protected final PType doExport() {
       return new PType.Nullable(elementTypeNode.doExport());
     }
@@ -864,29 +849,14 @@ public abstract class TypeNode extends PklNode {
 
   public static class UnionTypeNode extends WriteFrameSlotTypeNode {
     @Children final TypeNode[] elementTypeNodes;
-    private boolean skipElementTypeChecks;
     private final int defaultIndex;
 
     public UnionTypeNode(
-        SourceSection sourceSection,
-        int defaultIndex,
-        TypeNode[] elementTypeNodes,
-        boolean skipElementTypeChecks) {
+        SourceSection sourceSection, int defaultIndex, TypeNode[] elementTypeNodes) {
       super(sourceSection);
       assert elementTypeNodes.length > 0;
       this.elementTypeNodes = elementTypeNodes;
       this.defaultIndex = defaultIndex;
-      this.skipElementTypeChecks = skipElementTypeChecks;
-    }
-
-    @Override
-    protected final void invalidate() {
-      var skipElementTypeChecks = true;
-      for (var elementTypeNode : elementTypeNodes) {
-        elementTypeNode.invalidate();
-        skipElementTypeChecks &= elementTypeNode.isNoopTypeCheck();
-      }
-      this.skipElementTypeChecks = skipElementTypeChecks;
     }
 
     @Override
@@ -904,7 +874,10 @@ public abstract class TypeNode extends PklNode {
 
     @Override
     public boolean isNoopTypeCheck() {
-      return skipElementTypeChecks;
+      for (var element : elementTypeNodes) {
+        if (!element.isNoopTypeCheck()) return false;
+      }
+      return true;
     }
 
     @Override
@@ -1010,8 +983,6 @@ public abstract class TypeNode extends PklNode {
     @Fallback
     @ExplodeLoop
     protected Object executeLazily(VirtualFrame frame, Object value) {
-      if (skipElementTypeChecks) return value;
-
       // escape analysis should remove this allocation in compiled code
       var typeMismatches = new VmTypeMismatchException[elementTypeNodes.length];
 
@@ -1062,8 +1033,6 @@ public abstract class TypeNode extends PklNode {
 
     @Override
     public Object executeEagerly(VirtualFrame frame, Object value) {
-      if (skipElementTypeChecks) return value;
-
       // escape analysis should remove this allocation in compiled code
       var typeMismatches = new VmTypeMismatchException[elementTypeNodes.length];
 
@@ -1225,11 +1194,6 @@ public abstract class TypeNode extends PklNode {
     }
 
     @Override
-    protected final void invalidate() {
-      elementTypeNode.invalidate();
-    }
-
-    @Override
     public VmClass getVmClass() {
       return BaseModule.getCollectionClass();
     }
@@ -1301,18 +1265,10 @@ public abstract class TypeNode extends PklNode {
 
   public static final class ListTypeNode extends ObjectSlotTypeNode {
     @Child private TypeNode elementTypeNode;
-    private boolean skipElementTypeChecks;
 
     public ListTypeNode(SourceSection sourceSection, TypeNode elementTypeNode) {
       super(sourceSection);
       this.elementTypeNode = elementTypeNode;
-      skipElementTypeChecks = elementTypeNode.isNoopTypeCheck();
-    }
-
-    @Override
-    protected final void invalidate() {
-      elementTypeNode.invalidate();
-      skipElementTypeChecks = elementTypeNode.isNoopTypeCheck();
     }
 
     @Override
@@ -1357,7 +1313,7 @@ public abstract class TypeNode extends PklNode {
       if (!(value instanceof VmList vmList)) {
         throw typeMismatch(value, BaseModule.getListClass());
       }
-      if (skipElementTypeChecks) return vmList;
+      if (elementTypeNode.isNoopTypeCheck()) return vmList;
 
       for (var elem : vmList) {
         elementTypeNode.executeEagerly(frame, elem);
@@ -1374,7 +1330,7 @@ public abstract class TypeNode extends PklNode {
       if (!(value instanceof VmList vmList)) {
         throw typeMismatch(value, BaseModule.getListClass());
       }
-      if (skipElementTypeChecks) return vmList;
+      if (elementTypeNode.isNoopTypeCheck()) return vmList;
       var ret = vmList;
       var idx = 0;
 
@@ -1406,18 +1362,10 @@ public abstract class TypeNode extends PklNode {
 
   public abstract static class SetTypeNode extends ObjectSlotTypeNode {
     @Child private TypeNode elementTypeNode;
-    private boolean skipElementTypeChecks;
 
     protected SetTypeNode(SourceSection sourceSection, TypeNode elementTypeNode) {
       super(sourceSection);
       this.elementTypeNode = elementTypeNode;
-      skipElementTypeChecks = elementTypeNode.isNoopTypeCheck();
-    }
-
-    @Override
-    protected final void invalidate() {
-      elementTypeNode.invalidate();
-      skipElementTypeChecks = elementTypeNode.isNoopTypeCheck();
     }
 
     @Override
@@ -1467,7 +1415,7 @@ public abstract class TypeNode extends PklNode {
 
     @Specialization
     protected Object eval(VirtualFrame frame, VmSet value) {
-      if (skipElementTypeChecks) return value;
+      if (elementTypeNode.isNoopTypeCheck()) return value;
       for (var elem : value) {
         // no point doing a lazy check because set members have their hash code computed, which
         // necessarily deep-forces them.
@@ -1492,20 +1440,11 @@ public abstract class TypeNode extends PklNode {
   public static final class MapTypeNode extends ObjectSlotTypeNode {
     @Child private TypeNode keyTypeNode;
     @Child private TypeNode valueTypeNode;
-    private boolean skipEntryTypeChecks;
 
     public MapTypeNode(SourceSection sourceSection, TypeNode keyTypeNode, TypeNode valueTypeNode) {
       super(sourceSection);
       this.keyTypeNode = keyTypeNode;
       this.valueTypeNode = valueTypeNode;
-      skipEntryTypeChecks = keyTypeNode.isNoopTypeCheck() && valueTypeNode.isNoopTypeCheck();
-    }
-
-    @Override
-    protected final void invalidate() {
-      keyTypeNode.invalidate();
-      valueTypeNode.invalidate();
-      skipEntryTypeChecks = keyTypeNode.isNoopTypeCheck() && valueTypeNode.isNoopTypeCheck();
     }
 
     @Override
@@ -1578,7 +1517,7 @@ public abstract class TypeNode extends PklNode {
     }
 
     private Object eval(VirtualFrame frame, VmMap value) {
-      if (skipEntryTypeChecks) return value;
+      if (keyTypeNode.isNoopTypeCheck() && valueTypeNode.isNoopTypeCheck()) return value;
       var ret = value;
 
       for (var entry : value) {
@@ -1595,7 +1534,7 @@ public abstract class TypeNode extends PklNode {
     }
 
     private Object evalEager(VirtualFrame frame, VmMap value) {
-      if (skipEntryTypeChecks) return value;
+      if (keyTypeNode.isNoopTypeCheck() && valueTypeNode.isNoopTypeCheck()) return value;
       for (var entry : value) {
         keyTypeNode.executeEagerly(frame, VmUtils.getKey(entry));
         valueTypeNode.executeEagerly(frame, VmUtils.getValue(entry));
@@ -1759,9 +1698,6 @@ public abstract class TypeNode extends PklNode {
     @Child protected TypeNode valueTypeNode;
     @Child @Nullable protected ListingOrMappingTypeCastNode valueTypeCastNode;
 
-    private boolean skipKeyTypeChecks;
-    private boolean skipValueTypeChecks;
-
     protected ListingOrMappingTypeNode(
         SourceSection sourceSection,
         VmLanguage language,
@@ -1772,17 +1708,6 @@ public abstract class TypeNode extends PklNode {
       this.language = language;
       this.keyTypeNode = keyTypeNode;
       this.valueTypeNode = valueTypeNode;
-
-      skipKeyTypeChecks = keyTypeNode == null || keyTypeNode.isNoopTypeCheck();
-      skipValueTypeChecks = valueTypeNode.isNoopTypeCheck();
-    }
-
-    @Override
-    protected final void invalidate() {
-      if (keyTypeNode != null) keyTypeNode.invalidate();
-      valueTypeNode.invalidate();
-      skipKeyTypeChecks = keyTypeNode == null || keyTypeNode.isNoopTypeCheck();
-      skipValueTypeChecks = valueTypeNode.isNoopTypeCheck();
     }
 
     private boolean isListing() {
@@ -1904,7 +1829,11 @@ public abstract class TypeNode extends PklNode {
     }
 
     protected void doEagerCheck(VirtualFrame frame, VmObject object) {
-      doEagerCheck(frame, object, skipKeyTypeChecks, skipValueTypeChecks);
+      doEagerCheck(
+          frame,
+          object,
+          keyTypeNode == null || keyTypeNode.isNoopTypeCheck(),
+          valueTypeNode.isNoopTypeCheck());
     }
 
     protected void doEagerCheck(
@@ -1973,14 +1902,6 @@ public abstract class TypeNode extends PklNode {
       super(sourceSection);
       this.parameterTypeNodes = parameterTypeNodes;
       this.returnTypeNode = returnTypeNode;
-    }
-
-    @Override
-    protected final void invalidate() {
-      returnTypeNode.invalidate();
-      for (var node : parameterTypeNodes) {
-        node.invalidate();
-      }
     }
 
     @Override
@@ -2074,11 +1995,6 @@ public abstract class TypeNode extends PklNode {
     }
 
     @Override
-    protected final void invalidate() {
-      typeArgumentNode.invalidate();
-    }
-
-    @Override
     public final VmClass getVmClass() {
       return BaseModule.getFunctionClass();
     }
@@ -2130,13 +2046,6 @@ public abstract class TypeNode extends PklNode {
     protected FunctionNClassTypeNode(SourceSection sourceSection, TypeNode[] typeArgumentNodes) {
       super(sourceSection);
       this.typeArgumentNodes = typeArgumentNodes;
-    }
-
-    @Override
-    protected final void invalidate() {
-      for (var node : typeArgumentNodes) {
-        node.invalidate();
-      }
     }
 
     @Override
@@ -2219,12 +2128,6 @@ public abstract class TypeNode extends PklNode {
       this.referentTypeNode = referentTypeNode;
       this.getModuleNode = new GetModuleNode(sourceSection);
       validate();
-    }
-
-    @Override
-    protected final void invalidate() {
-      domainTypeNode.invalidate();
-      referentTypeNode.invalidate();
     }
 
     @Override
@@ -2343,16 +2246,9 @@ public abstract class TypeNode extends PklNode {
 
     public PairTypeNode(
         SourceSection sourceSection, TypeNode firstTypeNode, TypeNode secondTypeNode) {
-
       super(sourceSection);
       this.firstTypeNode = firstTypeNode;
       this.secondTypeNode = secondTypeNode;
-    }
-
-    @Override
-    protected final void invalidate() {
-      firstTypeNode.invalidate();
-      secondTypeNode.invalidate();
     }
 
     @Override
@@ -2434,11 +2330,6 @@ public abstract class TypeNode extends PklNode {
 
       super(sourceSection);
       this.elementTypeNode = elementTypeNode;
-    }
-
-    @Override
-    protected final void invalidate() {
-      throw exceptionBuilder().evalError("internalStdLibClass", "VarArgs").build();
     }
 
     @Override
@@ -2806,9 +2697,6 @@ public abstract class TypeNode extends PklNode {
       this.typeAlias = typeAlias;
       this.typeArgumentNodes = typeArgumentNodes;
       aliasedTypeNode = typeAlias.instantiate(typeArgumentNodes);
-      // invalidate runs leaf-first
-      // and does not recurse into constraint expressions as those are still unresolved
-      aliasedTypeNode.invalidate();
       aliasedTypeNode.accept(
           node -> {
             if (node instanceof ValidatingObjectSlotTypeNode typeNode) {
@@ -2816,11 +2704,6 @@ public abstract class TypeNode extends PklNode {
             }
             return true;
           });
-    }
-
-    @Override
-    protected void invalidate() {
-      aliasedTypeNode.invalidate();
     }
 
     public TypeNode getAliasedTypeNode() {
@@ -3009,11 +2892,6 @@ public abstract class TypeNode extends PklNode {
       this.language = language;
       this.childNode = childNode;
       this.constraintNodes = constraintNodes;
-    }
-
-    @Override
-    protected void invalidate() {
-      childNode.invalidate();
     }
 
     public TypeNode getChildTypeNode() {

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
@@ -70,6 +70,16 @@ public abstract class TypeNode extends PklNode {
     super(sourceSection);
   }
 
+  /**
+   * Invalidate any cached state and recalculate it.
+   *
+   * <p>Subclasses should override this and call invalidate on each child before invalidating its
+   * own state.
+   */
+  protected void invalidate() {
+    // noop by default
+  }
+
   public boolean isNoopTypeCheck() {
     return false;
   }
@@ -811,6 +821,11 @@ public abstract class TypeNode extends PklNode {
     }
 
     @Override
+    protected final void invalidate() {
+      elementTypeNode.invalidate();
+    }
+
+    @Override
     protected final PType doExport() {
       return new PType.Nullable(elementTypeNode.doExport());
     }
@@ -849,7 +864,7 @@ public abstract class TypeNode extends PklNode {
 
   public static class UnionTypeNode extends WriteFrameSlotTypeNode {
     @Children final TypeNode[] elementTypeNodes;
-    private final boolean skipElementTypeChecks;
+    private boolean skipElementTypeChecks;
     private final int defaultIndex;
 
     public UnionTypeNode(
@@ -861,6 +876,16 @@ public abstract class TypeNode extends PklNode {
       assert elementTypeNodes.length > 0;
       this.elementTypeNodes = elementTypeNodes;
       this.defaultIndex = defaultIndex;
+      this.skipElementTypeChecks = skipElementTypeChecks;
+    }
+
+    @Override
+    protected final void invalidate() {
+      var skipElementTypeChecks = true;
+      for (var elementTypeNode : elementTypeNodes) {
+        elementTypeNode.invalidate();
+        skipElementTypeChecks &= elementTypeNode.isNoopTypeCheck();
+      }
       this.skipElementTypeChecks = skipElementTypeChecks;
     }
 
@@ -1162,7 +1187,6 @@ public abstract class TypeNode extends PklNode {
     @Child private TypeNode elementTypeNode;
 
     public CollectionTypeNode(SourceSection sourceSection, TypeNode elementTypeNode) {
-
       super(sourceSection);
       this.elementTypeNode = elementTypeNode;
     }
@@ -1198,6 +1222,11 @@ public abstract class TypeNode extends PklNode {
         String qualifiedName) {
 
       return VmList.EMPTY;
+    }
+
+    @Override
+    protected final void invalidate() {
+      elementTypeNode.invalidate();
     }
 
     @Override
@@ -1272,11 +1301,17 @@ public abstract class TypeNode extends PklNode {
 
   public static final class ListTypeNode extends ObjectSlotTypeNode {
     @Child private TypeNode elementTypeNode;
-    private final boolean skipElementTypeChecks;
+    private boolean skipElementTypeChecks;
 
     public ListTypeNode(SourceSection sourceSection, TypeNode elementTypeNode) {
       super(sourceSection);
       this.elementTypeNode = elementTypeNode;
+      skipElementTypeChecks = elementTypeNode.isNoopTypeCheck();
+    }
+
+    @Override
+    protected final void invalidate() {
+      elementTypeNode.invalidate();
       skipElementTypeChecks = elementTypeNode.isNoopTypeCheck();
     }
 
@@ -1371,11 +1406,17 @@ public abstract class TypeNode extends PklNode {
 
   public abstract static class SetTypeNode extends ObjectSlotTypeNode {
     @Child private TypeNode elementTypeNode;
-    private final boolean skipElementTypeChecks;
+    private boolean skipElementTypeChecks;
 
     protected SetTypeNode(SourceSection sourceSection, TypeNode elementTypeNode) {
       super(sourceSection);
       this.elementTypeNode = elementTypeNode;
+      skipElementTypeChecks = elementTypeNode.isNoopTypeCheck();
+    }
+
+    @Override
+    protected final void invalidate() {
+      elementTypeNode.invalidate();
       skipElementTypeChecks = elementTypeNode.isNoopTypeCheck();
     }
 
@@ -1451,13 +1492,19 @@ public abstract class TypeNode extends PklNode {
   public static final class MapTypeNode extends ObjectSlotTypeNode {
     @Child private TypeNode keyTypeNode;
     @Child private TypeNode valueTypeNode;
-    private final boolean skipEntryTypeChecks;
+    private boolean skipEntryTypeChecks;
 
     public MapTypeNode(SourceSection sourceSection, TypeNode keyTypeNode, TypeNode valueTypeNode) {
-
       super(sourceSection);
       this.keyTypeNode = keyTypeNode;
       this.valueTypeNode = valueTypeNode;
+      skipEntryTypeChecks = keyTypeNode.isNoopTypeCheck() && valueTypeNode.isNoopTypeCheck();
+    }
+
+    @Override
+    protected final void invalidate() {
+      keyTypeNode.invalidate();
+      valueTypeNode.invalidate();
       skipEntryTypeChecks = keyTypeNode.isNoopTypeCheck() && valueTypeNode.isNoopTypeCheck();
     }
 
@@ -1712,8 +1759,8 @@ public abstract class TypeNode extends PklNode {
     @Child protected TypeNode valueTypeNode;
     @Child @Nullable protected ListingOrMappingTypeCastNode valueTypeCastNode;
 
-    private final boolean skipKeyTypeChecks;
-    private final boolean skipValueTypeChecks;
+    private boolean skipKeyTypeChecks;
+    private boolean skipValueTypeChecks;
 
     protected ListingOrMappingTypeNode(
         SourceSection sourceSection,
@@ -1726,6 +1773,14 @@ public abstract class TypeNode extends PklNode {
       this.keyTypeNode = keyTypeNode;
       this.valueTypeNode = valueTypeNode;
 
+      skipKeyTypeChecks = keyTypeNode == null || keyTypeNode.isNoopTypeCheck();
+      skipValueTypeChecks = valueTypeNode.isNoopTypeCheck();
+    }
+
+    @Override
+    protected final void invalidate() {
+      if (keyTypeNode != null) keyTypeNode.invalidate();
+      valueTypeNode.invalidate();
       skipKeyTypeChecks = keyTypeNode == null || keyTypeNode.isNoopTypeCheck();
       skipValueTypeChecks = valueTypeNode.isNoopTypeCheck();
     }
@@ -1921,6 +1976,14 @@ public abstract class TypeNode extends PklNode {
     }
 
     @Override
+    protected final void invalidate() {
+      returnTypeNode.invalidate();
+      for (var node : parameterTypeNodes) {
+        node.invalidate();
+      }
+    }
+
+    @Override
     public final VmClass getVmClass() {
       return getFunctionNClass();
     }
@@ -2011,6 +2074,11 @@ public abstract class TypeNode extends PklNode {
     }
 
     @Override
+    protected final void invalidate() {
+      typeArgumentNode.invalidate();
+    }
+
+    @Override
     public final VmClass getVmClass() {
       return BaseModule.getFunctionClass();
     }
@@ -2062,6 +2130,13 @@ public abstract class TypeNode extends PklNode {
     protected FunctionNClassTypeNode(SourceSection sourceSection, TypeNode[] typeArgumentNodes) {
       super(sourceSection);
       this.typeArgumentNodes = typeArgumentNodes;
+    }
+
+    @Override
+    protected final void invalidate() {
+      for (var node : typeArgumentNodes) {
+        node.invalidate();
+      }
     }
 
     @Override
@@ -2144,6 +2219,12 @@ public abstract class TypeNode extends PklNode {
       this.referentTypeNode = referentTypeNode;
       this.getModuleNode = new GetModuleNode(sourceSection);
       validate();
+    }
+
+    @Override
+    protected final void invalidate() {
+      domainTypeNode.invalidate();
+      referentTypeNode.invalidate();
     }
 
     @Override
@@ -2269,6 +2350,12 @@ public abstract class TypeNode extends PklNode {
     }
 
     @Override
+    protected final void invalidate() {
+      firstTypeNode.invalidate();
+      secondTypeNode.invalidate();
+    }
+
+    @Override
     protected Object executeLazily(VirtualFrame frame, Object value) {
       if (value instanceof VmPair vmPair) {
         var first = firstTypeNode.executeLazily(frame, vmPair.getFirst());
@@ -2347,6 +2434,11 @@ public abstract class TypeNode extends PklNode {
 
       super(sourceSection);
       this.elementTypeNode = elementTypeNode;
+    }
+
+    @Override
+    protected final void invalidate() {
+      throw exceptionBuilder().evalError("internalStdLibClass", "VarArgs").build();
     }
 
     @Override
@@ -2714,6 +2806,9 @@ public abstract class TypeNode extends PklNode {
       this.typeAlias = typeAlias;
       this.typeArgumentNodes = typeArgumentNodes;
       aliasedTypeNode = typeAlias.instantiate(typeArgumentNodes);
+      // invalidate runs leaf-first
+      // and does not recurse into constraint expressions as those are still unresolved
+      aliasedTypeNode.invalidate();
       aliasedTypeNode.accept(
           node -> {
             if (node instanceof ValidatingObjectSlotTypeNode typeNode) {
@@ -2721,6 +2816,11 @@ public abstract class TypeNode extends PklNode {
             }
             return true;
           });
+    }
+
+    @Override
+    protected void invalidate() {
+      aliasedTypeNode.invalidate();
     }
 
     public TypeNode getAliasedTypeNode() {
@@ -2767,6 +2867,21 @@ public abstract class TypeNode extends PklNode {
 
       try {
         return aliasedTypeNode.executeLazily(frame, value);
+      } finally {
+        setOwner(frame, prevOwner);
+        setReceiver(frame, prevReceiver);
+      }
+    }
+
+    @Override
+    public Object executeEagerly(VirtualFrame frame, Object value) {
+      var prevOwner = VmUtils.getOwner(frame);
+      var prevReceiver = VmUtils.getReceiver(frame);
+      setOwner(frame, VmUtils.getOwner(typeAlias.getEnclosingFrame()));
+      setReceiver(frame, VmUtils.getReceiver(typeAlias.getEnclosingFrame()));
+
+      try {
+        return aliasedTypeNode.executeEagerly(frame, value);
       } finally {
         setOwner(frame, prevOwner);
         setReceiver(frame, prevReceiver);
@@ -2894,6 +3009,11 @@ public abstract class TypeNode extends PklNode {
       this.language = language;
       this.childNode = childNode;
       this.constraintNodes = constraintNodes;
+    }
+
+    @Override
+    protected void invalidate() {
+      childNode.invalidate();
     }
 
     public TypeNode getChildTypeNode() {

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
@@ -361,16 +361,13 @@ public abstract class UnresolvedTypeNode extends PklNode {
       CompilerDirectives.transferToInterpreter();
 
       var elementTypeNodes = new TypeNode[unresolvedElementTypeNodes.length];
-      var skipElementTypeChecks = true;
 
       for (var i = 0; i < elementTypeNodes.length; i++) {
         var elementTypeNode = unresolvedElementTypeNodes[i].execute(frame);
         elementTypeNodes[i] = elementTypeNode;
-        skipElementTypeChecks &= elementTypeNode.isNoopTypeCheck();
       }
 
-      return new UnionTypeNode(
-          sourceSection, defaultIndex, elementTypeNodes, skipElementTypeChecks);
+      return new UnionTypeNode(sourceSection, defaultIndex, elementTypeNodes);
     }
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/protobuf/RendererNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/protobuf/RendererNodes.java
@@ -645,10 +645,7 @@ public final class RendererNodes {
             hasString && elements.size() == 1
                 ? elements.get(0)
                 : new UnionTypeNode(
-                    VmUtils.unavailableSourceSection(),
-                    -1,
-                    elements.toArray(new TypeNode[0]),
-                    false);
+                    VmUtils.unavailableSourceSection(), -1, elements.toArray(new TypeNode[0]));
         return type;
       }
       return type;

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAlias4.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAlias4.pkl
@@ -1,0 +1,20 @@
+typealias MyList<T> = List<T>
+res1 = List(new Dynamic {}) is MyList<module>
+
+typealias MySet<T> = Set<T>
+res2 = Set(new Dynamic {}) is MySet<module>
+
+typealias MyMap<T> = Map<Any, T>
+res3 = Map("foo", new Dynamic {}) is MyMap<module>
+
+typealias MyListing<T> = Listing<T>
+res4 = new Listing { new Dynamic {} } is MyListing<module>
+
+typealias MyMapping<K, V> = Mapping<K, V>
+res5 = new Mapping { ["foo"] = new Dynamic {} } is MyMapping<String, module>
+
+typealias MyUnion<A, B> = A | B
+res6 = new Dynamic {} is MyUnion<module, module>
+
+typealias NestedUnion<A, B> = (A | A) | (B | B)
+res7 = new Dynamic {} is NestedUnion<module, module>

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAlias4.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAlias4.pcf
@@ -1,0 +1,7 @@
+res1 = false
+res2 = false
+res3 = false
+res4 = false
+res5 = false
+res6 = false
+res7 = false


### PR DESCRIPTION
This also fixes `TypeAliasTypeNode` always performing lazy type checks even when they should be eager.

Resolves #1710
Resolves #1716