### PR TITLE
Normalize asset paths in local dependencies

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/packages/Dependency.java
+++ b/pkl-core/src/main/java/org/pkl/core/packages/Dependency.java
@@ -53,9 +53,11 @@ public abstract class Dependency {
     }
 
     public URI resolveAssetUri(URI projectBaseUri, PackageAssetUri packageAssetUri) {
-      // drop 1 to remove leading `/`
-      var assetPath = packageAssetUri.getAssetPath().substring(1);
-      var resolvedPath = path.resolve(assetPath);
+      // copy how remote dependencies work; the `..` segment at the root just normalizes to the
+      // root.
+      var assetPath = Path.of(packageAssetUri.getAssetPath()).normalize();
+      var relativePath = Path.of("/").relativize(assetPath);
+      var resolvedPath = path.resolve(relativePath);
       var normalized = IoUtils.toNormalizedPathString(resolvedPath);
       try {
         var relativeUri = new URI(null, null, normalized, null);

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project1/localProject2.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project1/localProject2.pkl
@@ -1,0 +1,3 @@
+// `..` at the package root stays in the package root
+res1 = import("@project2/../penguin.pkl")
+res2 = import("@project2/foo/../../penguin.pkl")

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project1/localProjectRead2.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/projects/project1/localProjectRead2.pkl
@@ -1,0 +1,3 @@
+res1 = read*("@project2/../*").keys
+res2 = read*("@project2/../../*").keys
+res3 = read("@project2/../../").text

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/localProject2.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/localProject2.pcf
@@ -1,0 +1,16 @@
+res1 {
+  bird {
+    name = "Penguin"
+    favoriteFruit {
+      name = "Ice Fruit"
+    }
+  }
+}
+res2 {
+  bird {
+    name = "Penguin"
+    favoriteFruit {
+      name = "Ice Fruit"
+    }
+  }
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/localProjectRead2.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/projects/project1/localProjectRead2.pcf
@@ -1,0 +1,8 @@
+res1 = Set("@project2/../PklProject", "@project2/../PklProject.deps.json", "@project2/../penguin.pkl")
+res2 = Set("@project2/../../PklProject", "@project2/../../PklProject.deps.json", "@project2/../../penguin.pkl")
+res3 = """
+  penguin.pkl
+  PklProject
+  PklProject.deps.json
+  
+  """


### PR DESCRIPTION
This changes local asset path resolution so that `..` segments at the dependency root just resolves to the dependency root.

This makes import resolution work the same between local and remote dependencies.