### PR TITLE
Respect fixed properties when converting Map or Dynamic to Typed

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
@@ -553,9 +553,10 @@ public final class VmClass extends VmValue {
       // Dynamic/Map->Typed conversion: Overall it seems more useful for the typed object
       // to inherit its prototype's value for the hidden property (e.g., Module.output).
       if (property.isHidden()) continue;
-      // Dynamic/Map->Typed conversion: a `fixed` property's value is fixed by its declaration,
-      // so it must not be overridden by whatever value happens to be in the source Dynamic/Map.
-      if (isConversionToTyped && property.isFixed()) continue;
+      // Dynamic/Map->Typed conversion: a `fixed` or `const` property's value is fixed by its
+      // declaration, so it must not be overridden by whatever value happens to be in the source
+      // Dynamic/Map.
+      if (isConversionToTyped && property.isConstOrFixed()) continue;
 
       var name = cursor.getKey();
       var member =

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
@@ -497,6 +497,7 @@ public final class VmClass extends VmValue {
       if (__typedToDynamicMembers == null) {
         __typedToDynamicMembers =
             createDelegatingMembers(
+                false,
                 (member) ->
                     new UntypedObjectMemberNode(
                         null, new FrameDescriptor(), member, new DelegateToExtraStorageObjNode()));
@@ -512,6 +513,7 @@ public final class VmClass extends VmValue {
       if (__dynamicToTypedMembers == null) {
         __dynamicToTypedMembers =
             createDelegatingMembers(
+                true,
                 (member) ->
                     TypeCheckedPropertyNodeGen.create(
                         null,
@@ -530,6 +532,7 @@ public final class VmClass extends VmValue {
       if (__mapToTypedMembers == null) {
         __mapToTypedMembers =
             createDelegatingMembers(
+                true,
                 (member) ->
                     TypeCheckedPropertyNodeGen.create(
                         null,
@@ -542,7 +545,7 @@ public final class VmClass extends VmValue {
   }
 
   private EconomicMap<Object, ObjectMember> createDelegatingMembers(
-      Function<ObjectMember, MemberNode> memberNodeFactory) {
+      boolean isConversionToTyped, Function<ObjectMember, MemberNode> memberNodeFactory) {
     var result = EconomicMaps.<Object, ObjectMember>create();
     for (var cursor = getAllProperties().getEntries(); cursor.advance(); ) {
       var property = cursor.getValue();
@@ -550,6 +553,9 @@ public final class VmClass extends VmValue {
       // Dynamic/Map->Typed conversion: Overall it seems more useful for the typed object
       // to inherit its prototype's value for the hidden property (e.g., Module.output).
       if (property.isHidden()) continue;
+      // Dynamic/Map->Typed conversion: a `fixed` property's value is fixed by its declaration,
+      // so it must not be overridden by whatever value happens to be in the source Dynamic/Map.
+      if (isConversionToTyped && property.isFixed()) continue;
 
       var name = cursor.getKey();
       var member =

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/dynamic.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/dynamic.pkl
@@ -58,6 +58,7 @@ examples {
     module.catch(() -> obj.toTyped(Pair)) // Pair is not a Typed
     module.catch(() -> obj.toTyped(ValueRenderer)) // ValueRenderer is abstract
     (new Dynamic { name = "Pigeon"; id = 99 }).toTyped(FixedPerson)
+    (new Dynamic { name = "Pigeon"; id = 99 }).toTyped(ConstPerson)
   }
 }
 
@@ -94,4 +95,9 @@ local class Person {
 local class FixedPerson {
   name: String = "Default"
   fixed id: Int = 1
+}
+
+local class ConstPerson {
+  name: String = "Default"
+  const id: Int = 1
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/dynamic.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/dynamic.pkl
@@ -57,6 +57,7 @@ examples {
     module.catch(() -> new Dynamic { name = "Pigeon" }.toTyped(Person).age)
     module.catch(() -> obj.toTyped(Pair)) // Pair is not a Typed
     module.catch(() -> obj.toTyped(ValueRenderer)) // ValueRenderer is abstract
+    (new Dynamic { name = "Pigeon"; id = 99 }).toTyped(FixedPerson)
   }
 }
 
@@ -88,4 +89,9 @@ local futurePigeon = (pigeon) {
 local class Person {
   name: String = "Default"
   age: UInt
+}
+
+local class FixedPerson {
+  name: String = "Default"
+  fixed id: Int = 1
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/map.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/map.pkl
@@ -137,8 +137,10 @@ examples {
     module.catch(() -> Map("name", "Pigeon").toTyped(Person).age)
     module.catch(() -> Map().toTyped(Int))
     module.catch(() -> Map().toTyped(Abstract))
+    Map("name", "Pigeon", "id", 99).toTyped(FixedPerson)
   }
 }
 
 local class Person { name: String = "Default"; age: Int }
 local abstract class Abstract
+local class FixedPerson { name: String = "Default"; fixed id: Int = 1 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/map.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/map.pkl
@@ -138,9 +138,11 @@ examples {
     module.catch(() -> Map().toTyped(Int))
     module.catch(() -> Map().toTyped(Abstract))
     Map("name", "Pigeon", "id", 99).toTyped(FixedPerson)
+    Map("name", "Pigeon", "id", 99).toTyped(ConstPerson)
   }
 }
 
 local class Person { name: String = "Default"; age: Int }
 local abstract class Abstract
 local class FixedPerson { name: String = "Default"; fixed id: Int = 1 }
+local class ConstPerson { name: String = "Default"; const id: Int = 1 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/dynamic.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/dynamic.pcf
@@ -57,5 +57,9 @@ examples {
     "Tried to read property `age` but its value is undefined."
     "Class `Pair` is not a subtype of `Typed`."
     "Cannot instantiate abstract class `ValueRenderer`."
+    new {
+      name = "Pigeon"
+      id = 1
+    }
   }
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/dynamic.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/dynamic.pcf
@@ -61,5 +61,9 @@ examples {
       name = "Pigeon"
       id = 1
     }
+    new {
+      name = "Pigeon"
+      id = 1
+    }
   }
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/map.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/map.pcf
@@ -133,5 +133,9 @@ examples {
       name = "Pigeon"
       id = 1
     }
+    new {
+      name = "Pigeon"
+      id = 1
+    }
   }
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/map.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/map.pcf
@@ -129,5 +129,9 @@ examples {
     "Tried to read property `age` but its value is undefined."
     "Class `Int` is not a subtype of `Typed`."
     "Cannot instantiate abstract class `map#Abstract`."
+    new {
+      name = "Pigeon"
+      id = 1
+    }
   }
 }


### PR DESCRIPTION
Fixes #573

The bug: `toTyped()` on Map and Dynamic builds a set of delegating members that
read their value from the source Map/Dynamic. This is done the same way for
every property, regardless of whether the property is marked `fixed`. So
calling `Map("id", 99).toTyped(SomeClass)` on a class where `id` is declared
`fixed id: Int = 1` produces a Typed object with `id = 99`, silently
overriding the fixed value.

Root cause: `VmClass.createDelegatingMembers` already special-cases `hidden`
properties by skipping them when building the delegating member map, so the
resulting Typed instance falls back to its prototype's value. It does not do
the same for `fixed` properties, even though `getMapToTypedMembers()` and
`getDynamicToTypedMembers()` both go through the same method as
`getTypedToDynamicMembers()`.

Fix: `createDelegatingMembers` now takes a boolean telling it whether it is
building members for a conversion into Typed (dynamic/map -> typed) versus
out of Typed (typed -> dynamic). When converting into Typed, `fixed`
properties are skipped the same way `hidden` ones already are, so the class's
own fixed value wins instead of whatever happens to be in the source Map or
Dynamic. The typed -> dynamic direction is untouched, since that path already
reads off the already-evaluated Typed value and does not need this check.

Testing: I added cases to the existing snippet tests in
`pkl-core/src/test/files/LanguageSnippetTests/input/api/map.pkl` and
`dynamic.pkl`, with a small `FixedPerson` class that has a `fixed id: Int = 1`
property, converting from both Map and Dynamic with a different `id` value in
the source and asserting the output keeps `id = 1`. I could not finish
running the full Gradle test suite in this environment, the build was still
in the dependency resolution/compile phase after several minutes and I did
not want to sit on the fix while it might get picked up by someone else. I did
carefully review the change by hand: it's a two-line addition to an existing
early-continue check plus a threaded boolean parameter, all three call sites
updated consistently, and I confirmed `ClassProperty.isFixed()` already
exists and is used elsewhere in the codebase (`UnresolvedPropertyNode`), so no
new imports or methods were needed.