### PR TITLE
codegen-java: Support generating nullable annotations

### DIFF
--- a/docs/modules/java-binding/pages/codegen.adoc
+++ b/docs/modules/java-binding/pages/codegen.adoc
@@ -204,6 +204,16 @@ The specified annotation type must be annotated with `@java.lang.annotation.Targ
 or the generated code may not compile.
 ====
 
+.--nullable-annotation
+[%collapsible]
+====
+Default: `none` +
+Fully qualified name of the annotation type to use for annotating nullable types. +
+The specified annotation type must be annotated with `@java.lang.annotation.Target(ElementType.TYPE_USE)`
+or the generated code may not compile.
+If unset, nullable types are not annotated.
+====
+
 Common code generator options:
 
 include::{partialsdir}/cli-codegen-options.adoc[]

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -430,6 +430,17 @@ The specified annotation type must be annotated with `@java.lang.annotation.Targ
 or the generated code may not compile.
 ====
 
+.nullableAnnotation: Property<String>
+[%collapsible]
+====
+Default: `null` +
+Example: `nullableAnnotation = "org.project.MyAnnotation"` +
+Fully qualified name of the annotation type to use for annotating nullable types. +
+The specified annotation type must be annotated with `@java.lang.annotation.Target(ElementType.TYPE_USE)`
+or the generated code may not compile.
+If set to `null`, nullable types are not annotated.
+====
+
 Common code generation properties:
 
 include::../partials/gradle-codegen-properties.adoc[]

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ data class CliJavaCodeGeneratorOptions(
    *
    * The specified annotation type must have a [java.lang.annotation.Target] of
    * [java.lang.annotation.ElementType.TYPE_USE] or the generated code may not compile. If set to
-   * `null`, [org.pkl.config.java.mapper.NonNull] will be used.
+   * `null`, [org.jspecify.annotations.NonNull] will be used.
    */
   val nonNullAnnotation: String? = null,
 
@@ -77,6 +77,15 @@ data class CliJavaCodeGeneratorOptions(
    * Pkl module name, and the value is the desired replacement.
    */
   val renames: Map<String, String> = emptyMap(),
+
+  /**
+   * Fully qualified name of the annotation type to use for annotating nullable types.
+   *
+   * The specified annotation type must have a [java.lang.annotation.Target] of
+   * [java.lang.annotation.ElementType.TYPE_USE] or the generated code may not compile. If set to
+   * `null`, nullable types are not annotated.
+   */
+  val nullableAnnotation: String? = null,
 ) {
   @Suppress("DeprecatedCallableAddReplaceWith")
   @Deprecated("deprecated without replacement")
@@ -93,5 +102,6 @@ data class CliJavaCodeGeneratorOptions(
       nonNullAnnotation,
       implementSerializable,
       renames,
+      nullableAnnotation,
     )
 }

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/JavaCodeGenerator.kt
@@ -82,7 +82,7 @@ data class JavaCodeGeneratorOptions(
    *
    * The specified annotation type must have a [java.lang.annotation.Target] of
    * [java.lang.annotation.ElementType.TYPE_USE] or the generated code may not compile. If set to
-   * `null`, `org.pkl.config.java.mapper.NonNull` will be used.
+   * `null`, [org.jspecify.annotations.NonNull] will be used.
    */
   val nonNullAnnotation: String? = null,
 
@@ -96,6 +96,15 @@ data class JavaCodeGeneratorOptions(
    * from the corresponding name derived from the Pkl module declaration .
    */
   val renames: Map<String, String> = emptyMap(),
+
+  /**
+   * Fully qualified name of the annotation type to use for annotating nullable types.
+   *
+   * The specified annotation type must have a [java.lang.annotation.Target] of
+   * [java.lang.annotation.ElementType.TYPE_USE] or the generated code may not compile. If set to
+   * `null`, nullable types are not annotated.
+   */
+  val nullableAnnotation: String? = null,
 )
 
 /** Entrypoint for the Java code generator API. */
@@ -178,6 +187,10 @@ class JavaCodeGenerator(
         }
       return AnnotationSpec.builder(className).build()
     }
+
+  private val nullableAnnotation: AnnotationSpec?
+    get() =
+      codegenOptions.nullableAnnotation?.let { AnnotationSpec.builder(toClassName(it)).build() }
 
   private val javaFileName: String
     get() {
@@ -766,7 +779,8 @@ class JavaCodeGenerator(
           PClassInfo.Float -> TypeName.DOUBLE.boxIf(boxed).nullableIf(nullable)
           PClassInfo.Duration -> DURATION.nullableIf(nullable)
           PClassInfo.DataSize -> DATA_SIZE.nullableIf(nullable)
-          PClassInfo.Bytes -> ArrayTypeName.of(TypeName.BYTE)
+          PClassInfo.Bytes ->
+            ArrayTypeName.of(TypeName.BYTE).let { if (nullable) it.annotatedNullable() else it }
           PClassInfo.Pair ->
             ParameterizedTypeName.get(
                 PAIR,
@@ -893,8 +907,14 @@ class JavaCodeGenerator(
     }
 
   private fun TypeName.nullableIf(isNullable: Boolean): TypeName =
-    if (isPrimitive && isNullable) box()
-    else if (isPrimitive || isNullable) this else annotated(nonNullAnnotation)
+    when {
+      isNullable -> boxIf(isPrimitive).annotatedNullable()
+      isPrimitive -> this
+      else -> annotated(nonNullAnnotation)
+    }
+
+  private fun TypeName.annotatedNullable(): TypeName =
+    nullableAnnotation?.let { annotated(it) } ?: this
 
   private fun TypeName.boxIf(shouldBox: Boolean): TypeName = if (shouldBox) box() else this
 

--- a/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
+++ b/pkl-codegen-java/src/main/kotlin/org/pkl/codegen/java/Main.kt
@@ -109,6 +109,18 @@ class PklJavaCodegenCommand : ModulesCommand(name = "pkl-codegen-java", helpLink
           .trimIndent(),
     )
 
+  private val nullableAnnotation: String? by
+    option(
+      names = arrayOf("--nullable-annotation"),
+      help =
+        """
+        Fully qualified name of the annotation type to use for annotating nullable types.
+        The specified annotation type must be annotated with `@java.lang.annotation.Target(ElementType.TYPE_USE)`
+        or the generated code may not compile.
+        """
+          .trimIndent(),
+    )
+
   private val implementSerializable: Boolean by
     option(
         names = arrayOf("--implement-serializable"),
@@ -145,6 +157,7 @@ class PklJavaCodegenCommand : ModulesCommand(name = "pkl-codegen-java", helpLink
         generateSpringBootConfig = generateSpringBoot,
         paramsAnnotation = if (paramsAnnotation == "none") null else paramsAnnotation,
         nonNullAnnotation = nonNullAnnotation,
+        nullableAnnotation = nullableAnnotation,
         implementSerializable = implementSerializable,
         renames = renames,
       )

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/CliJavaCodeGeneratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.pkl.codegen.java
 
+import com.github.ajalt.clikt.core.parse
 import java.nio.file.Path
 import kotlin.io.path.listDirectoryEntries
 import org.assertj.core.api.Assertions.assertThat
@@ -26,6 +27,36 @@ import org.pkl.commons.readString
 class CliJavaCodeGeneratorTest {
 
   private val dollar = "$"
+
+  @Test
+  fun `nullable annotation option`(@TempDir tempDir: Path) {
+    val moduleFile =
+      PklModule(
+          "org.mod",
+          """
+          module org.mod
+
+          nullable: String?
+          """,
+        )
+        .writeToDisk(tempDir.resolve("org/mod.pkl"))
+    val outputDir = tempDir.resolve("output")
+
+    PklJavaCodegenCommand()
+      .parse(
+        arrayOf(
+          "--nullable-annotation",
+          "org.jspecify.annotations.Nullable",
+          "--output-dir",
+          outputDir.toString(),
+          moduleFile.toString(),
+        )
+      )
+
+    assertThat(outputDir.resolve("java/org/Mod.java").readString())
+      .contains("import org.jspecify.annotations.Nullable;")
+      .contains("public final @Nullable String nullable;")
+  }
 
   @Test
   fun `module inheritance`(@TempDir tempDir: Path) {

--- a/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
+++ b/pkl-codegen-java/src/test/kotlin/org/pkl/codegen/java/JavaCodeGeneratorTest.kt
@@ -1167,14 +1167,26 @@ class JavaCodeGeneratorTest {
         module mod
 
         foo: String
+        bar: String?
+        baz: List<String?>
+        qux: Int?
         """
           .trimIndent(),
-        JavaCodeGeneratorOptions(nonNullAnnotation = "com.example.Annotations\$NonNull"),
+        JavaCodeGeneratorOptions(
+          nonNullAnnotation = "com.example.Annotations\$NonNull",
+          nullableAnnotation = "com.example.Annotations\$Nullable",
+        ),
       )
 
     assertThat(javaCode)
       .contains("import com.example.Annotations;")
       .contains("public final @Annotations.NonNull String foo;")
+      .contains("public final @Annotations.Nullable String bar;")
+      .contains("public final @Annotations.NonNull List<@Annotations.Nullable String> baz;")
+      .contains("public final @Annotations.Nullable Long qux;")
+      .contains("public Mod(@Named(\"foo\") @Annotations.NonNull String foo,")
+      .contains("@Named(\"bar\") @Annotations.Nullable String bar,")
+      .contains("public Mod withBar(@Annotations.Nullable String bar)")
 
     javaCode =
       generateJavaCode(
@@ -1215,6 +1227,38 @@ class JavaCodeGeneratorTest {
         """
           .trimMargin()
       )
+  }
+
+  @Test
+  fun `custom nullable annotation with getters`() {
+    val javaCode =
+      generateJavaCode(
+        """
+        module mod
+
+        nullable: String?
+        strings: List<String?>
+        nullableStrings: List<String>?
+        bytes: Bytes?
+        """
+          .trimIndent(),
+        JavaCodeGeneratorOptions(
+          generateGetters = true,
+          nullableAnnotation = "org.jspecify.annotations.Nullable",
+        ),
+      )
+
+    assertThat(javaCode)
+      .contains("import org.jspecify.annotations.Nullable;")
+      .contains("private final @Nullable String nullable;")
+      .contains("private final @NonNull List<@Nullable String> strings;")
+      .contains("private final @Nullable List<@NonNull String> nullableStrings;")
+      .contains("private final byte @Nullable [] bytes;")
+      .contains("public Mod(@Named(\"nullable\") @Nullable String nullable,")
+      .contains("public @Nullable String getNullable()")
+      .contains("public Mod withNullable(@Nullable String nullable)")
+
+    assertThatCode { javaCode.compile() }.doesNotThrowAnyException()
   }
 
   @Test

--- a/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/PklPlugin.java
@@ -211,6 +211,7 @@ public class PklPlugin implements Plugin<Project> {
                     task.getGenerateJavadoc().set(spec.getGenerateJavadoc());
                     task.getParamsAnnotation().set(spec.getParamsAnnotation());
                     task.getNonNullAnnotation().set(spec.getNonNullAnnotation());
+                    task.getNullableAnnotation().set(spec.getNullableAnnotation());
                   });
         });
 

--- a/pkl-gradle/src/main/java/org/pkl/gradle/spec/JavaCodeGenSpec.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/spec/JavaCodeGenSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,4 +26,6 @@ public interface JavaCodeGenSpec extends CodeGenSpec {
   Property<String> getParamsAnnotation();
 
   Property<String> getNonNullAnnotation();
+
+  Property<String> getNullableAnnotation();
 }

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/JavaCodeGenTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/JavaCodeGenTask.java
@@ -39,6 +39,10 @@ public abstract class JavaCodeGenTask extends CodeGenTask {
   @Optional
   public abstract Property<String> getNonNullAnnotation();
 
+  @Input
+  @Optional
+  public abstract Property<String> getNullableAnnotation();
+
   @Override
   protected void doRunTask() {
     //noinspection ResultOfMethodCallIgnored
@@ -56,7 +60,8 @@ public abstract class JavaCodeGenTask extends CodeGenTask {
                 getParamsAnnotation().getOrNull(),
                 getNonNullAnnotation().getOrNull(),
                 getImplementSerializable().get(),
-                getRenames().get()))
+                getRenames().get(),
+                getNullableAnnotation().getOrNull()))
         .run();
   }
 }

