### PR TITLE
Do not treat replaceable `TypeVariableNode` instances as noops

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/TypeNode.java
@@ -2395,11 +2395,13 @@ public abstract class TypeNode extends PklNode {
 
   public static final class TypeVariableNode extends WriteFrameSlotTypeNode {
     private final TypeParameter typeParameter;
+    private final boolean isInTypeAlias;
 
-    public TypeVariableNode(SourceSection sourceSection, TypeParameter typeParameter) {
-
+    public TypeVariableNode(
+        SourceSection sourceSection, TypeParameter typeParameter, boolean isInTypeAlias) {
       super(sourceSection);
       this.typeParameter = typeParameter;
+      this.isInTypeAlias = isInTypeAlias;
     }
 
     public int getTypeParameterIndex() {
@@ -2408,7 +2410,10 @@ public abstract class TypeNode extends PklNode {
 
     @Override
     public boolean isNoopTypeCheck() {
-      return true;
+      // if in a type alias, this node will be replaced by another TypeNode that may not be a noop
+      // so we return false so that containing TypeNodes don't skip checks erroneously
+      // this is slightly less efficient if the replacement _is_ a noop, but only inside typealiases
+      return !isInTypeAlias;
     }
 
     @Override
@@ -2783,6 +2788,22 @@ public abstract class TypeNode extends PklNode {
 
       try {
         return aliasedTypeNode.executeAndSet(frame, value);
+      } finally {
+        setOwner(frame, prevOwner);
+        setReceiver(frame, prevReceiver);
+      }
+    }
+
+    /** See docstring on {@link TypeAliasTypeNode#executeLazily}. */
+    @Override
+    public Object executeEagerly(VirtualFrame frame, Object value) {
+      var prevOwner = VmUtils.getOwner(frame);
+      var prevReceiver = VmUtils.getReceiver(frame);
+      setOwner(frame, VmUtils.getOwner(typeAlias.getEnclosingFrame()));
+      setReceiver(frame, VmUtils.getReceiver(typeAlias.getEnclosingFrame()));
+
+      try {
+        return aliasedTypeNode.executeEagerly(frame, value);
       } finally {
         setOwner(frame, prevOwner);
         setReceiver(frame, prevReceiver);

--- a/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/type/UnresolvedTypeNode.java
@@ -18,12 +18,14 @@ package org.pkl.core.ast.type;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.nodes.NodeUtil;
 import com.oracle.truffle.api.source.SourceSection;
 import java.util.Set;
 import org.pkl.core.TypeParameter;
 import org.pkl.core.ast.ExpressionNode;
 import org.pkl.core.ast.PklNode;
 import org.pkl.core.ast.expression.primary.GetModuleNode;
+import org.pkl.core.ast.member.TypeAliasNode;
 import org.pkl.core.ast.type.TypeNode.*;
 import org.pkl.core.ast.type.TypeNodeFactory.*;
 import org.pkl.core.runtime.*;
@@ -437,7 +439,9 @@ public abstract class UnresolvedTypeNode extends PklNode {
     public TypeNode execute(VirtualFrame frame) {
       CompilerDirectives.transferToInterpreter();
 
-      return new TypeVariableNode(sourceSection, typeParameter);
+      //noinspection ConstantValue
+      return new TypeVariableNode(
+          sourceSection, typeParameter, NodeUtil.findParent(this, TypeAliasNode.class) != null);
     }
   }
 

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAlias4.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/types/typeAlias4.pkl
@@ -1,0 +1,24 @@
+typealias MyList<T> = List<T>
+res1 = List(new Dynamic {}) is MyList<module>
+
+typealias MyList2<T> = List(any((it) -> it is T))
+res1a = List(new Dynamic {}) is MyList<module>
+res1b = List(this) is MyList<module>
+
+typealias MySet<T> = Set<T>
+res2 = Set(new Dynamic {}) is MySet<module>
+
+typealias MyMap<T> = Map<Any, T>
+res3 = Map("foo", new Dynamic {}) is MyMap<module>
+
+typealias MyListing<T> = Listing<T>
+res4 = new Listing { new Dynamic {} } is MyListing<module>
+
+typealias MyMapping<K, V> = Mapping<K, V>
+res5 = new Mapping { ["foo"] = new Dynamic {} } is MyMapping<String, module>
+
+typealias MyUnion<A, B> = A | B
+res6 = new Dynamic {} is MyUnion<module, module>
+
+typealias NestedUnion<A, B> = (A | A) | (B | B)
+res7 = new Dynamic {} is NestedUnion<module, module>

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAlias4.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/types/typeAlias4.pcf
@@ -1,0 +1,9 @@
+res1 = false
+res1a = false
+res1b = true
+res2 = false
+res3 = false
+res4 = false
+res5 = false
+res6 = false
+res7 = false


### PR DESCRIPTION
This also fixes `TypeAliasTypeNode` always performing lazy type checks even when they should be eager.

Resolves #1710
Resolves #1716
Supersedes #1717