### PR TITLE
Mark protobuf module as deprecated

### DIFF
--- a/docs/modules/pkl-cli/pages/index.adoc
+++ b/docs/modules/pkl-cli/pages/index.adoc
@@ -307,7 +307,7 @@ The default output renderer for a module supports the following formats:
 * `pcf`
 * `plist`
 * `properties`
-* `textproto`
+* `textproto` (deprecated in Pkl 0.33)
 * `xml`
 * `yaml`
 

--- a/docs/modules/pkl-gradle/pages/index.adoc
+++ b/docs/modules/pkl-gradle/pages/index.adoc
@@ -152,7 +152,7 @@ The default output renderer for a module supports the following formats:
 * `"pcf"`
 * `"plist"`
 * `"properties"`
-* `"textproto"`
+* `"textproto"` (deprecated in Pkl 0.33)
 * `"xml"`
 * `"yaml"`
 ====

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliEvaluatorOptions.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliEvaluatorOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ data class CliEvaluatorOptions(
    * - `"pcf"` (default)
    * - `"plist"`
    * - `"properties"`
-   * - `"textproto"`
+   * - `"textproto"` (deprecated in Pkl 0.33)
    * - `"xml"`
    * - `"yaml"`
    */

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -102,17 +102,7 @@ class BaseOptions : OptionGroup() {
   private val defaults = CliBaseOptions()
 
   private val output =
-    arrayOf(
-      "json",
-      "jsonnet",
-      "pcf",
-      "properties",
-      "plist",
-      "textproto",
-      "xml",
-      "yaml",
-      "pkl-binary",
-    )
+    arrayOf("json", "jsonnet", "pcf", "properties", "plist", "xml", "yaml", "pkl-binary")
 
   val allowedModules: List<Pattern> by
     option(

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -24,6 +24,7 @@ import "pkl:json"
 import "pkl:jsonnet"
 import "pkl:math"
 import "pkl:pklbinary"
+// noinspection Deprecated
 import "pkl:protobuf"
 import "pkl:xml"
 import "pkl:yaml"

--- a/stdlib/protobuf.pkl
+++ b/stdlib/protobuf.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,16 @@
 //===----------------------------------------------------------------------===//
 
 /// A renderer for [Protocol Buffers](https://developers.google.com/protocol-buffers).
-/// Note: This module is _experimental_ and not ready for production use.
+///
+/// WARNING:
+/// This module is deprecated, and scheduled for removal without replacement.
+/// For rendering into a protobuf wire format, consider rendering to
+/// [ProtoJSON](https://protobuf.dev/programming-guides/json/) using [json.Renderer].
 @ModuleInfo { minPklVersion = "0.33.0" }
+@Deprecated { since = "0.33.0"; message = "Scheduled for removal without replacement" }
 module pkl.protobuf
 
+import "pkl:json"
 import "pkl:reflect"
 
 /// A renderer for [Protocol Buffers](https://developers.google.com/protocol-buffers).


### PR DESCRIPTION
This moves the protobuf module from experimental to deprecated

Rationale:

* This is very seldom used, if used at all
* Not fully fleshed out (this really should be paired with a protoc-gen-pkl, which doesn't exist)
* There is a ProtoJSON wire format that we can already render to
