### PR TITLE
Improve thread safety for pkl:base

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/BaseModule.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/BaseModule.java
@@ -15,6 +15,8 @@
  */
 package org.pkl.core.runtime;
 
+import static org.pkl.core.PClassInfo.pklBaseUri;
+
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
@@ -22,7 +24,7 @@ public final class BaseModule extends StdLibModule {
   static final VmTyped instance = VmUtils.createEmptyModule();
 
   static {
-    loadBaseModule(instance);
+    loadModule(pklBaseUri, instance);
   }
 
   public static VmTyped getModule() {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/BaseModule.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/BaseModule.java
@@ -15,8 +15,6 @@
  */
 package org.pkl.core.runtime;
 
-import static org.pkl.core.PClassInfo.pklBaseUri;
-
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
@@ -24,7 +22,7 @@ public final class BaseModule extends StdLibModule {
   static final VmTyped instance = VmUtils.createEmptyModule();
 
   static {
-    loadModule(pklBaseUri, instance);
+    loadBaseModule(instance);
   }
 
   public static VmTyped getModule() {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/StdLibModule.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/StdLibModule.java
@@ -29,40 +29,33 @@ import org.pkl.core.http.HttpClient;
 import org.pkl.core.module.ModuleKeyFactories;
 import org.pkl.core.module.ModuleKeys;
 import org.pkl.core.module.ResolvedModuleKey;
+import org.pkl.core.resource.ResourceReader;
 import org.pkl.core.resource.ResourceReaders;
 
 public abstract class StdLibModule {
   @TruffleBoundary
   protected static void loadModule(URI uri, VmTyped instance) {
-    assert !uri.equals(pklBaseUri) : "pkl:base should be loaded with `loadBaseModule`";
-    doLoad(uri, instance, false);
+    doLoad(uri, instance);
   }
 
-  @TruffleBoundary
-  protected static void loadBaseModule(VmTyped instance) {
-    doLoad(
-        pklBaseUri,
-        instance,
-        // seed base module's `output` members; `output` contains truffle nodes that
-        // need to be initialized statically (e.g. LetExprNode, TypeTestNode).
-        // additionally, its `cachedMembers` is not thread-safe and needs to be initialized
-        // statically.
-        true);
-  }
-
-  private static void doLoad(URI uri, VmTyped instance, boolean forceOutput) {
+  private static void doLoad(URI uri, VmTyped instance) {
     VmUtils.createContext(
             () -> {
               var vmContext = VmContext.get(null);
+              var isPklBaseModule = uri.equals(pklBaseUri);
+              var resourceReaders =
+                  isPklBaseModule
+                      // needed when initializing `pkl:base` because of
+                      // `read("prop:pkl.outputFormat")`
+                      ? List.of(ResourceReaders.externalProperty())
+                      : List.<ResourceReader>of();
               vmContext.initialize(
                   new VmContext.Holder(
                       StackFrameTransformers.defaultTransformer,
                       SecurityManagers.defaultManager,
                       HttpClient.dummyClient(),
                       new ModuleResolver(List.of(ModuleKeyFactories.standardLibrary)),
-                      new ResourceManager(
-                          SecurityManagers.defaultManager,
-                          List.of(ResourceReaders.externalProperty())),
+                      new ResourceManager(SecurityManagers.defaultManager, resourceReaders),
                       Loggers.noop(),
                       Map.of(),
                       Map.of(),
@@ -86,7 +79,12 @@ public abstract class StdLibModule {
               // (stdlib module objects are statically shared singletons when running on JVM)
               // and ensure compile-time evaluation in AOT mode
               instance.force(false, true);
-              if (forceOutput) {
+
+              // seed base module's `output` members; `output` contains truffle nodes that
+              // need to be initialized statically (e.g. LetExprNode, TypeTestNode).
+              // additionally, its `cachedMembers` is not thread-safe and needs to be initialized
+              // statically.
+              if (isPklBaseModule) {
                 var output = VmUtils.readModuleOutput(instance);
                 output.force(false, true);
               }

--- a/pkl-core/src/main/java/org/pkl/core/runtime/StdLibModule.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/StdLibModule.java
@@ -15,6 +15,8 @@
  */
 package org.pkl.core.runtime;
 
+import static org.pkl.core.PClassInfo.pklBaseUri;
+
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import java.net.URI;
 import java.util.List;
@@ -27,13 +29,28 @@ import org.pkl.core.http.HttpClient;
 import org.pkl.core.module.ModuleKeyFactories;
 import org.pkl.core.module.ModuleKeys;
 import org.pkl.core.module.ResolvedModuleKey;
+import org.pkl.core.resource.ResourceReaders;
 
 public abstract class StdLibModule {
   @TruffleBoundary
   protected static void loadModule(URI uri, VmTyped instance) {
-    // evaluate eagerly to increase thread safety
-    // (stdlib module objects are statically shared singletons when running on JVM)
-    // and ensure compile-time evaluation in AOT mode
+    assert !uri.equals(pklBaseUri) : "pkl:base should be loaded with `loadBaseModule`";
+    doLoad(uri, instance, false);
+  }
+
+  @TruffleBoundary
+  protected static void loadBaseModule(VmTyped instance) {
+    doLoad(
+        pklBaseUri,
+        instance,
+        // seed base module's `output` members; `output` contains truffle nodes that
+        // need to be initialized statically (e.g. LetExprNode, TypeTestNode).
+        // additionally, its `cachedMembers` is not thread-safe and needs to be initialized
+        // statically.
+        true);
+  }
+
+  private static void doLoad(URI uri, VmTyped instance, boolean forceOutput) {
     VmUtils.createContext(
             () -> {
               var vmContext = VmContext.get(null);
@@ -43,7 +60,9 @@ public abstract class StdLibModule {
                       SecurityManagers.defaultManager,
                       HttpClient.dummyClient(),
                       new ModuleResolver(List.of(ModuleKeyFactories.standardLibrary)),
-                      new ResourceManager(SecurityManagers.defaultManager, List.of()),
+                      new ResourceManager(
+                          SecurityManagers.defaultManager,
+                          List.of(ResourceReaders.externalProperty())),
                       Loggers.noop(),
                       Map.of(),
                       Map.of(),
@@ -67,6 +86,10 @@ public abstract class StdLibModule {
               // (stdlib module objects are statically shared singletons when running on JVM)
               // and ensure compile-time evaluation in AOT mode
               instance.force(false, true);
+              if (forceOutput) {
+                var output = VmUtils.readModuleOutput(instance);
+                output.force(false, true);
+              }
             })
         .close();
   }

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluatorTest.kt
@@ -772,6 +772,23 @@ class EvaluatorTest {
       .doesNotThrowAnyException()
   }
 
+  @Test
+  fun `concurrent evals`() {
+    val exceptions = mutableListOf<Throwable>()
+    val threads =
+      (0..10).map {
+        Thread { Evaluator.preconfigured().use { ev -> ev.evaluateOutputText(text("foo = 1")) } }
+          .also { t ->
+            t.uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, e ->
+              synchronized(exceptions) { exceptions.add(e) }
+            }
+            t.start()
+          }
+      }
+    for (t in threads) t.join()
+    exceptions.firstOrNull()?.let { throw it }
+  }
+
   private fun checkModule(module: PModule) {
     assertThat(module.properties.size).isEqualTo(2)
     assertThat(module.getProperty("name")).isEqualTo("pigeon")


### PR DESCRIPTION
Stdlib modules are singletons that are shared across multiple evaluators. They're _supposed_ to be thread-safe.

This improves thread safety by deep-forcing the module's `output` during initialization, which initializes truffle nodes (e.g. `TypeTestNode`, `LetExprNode`), and also initializes the member cache of the module output of `pkl:base`

This doesn't guarantee thread safety everywhere: here, we assume that `output` is the root for every truffle node that has thread safety issues in the base module.

Note that this changes the behavior of evaluating `pkl:base` itself.

Before:
```
$ pkl eval pkl:base -x 'output.renderer.renderDocument(new Dynamic { foo = 1 })' -f json
{
  "foo": 1
}
```

After (renderer is statically set and cannot be changed)
```
$ pkl eval pkl:base -x 'output.renderer.renderDocument(new Dynamic { foo = 1 })' -f json
foo = 1
```

Closes https://github.com/apple/pkl/issues/1470