### PR TITLE
Avoid duplicate pkl-gradle publication

### DIFF
--- a/build-logic/src/main/kotlin/PklPublishing.kt
+++ b/build-logic/src/main/kotlin/PklPublishing.kt
@@ -61,26 +61,31 @@ fun Project.configurePklPomMetadata() {
   }
 }
 
-/** Configures POM validation task to check for unresolved versions and snapshots in releases. */
-fun Project.configurePomValidation() {
+/**
+ * Configures POM validation for [publicationName] to check for unresolved versions and snapshots in
+ * releases.
+ */
+fun Project.configurePomValidation(publicationName: String = "library") {
+  val generatePomTaskName =
+    "generatePomFileFor${publicationName.replaceFirstChar { it.uppercase() }}Publication"
+  val generatePomTasks =
+    tasks.withType<GenerateMavenPom>().matching { it.name == generatePomTaskName }
+  val pomFiles = providers.provider { generatePomTasks.map { it.destination } }
+
   val validatePom =
     tasks.register("validatePom") {
-      if (tasks.findByName("generatePomFileForLibraryPublication") == null) {
-        return@register
-      }
-      val generatePomFileForLibraryPublication =
-        tasks.named<GenerateMavenPom>("generatePomFileForLibraryPublication")
       val outputFile =
         layout.buildDirectory.file("validatePom") // dummy output to satisfy up-to-date check
 
-      dependsOn(generatePomFileForLibraryPublication)
-      inputs.file(generatePomFileForLibraryPublication.get().destination)
+      dependsOn(generatePomTasks)
+      inputs.files(pomFiles)
       outputs.file(outputFile)
+      onlyIf { pomFiles.get().isNotEmpty() }
 
       doLast {
         outputFile.get().asFile.delete()
 
-        val pomFile = generatePomFileForLibraryPublication.get().destination
+        val pomFile = pomFiles.get().single()
         assert(pomFile.exists())
 
         val text = pomFile.readText()

--- a/pkl-gradle/pkl-gradle.gradle.kts
+++ b/pkl-gradle/pkl-gradle.gradle.kts
@@ -20,8 +20,18 @@ plugins {
   id("pklJSpecify")
   `java-gradle-plugin`
   `maven-publish`
-  id("pklPublishLibrary")
   signing
+}
+
+configurePklPomMetadata()
+
+configurePomValidation("pluginMaven")
+
+configurePklSigning()
+
+artifacts {
+  tasks.findByName("javadocJar")?.let { archives(it) }
+  tasks.findByName("sourcesJar")?.let { archives(it) }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

- stop applying `pklPublishLibrary` to `pkl-gradle`, since `java-gradle-plugin` already creates the `pluginMaven` publication
- retain the shared POM metadata, validation, signing, and archive-artifact configuration without creating a duplicate publication
- allow POM validation to target `pluginMaven` while preserving the existing `library` default

`java-gradle-plugin` creates `pluginMaven` from the Java component. Applying `pklPublishLibrary` created a second `library` publication from that same component with the same coordinates, causing the Sonatype overwrite warning.

This is a fresh submission of #1761 following the reviewer invitation to resubmit.

Fixes #1742

## Verification

- reproduced the duplicate on a clean upstream `main` checkout by confirming identical `library` and `pluginMaven` POMs and both Sonatype publication tasks
- `./gradlew :pkl-gradle:clean :pkl-gradle:validatePom :pkl-gradle:build :pkl-core:validatePom :pkl-bom:validatePom :stdlib:validatePom --no-build-cache --console=plain`
- `./gradlew :pkl-gradle:publishToSonatype --dry-run --console=plain`
- confirmed the `pluginMaven` POM is generated and the duplicate `library` POM is absent
- confirmed the dry run schedules only `pluginMaven` and the required `pklPluginMarkerMaven` publication
- confirmed signing tasks remain for both publications
- compared `pluginMaven` module metadata with the baseline and confirmed the main, sources, and Javadoc publication artifacts are unchanged
- confirmed the legacy `archives` variant still contains the main, sources, and Javadoc JARs
- `./gradlew :pkl-gradle:spotlessCheck`
- `git diff --check`