### PR TITLE
Avoid duplicate pkl-gradle publication

### DIFF
--- a/build-logic/src/main/kotlin/PklPublishing.kt
+++ b/build-logic/src/main/kotlin/PklPublishing.kt
@@ -65,22 +65,26 @@ fun Project.configurePklPomMetadata() {
 fun Project.configurePomValidation() {
   val validatePom =
     tasks.register("validatePom") {
-      if (tasks.findByName("generatePomFileForLibraryPublication") == null) {
-        return@register
-      }
-      val generatePomFileForLibraryPublication =
-        tasks.named<GenerateMavenPom>("generatePomFileForLibraryPublication")
+      val pomTaskName =
+        when {
+          tasks.findByName("generatePomFileForLibraryPublication") != null ->
+            "generatePomFileForLibraryPublication"
+          tasks.findByName("generatePomFileForPluginMavenPublication") != null ->
+            "generatePomFileForPluginMavenPublication"
+          else -> return@register
+        }
+      val generatePomFileForPublication = tasks.named<GenerateMavenPom>(pomTaskName)
       val outputFile =
         layout.buildDirectory.file("validatePom") // dummy output to satisfy up-to-date check
 
-      dependsOn(generatePomFileForLibraryPublication)
-      inputs.file(generatePomFileForLibraryPublication.get().destination)
+      dependsOn(generatePomFileForPublication)
+      inputs.file(generatePomFileForPublication.get().destination)
       outputs.file(outputFile)
 
       doLast {
         outputFile.get().asFile.delete()
 
-        val pomFile = generatePomFileForLibraryPublication.get().destination
+        val pomFile = generatePomFileForPublication.get().destination
         assert(pomFile.exists())
 
         val text = pomFile.readText()

--- a/pkl-gradle/pkl-gradle.gradle.kts
+++ b/pkl-gradle/pkl-gradle.gradle.kts
@@ -20,9 +20,14 @@ plugins {
   id("pklJSpecify")
   `java-gradle-plugin`
   `maven-publish`
-  id("pklPublishLibrary")
   signing
 }
+
+configurePklPomMetadata()
+
+configurePomValidation()
+
+configurePklSigning()
 
 dependencies {
   // Declare a `compileOnly` dependency on `projects.pklTools`


### PR DESCRIPTION
## Summary

- stop applying the library publication convention to `pkl-gradle`, since `java-gradle-plugin` already creates `pluginMaven` with the same coordinates
- retain the shared POM metadata, validation, and signing configuration without creating a duplicate publication
- validate the `pluginMaven` POM when a library publication is not present

Fixes #1742

## Testing

- `./gradlew build`
- `./gradlew buildNative`
- `./gradlew :pkl-gradle:validatePom`
- `./gradlew publishToSonatype --dry-run`
- signed publication to the local Maven repository using a temporary test key