### PR TITLE
Suppress pluginMaven POM metadata warning

### DIFF
--- a/pkl-gradle/pkl-gradle.gradle.kts
+++ b/pkl-gradle/pkl-gradle.gradle.kts
@@ -113,6 +113,11 @@ tasks.test {
 publishing {
   publications {
     withType<MavenPublication>().configureEach {
+      if (name == "pluginMaven") {
+        // The plugin intentionally depends on the shaded pkl-tools runtime variant,
+        // which Gradle module metadata can express but Maven POM metadata cannot.
+        suppressPomMetadataWarningsFor("runtimeElements")
+      }
       pom {
         name = "pkl-gradle plugin"
         url = "https://github.com/apple/pkl/tree/main/pkl-gradle"


### PR DESCRIPTION
Fixes #1743

Adds a targeted suppressPomMetadataWarningsFor("runtimeElements")
for the pluginMaven publication in pkl-gradle.

Keeps runtime behavior unchanged; only suppresses the known
Gradle-to-Maven compatibility warning for the shaded :pkl-tools
variant.

Validation:
- git diff --check passed
- IDE diagnostics passed
- Full Gradle validation is blocked here because no Java runtime is installed

Note for reviewer:
Hi Daniel — this is a small targeted fix for #1743. I kept the change limited to the pluginMaven publication and only suppressed the known runtimeElements metadata warning. Thanks for taking a look.