--- a/pkl-gradle/src/test/kotlin/org/pkl/gradle/JavaCodeGeneratorsTest.kt
+++ b/pkl-gradle/src/test/kotlin/org/pkl/gradle/JavaCodeGeneratorsTest.kt
@@ -53,7 +53,7 @@ class JavaCodeGeneratorsTest : AbstractTest() {
       |  public static final class Person {
       |    public final @Nonnull String name;
       |
-      |    public final @Nonnull List<Address> addresses;
+      |    public final @Nonnull List<@Nullable Address> addresses;
     """,
     )
 
@@ -150,6 +150,7 @@ class JavaCodeGeneratorsTest : AbstractTest() {
       dependencies {
         integTestImplementation "javax.inject:javax.inject:1"
         integTestImplementation "com.google.code.findbugs:jsr305:3.0.2"
+        integTestImplementation "org.jspecify:jspecify:1.0.0"
       }
 
       pkl {
@@ -159,6 +160,7 @@ class JavaCodeGeneratorsTest : AbstractTest() {
             outputDir = file("build/generated")
             paramsAnnotation = "javax.inject.Named"
             nonNullAnnotation = "javax.annotation.Nonnull"
+            nullableAnnotation = "org.jspecify.annotations.Nullable"
             settingsModule = "pkl:settings"
             renames = ['org': 'foo.bar']
           }
@@ -192,6 +194,7 @@ class JavaCodeGeneratorsTest : AbstractTest() {
       dependencies {
         implementation "javax.inject:javax.inject:1"
         implementation "com.google.code.findbugs:jsr305:3.0.2"
+        implementation "org.jspecify:jspecify:1.0.0"
       }
 
       pkl {
@@ -201,6 +204,7 @@ class JavaCodeGeneratorsTest : AbstractTest() {
             outputDir = file("build/generated")
             paramsAnnotation = "javax.inject.Named"
             nonNullAnnotation = "javax.annotation.Nonnull"
+            nullableAnnotation = "org.jspecify.annotations.Nullable"
             settingsModule = "pkl:settings"
             renames = [
               'org': 'foo.bar'


### PR DESCRIPTION
Fixes #811

Adds an optional `nullableAnnotation` setting across the Java codegen API, CLI, and Gradle plugin. When configured, nullable Pkl types receive the specified TYPE_USE annotation across fields, getters, constructor parameters, `withX()` methods, nested generic arguments, boxed primitives, and byte arrays. The default remains no nullable annotation, preserving existing generated output.

Tests cover direct API generation, the actual `--nullable-annotation` CLI flag, Gradle DSL/task propagation, configuration cache, and compilation of generated JSpecify-annotated Java.
