### PR TITLE
Allow `projectpackage:` resource reads by default in Gradle plugin

### DIFF
--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -309,7 +309,9 @@ public class PklPlugin implements Plugin<Project> {
                 "repl:", "file:", "modulepath:", "https:", "pkl:", "package:", "projectpackage:"));
 
     spec.getAllowedResources()
-        .convention(List.of("env:", "prop:", "file:", "modulepath:", "https:", "package:"));
+        .convention(
+            List.of(
+                "env:", "prop:", "file:", "modulepath:", "https:", "package:", "projectpackage:"));
 
     spec.getEvalRootDir().convention(project.getRootProject().getLayout().getProjectDirectory());
 


### PR DESCRIPTION
Fix an inconsistency: they are allowed as imports, but not reads.

Closes #1734 