### PR TITLE
Add feature flagging system

### DIFF
--- a/bench/src/jmh/java/org/pkl/core/ListSort.java
+++ b/bench/src/jmh/java/org/pkl/core/ListSort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,8 @@ public class ListSort {
           IoUtils.getCurrentWorkingDir(),
           StackFrameTransformers.defaultTransformer,
           false,
-          TraceMode.COMPACT);
+          TraceMode.COMPACT,
+          Map.of());
   private static final List<Object> list = new ArrayList<>(100000);
 
   static {

--- a/docs/modules/bindings-specification/pages/message-passing-api.adoc
+++ b/docs/modules/bindings-specification/pages/message-passing-api.adoc
@@ -126,6 +126,28 @@ project: Project?
 /// Added in Pkl 0.26.0.
 http: Http?
 
+/// Register external module readers.
+///
+/// Added in Pkl 0.27.0.
+externalModuleReaders: Mapping<String, ExternalReader>?
+
+/// Register external resource readers.
+///
+/// Added in Pkl 0.27.0.
+externalResourceReaders: Mapping<String, ExternalReader>?
+
+/// Dictates the rendering of calls to the trace() method within Pkl.
+///
+/// Added in Pkl 0.30.0.
+traceMode: ("compact" | "pretty")?
+
+/// Feature flags to enable or disable.
+///
+/// Specifying a feature flag unknown to the current version of Pkl will result in a warning.
+///
+/// Added in Pkl 0.33.0.
+featureFlags: Mapping<String, Boolean>?
+
 class ClientResourceReader {
   /// The URI scheme this reader is responsible for reading.
   scheme: String
@@ -177,7 +199,7 @@ class Project {
   projectFileUri: String
 
   /// The dependencies of this project.
-  dependencies: Mapping<String, Project|RemoteDependency>
+  dependencies: Mapping<String, Project | RemoteDependency>
 }
 
 class RemoteDependency {
@@ -255,6 +277,23 @@ class Proxy {
   /// }
   /// ```
   noProxy: Listing<String>(isDistinct)
+}
+
+class ExternalReader {
+  /// The executable to launch as the external reader process.
+  ///
+  /// Must be either an absolute path to the executable or an executable name to resolve against the operating system's `$PATH`.
+  executable: String
+
+  /// Arguments to pass to [executable].
+  arguments: Listing<String>?
+
+  /// External reader process working directory.
+  ///
+  /// Default value: the working directory of the Pkl process. 
+  ///
+  /// Added in Pkl 0.32.0.
+  workingDir: String?
 }
 ----
 <1> link:{uri-messagepack-bin}[bin format]

--- a/docs/modules/pkl-cli/partials/cli-common-options.adoc
+++ b/docs/modules/pkl-cli/partials/cli-common-options.adoc
@@ -182,3 +182,17 @@ Default: `compact` +
 Specifies how `trace()` output is formatted.
 Possible options are `compact` and `pretty`.
 ====
+
+.--feature
+[%collapsible]
+====
+Default: (none) +
+Example: `magic=true` +
+
+Enable or disable feature flags.
+
+Available feature flags and their default values are provided in the full command line help.
+Specifying a feature flag unknown to the current version of Pkl will result in a warning.
+
+Providing only the name of a flag is equivalent to setting its value to `true`.
+====

--- a/docs/src/test/kotlin/DocSnippetTests.kt
+++ b/docs/src/test/kotlin/DocSnippetTests.kt
@@ -114,6 +114,7 @@ class DocSnippetTestsEngine : HierarchicalTestEngine<DocSnippetTestsEngine.Execu
         StackFrameTransformers.defaultTransformer,
         false,
         TraceMode.COMPACT,
+        emptyMap(),
       )
     return ExecutionContext(replServer)
   }

--- a/pkl-cli/src/main/kotlin/org/pkl/cli/CliRepl.kt
+++ b/pkl-cli/src/main/kotlin/org/pkl/cli/CliRepl.kt
@@ -70,6 +70,7 @@ internal class CliRepl(private val options: CliEvaluatorOptions) : CliCommand(op
           stackFrameTransformer,
           options.base.color?.hasColor() ?: false,
           options.base.traceMode ?: TraceMode.COMPACT,
+          options.base.featureFlags?.asFeatureFlags("cli") ?: emptyMap(),
         )
       Repl(options.base.normalizedWorkingDir, server, options.base.color?.hasColor() ?: false).run()
     }

--- a/pkl-cli/src/test/kotlin/org/pkl/cli/repl/ReplMessagesTest.kt
+++ b/pkl-cli/src/test/kotlin/org/pkl/cli/repl/ReplMessagesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ class ReplMessagesTest {
       StackFrameTransformers.defaultTransformer,
       false,
       TraceMode.COMPACT,
+      emptyMap(),
     )
 
   @Test

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliBaseOptions.kt
@@ -158,6 +158,9 @@ data class CliBaseOptions(
 
   /** Whether power assertions are enabled. */
   val powerAssertionsEnabled: Boolean = false,
+
+  /** Feature flag state. */
+  val featureFlags: Map<String, Boolean>? = null,
 ) {
 
   companion object {

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/CliCommand.kt
@@ -214,6 +214,22 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
     cliOptions.traceMode ?: evaluatorSettings?.traceMode ?: TraceMode.COMPACT
   }
 
+  private val featureFlags: Map<FeatureFlag, Boolean> by lazy {
+    cliOptions.featureFlags?.asFeatureFlags("cli")
+      ?: evaluatorSettings?.featureFlags?.asFeatureFlags("PklProject")
+      ?: emptyMap()
+  }
+
+  protected fun Map<String, Boolean>.asFeatureFlags(context: String): Map<FeatureFlag, Boolean> =
+    mapNotNull { entry ->
+        FeatureFlag.parse(entry.key)?.let {
+          return@mapNotNull it to entry.value
+        }
+        logger.warn("Unrecognized feature flag named `${entry.key}`", "pkl:#${context}")
+        return@mapNotNull null
+      }
+      .toMap()
+
   private fun HttpClient.Builder.addDefaultCliCertificates() {
     val caCertsDir = IoUtils.getPklHomeDir().resolve("cacerts")
     var certsAdded = false
@@ -258,6 +274,8 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
       buildLazily()
     }
   }
+
+  val logger: Logger = Loggers.stdErr()
 
   protected fun moduleKeyFactories(modulePathResolver: ModulePathResolver): List<ModuleKeyFactory> {
     return buildList {
@@ -310,10 +328,11 @@ abstract class CliCommand(protected val cliOptions: CliBaseOptions) {
       .addModuleKeyFactories(moduleKeyFactories(modulePathResolver))
       .addResourceReaders(resourceReaders(modulePathResolver))
       .setColor(useColor)
-      .setLogger(Loggers.stdErr())
+      .setLogger(logger)
       .setTimeout(cliOptions.timeout)
       .setModuleCacheDir(moduleCacheDir)
       .setTraceMode(traceMode)
       .setPowerAssertionsEnabled(cliOptions.powerAssertionsEnabled)
+      .setFeatureFlags(featureFlags)
   }
 }

--- a/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
+++ b/pkl-commons-cli/src/main/kotlin/org/pkl/commons/cli/commands/BaseOptions.kt
@@ -18,6 +18,7 @@ package org.pkl.commons.cli.commands
 import com.github.ajalt.clikt.completion.CompletionCandidates
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.options.*
+import com.github.ajalt.clikt.parameters.transform.TransformContext
 import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.long
@@ -27,10 +28,12 @@ import java.net.URI
 import java.net.URISyntaxException
 import java.nio.file.Path
 import java.time.Duration
+import java.util.Locale
 import java.util.regex.Pattern
 import org.pkl.commons.cli.CliBaseOptions
 import org.pkl.commons.cli.CliException
 import org.pkl.commons.shlex
+import org.pkl.core.FeatureFlag
 import org.pkl.core.evaluatorSettings.Color
 import org.pkl.core.evaluatorSettings.PklEvaluatorSettings.ExternalReader
 import org.pkl.core.evaluatorSettings.TraceMode
@@ -92,7 +95,7 @@ class BaseOptions : OptionGroup() {
     > {
       return splitPair(delimiter).convert {
         val cmd = shlex(it.second)
-        Pair(it.first, ExternalReader(cmd.first(), cmd.drop(1), null))
+        it.first to ExternalReader(cmd.first(), cmd.drop(1), null)
       }
     }
 
@@ -350,6 +353,39 @@ class BaseOptions : OptionGroup() {
       .enum<TraceMode> { it.name.lowercase() }
       .single()
 
+  val featureFlags: Map<String, Boolean> by
+    option(
+        names = arrayOf("--feature"),
+        metavar = "<feature>[=<boolean>]",
+        help =
+          "Feature flag enabled state. Omitting <boolean> is equivalent to true. <${FeatureFlag.entries.joinToString(", ") { "${it.name.lowercase(Locale.ROOT)} (default: ${it.defaultValue()})" }}>",
+      )
+      .convert {
+        val idx = it.indexOf('=')
+        return@convert if (idx < 0) it to true
+        else it.substring(0..<idx) to valueToBool(it.substring(idx + 1))
+      }
+      .multiple()
+      .toMap()
+
+  private fun TransformContext.valueToBool(value: String): Boolean {
+    return when (value.lowercase()) {
+      "true",
+      "t",
+      "1",
+      "yes",
+      "y",
+      "on" -> true
+      "false",
+      "f",
+      "0",
+      "no",
+      "n",
+      "off" -> false
+      else -> fail(context.localization.boolConversionError(value))
+    }
+  }
+
   // hidden option used by native tests
   private val testPort: Int by
     option(names = arrayOf("--test-port"), help = "Internal test option", hidden = true)
@@ -391,6 +427,7 @@ class BaseOptions : OptionGroup() {
       externalResourceReaders = externalResourceReaders.ifEmpty { null },
       traceMode = traceMode,
       powerAssertionsEnabled = powerAssertionsEnabled,
+      featureFlags = featureFlags,
     )
   }
 }

--- a/pkl-commons-cli/src/test/kotlin/org/pkl/commons/cli/CliCommandTest.kt
+++ b/pkl-commons-cli/src/test/kotlin/org/pkl/commons/cli/CliCommandTest.kt
@@ -125,6 +125,10 @@ class CliCommandTest {
         ["foo"] { executable = "foo" }
       }
       traceMode = "pretty"
+      featureFlags {
+        ["foo"] = true
+        ["bar"] = false
+      }
     }
     """
       .trimIndent()
@@ -153,6 +157,7 @@ class CliCommandTest {
     assertThat(cliTest.myExternalModuleReaders).isEmpty()
     assertThat(cliTest.myExternalResourceReaders).isEmpty()
     assertThat(builder.traceMode).isEqualTo(TraceMode.COMPACT)
+    assertThat(builder.featureFlags).isEmpty()
   }
 
   // hygiene test to ensure new evaluator settings get covered by the above test

--- a/pkl-commons-test/src/main/kotlin/org/pkl/commons/test/server/AbstractServerTest.kt
+++ b/pkl-commons-test/src/main/kotlin/org/pkl/commons/test/server/AbstractServerTest.kt
@@ -113,6 +113,7 @@ abstract class AbstractServerTest {
       externalModuleReaders = null,
       externalResourceReaders = null,
       traceMode = null,
+      featureFlags = null,
     )
 
   @Test
@@ -1158,6 +1159,7 @@ abstract class AbstractServerTest {
         null,
         project,
         http,
+        null,
         null,
         null,
         null,

--- a/pkl-config-java/src/main/java/org/pkl/config/java/ConfigEvaluatorBuilder.java
+++ b/pkl-config-java/src/main/java/org/pkl/config/java/ConfigEvaluatorBuilder.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
 import org.pkl.config.java.mapper.ValueMapperBuilder;
 import org.pkl.core.EvaluatorBuilder;
+import org.pkl.core.Logger;
 import org.pkl.core.SecurityManager;
 import org.pkl.core.StackFrameTransformer;
 import org.pkl.core.http.HttpClient;
@@ -229,6 +230,18 @@ public final class ConfigEvaluatorBuilder {
    */
   public ConfigEvaluatorBuilder applyFromProject(Project project) {
     evaluatorBuilder.applyFromProject(project);
+    return this;
+  }
+
+  /**
+   * Sets the project for the evaluator, and applies any settings if set.
+   *
+   * <p>This is a convenience method that delegates to the underlying evaluator builder.
+   *
+   * @throws IllegalStateException if {@link #setSecurityManager(SecurityManager)} was also called.
+   */
+  public ConfigEvaluatorBuilder applyFromProject(Project project, Logger logger) {
+    evaluatorBuilder.applyFromProject(project, logger);
     return this;
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/Analyzer.java
+++ b/pkl-core/src/main/java/org/pkl/core/Analyzer.java
@@ -48,6 +48,7 @@ public class Analyzer {
   private final ModuleResolver moduleResolver;
   private final HttpClient httpClient;
   private final TraceMode traceMode;
+  private final Map<FeatureFlag, Boolean> featureFlags;
 
   public Analyzer(
       StackFrameTransformer transformer,
@@ -57,7 +58,8 @@ public class Analyzer {
       @Nullable Path moduleCacheDir,
       @Nullable DeclaredDependencies projectDependencies,
       HttpClient httpClient,
-      TraceMode traceMode) {
+      TraceMode traceMode,
+      Map<FeatureFlag, Boolean> featureFlags) {
     this.transformer = transformer;
     this.color = color;
     this.securityManager = securityManager;
@@ -66,6 +68,7 @@ public class Analyzer {
     this.moduleResolver = new ModuleResolver(moduleKeyFactories);
     this.httpClient = httpClient;
     this.traceMode = traceMode;
+    this.featureFlags = featureFlags;
   }
 
   /**
@@ -118,7 +121,8 @@ public class Analyzer {
                       : new ProjectDependenciesManager(
                           projectDependencies, moduleResolver, securityManager),
                   traceMode,
-                  false));
+                  false,
+                  featureFlags));
         });
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/EvaluatorBuilder.java
@@ -72,6 +72,8 @@ public final class EvaluatorBuilder {
 
   private boolean powerAssertionsEnabled = false;
 
+  private final Map<FeatureFlag, Boolean> featureFlags = new HashMap<>();
+
   private EvaluatorBuilder() {}
 
   /**
@@ -481,12 +483,44 @@ public final class EvaluatorBuilder {
     return powerAssertionsEnabled;
   }
 
+  /** Adds the given feature flag, overriding any value previously set under the same flag. */
+  public EvaluatorBuilder addFeatureFlag(FeatureFlag flag, boolean value) {
+    featureFlags.put(flag, value);
+    return this;
+  }
+
+  /** Adds the given feature flags, overriding any value previously set under the same flags. */
+  public EvaluatorBuilder addFeatureFlags(Map<FeatureFlag, Boolean> flags) {
+    featureFlags.putAll(flags);
+    return this;
+  }
+
+  /** Removes any existing feature flags, then adds the given flags. */
+  public EvaluatorBuilder setFeatureFlags(Map<FeatureFlag, Boolean> flags) {
+    featureFlags.clear();
+    return addFeatureFlags(flags);
+  }
+
+  /** Returns the current configured feature flags */
+  public Map<FeatureFlag, Boolean> getFeatureFlags() {
+    return featureFlags;
+  }
+
   /**
    * Given a project, sets its dependencies, and also applies any evaluator settings if set.
    *
    * @throws IllegalStateException if {@link #setSecurityManager(SecurityManager)} was also called.
    */
   public EvaluatorBuilder applyFromProject(Project project) {
+    return applyFromProject(project, Loggers.noop());
+  }
+
+  /**
+   * Given a project, sets its dependencies, and also applies any evaluator settings if set.
+   *
+   * @throws IllegalStateException if {@link #setSecurityManager(SecurityManager)} was also called.
+   */
+  public EvaluatorBuilder applyFromProject(Project project, Logger logger) {
     this.dependencies = project.getDependencies();
     var settings = project.getResolvedEvaluatorSettings();
     if (securityManager != null) {
@@ -567,6 +601,19 @@ public final class EvaluatorBuilder {
       setTraceMode(settings.traceMode());
     }
 
+    if (settings.featureFlags() != null) {
+      for (var entry : settings.featureFlags().entrySet()) {
+        var flag = FeatureFlag.parse(entry.getKey());
+        if (flag == null) {
+          logger.warn(
+              String.format("Unrecognized feature flag named `%s`", entry.getKey()),
+              "pkl:#PklProject");
+          continue;
+        }
+        addFeatureFlag(flag, entry.getValue());
+      }
+    }
+
     return this;
   }
 
@@ -595,6 +642,7 @@ public final class EvaluatorBuilder {
         dependencies,
         outputFormat,
         traceMode,
-        powerAssertionsEnabled);
+        powerAssertionsEnabled,
+        featureFlags);
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/EvaluatorImpl.java
+++ b/pkl-core/src/main/java/org/pkl/core/EvaluatorImpl.java
@@ -92,7 +92,8 @@ public final class EvaluatorImpl implements Evaluator {
       @Nullable DeclaredDependencies projectDependencies,
       @Nullable String outputFormat,
       TraceMode traceMode,
-      boolean powerAssertions) {
+      boolean powerAssertions,
+      Map<FeatureFlag, Boolean> featureFlags) {
 
     securityManager = manager;
     frameTransformer = transformer;
@@ -127,7 +128,8 @@ public final class EvaluatorImpl implements Evaluator {
                           : new ProjectDependenciesManager(
                               projectDependencies, moduleResolver, securityManager),
                       traceMode,
-                      powerAssertions));
+                      powerAssertions,
+                      featureFlags));
             });
     this.timeout = timeout;
     // NOTE: would probably make sense to share executor between evaluators

--- a/pkl-core/src/main/java/org/pkl/core/FeatureFlag.java
+++ b/pkl-core/src/main/java/org/pkl/core/FeatureFlag.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.core;
+
+import java.util.Locale;
+import org.jspecify.annotations.Nullable;
+
+public enum FeatureFlag {
+  ; // no feature flags yet!
+
+  // keep in sync with pkl.EvaluatorSettings#KnownFeatureFlags
+
+  // if the stdlib needs to be eval'd with different flags than the defaults, edit
+  // prg.pkl.core.runtime.StdLibModule.stdLibFeatureFlags
+
+  FeatureFlag(boolean defaultValue) {
+    this.defaultValue = defaultValue;
+  }
+
+  public static @Nullable FeatureFlag parse(String name) {
+    try {
+      return FeatureFlag.valueOf(name.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private final boolean defaultValue;
+
+  public boolean defaultValue() {
+    return defaultValue;
+  }
+}

--- a/pkl-core/src/main/java/org/pkl/core/Logger.java
+++ b/pkl-core/src/main/java/org/pkl/core/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,18 @@ package org.pkl.core;
 @SuppressWarnings("unused")
 public interface Logger {
   /** Logs the given message on level TRACE. */
-  default void trace(String message, StackFrame frame) {}
+  default void trace(String message, StackFrame frame) {
+    trace(message, frame.getModuleUri());
+  }
+
+  /** Logs the given message on level TRACE. */
+  default void trace(String message, String frameUri) {}
 
   /** Logs the given message on level WARN. */
-  default void warn(String message, StackFrame frame) {}
+  default void warn(String message, StackFrame frame) {
+    warn(message, frame.getModuleUri());
+  }
+
+  /** Logs the given message on level WARN. */
+  default void warn(String message, String frameUri) {}
 }

--- a/pkl-core/src/main/java/org/pkl/core/Loggers.java
+++ b/pkl-core/src/main/java/org/pkl/core/Loggers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,12 @@ public final class Loggers {
   public static Logger noop() {
     return new Logger() {
       @Override
-      public void trace(String message, StackFrame frame) {
+      public void trace(String message, String frameUri) {
         // do nothing
       }
 
       @Override
-      public void warn(String message, StackFrame frame) {
+      public void warn(String message, String frameUri) {
         // do nothing
       }
     };
@@ -48,14 +48,14 @@ public final class Loggers {
   public static Logger stream(PrintStream stream) {
     return new Logger() {
       @Override
-      public void trace(String message, StackFrame frame) {
-        stream.println(formatMessage("TRACE", message, frame));
+      public void trace(String message, String frameUri) {
+        stream.println(formatMessage("TRACE", message, frameUri));
         stream.flush();
       }
 
       @Override
-      public void warn(String message, StackFrame frame) {
-        stream.println(formatMessage("WARN", message, frame));
+      public void warn(String message, String frameUri) {
+        stream.println(formatMessage("WARN", message, frameUri));
         stream.flush();
       }
     };
@@ -66,27 +66,27 @@ public final class Loggers {
   public static Logger writer(PrintWriter writer) {
     return new Logger() {
       @Override
-      public void trace(String message, StackFrame frame) {
-        writer.println(formatMessage("TRACE", message, frame));
+      public void trace(String message, String frameUri) {
+        writer.println(formatMessage("TRACE", message, frameUri));
         writer.flush();
       }
 
       @Override
-      public void warn(String message, StackFrame frame) {
-        writer.println(formatMessage("WARN", message, frame));
+      public void warn(String message, String frameUri) {
+        writer.println(formatMessage("WARN", message, frameUri));
         writer.flush();
       }
     };
   }
 
-  private static String formatMessage(String level, String message, StackFrame frame) {
+  private static String formatMessage(String level, String message, String frameUri) {
     return "pkl: "
         + level
         + ": "
         + message
         + (message.endsWith("\n") ? "" : " ")
         + "("
-        + frame.getModuleUri()
+        + frameUri
         + ')';
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/evaluatorSettings/PklEvaluatorSettings.java
+++ b/pkl-core/src/main/java/org/pkl/core/evaluatorSettings/PklEvaluatorSettings.java
@@ -52,7 +52,8 @@ public record PklEvaluatorSettings(
     @Nullable Http http,
     @Nullable Map<String, ExternalReader> externalModuleReaders,
     @Nullable Map<String, ExternalReader> externalResourceReaders,
-    @Nullable TraceMode traceMode) {
+    @Nullable TraceMode traceMode,
+    @Nullable Map<String, Boolean> featureFlags) {
 
   /** Initializes a {@link PklEvaluatorSettings} from a raw object representation. */
   @SuppressWarnings("unchecked")
@@ -102,6 +103,7 @@ public record PklEvaluatorSettings(
 
     var color = (String) pSettings.get("color");
     var traceMode = (String) pSettings.get("traceMode");
+    var featureFlags = (Map<String, Boolean>) pSettings.get("featureFlags");
 
     return new PklEvaluatorSettings(
         (Map<String, String>) pSettings.get("externalProperties"),
@@ -117,7 +119,8 @@ public record PklEvaluatorSettings(
         Http.parse((Value) pSettings.get("http")),
         externalModuleReaders,
         externalResourceReaders,
-        traceMode == null ? null : TraceMode.valueOf(traceMode.toUpperCase(Locale.ROOT)));
+        traceMode == null ? null : TraceMode.valueOf(traceMode.toUpperCase(Locale.ROOT)),
+        featureFlags);
   }
 
   public record Http(
@@ -261,7 +264,8 @@ public record PklEvaluatorSettings(
         && Objects.equals(timeout, that.timeout)
         && Objects.equals(rootDir, that.rootDir)
         && Objects.equals(http, that.http)
-        && Objects.equals(traceMode, that.traceMode);
+        && Objects.equals(traceMode, that.traceMode)
+        && Objects.equals(featureFlags, that.featureFlags);
   }
 
   private int hashPatterns(@Nullable List<Pattern> patterns) {
@@ -287,7 +291,8 @@ public record PklEvaluatorSettings(
             timeout,
             rootDir,
             http,
-            traceMode);
+            traceMode,
+            featureFlags);
     result = 31 * result + hashPatterns(allowedModules);
     result = 31 * result + hashPatterns(allowedResources);
     return result;

--- a/pkl-core/src/main/java/org/pkl/core/messaging/AbstractMessagePackDecoder.java
+++ b/pkl-core/src/main/java/org/pkl/core/messaging/AbstractMessagePackDecoder.java
@@ -166,8 +166,8 @@ public abstract class AbstractMessagePackDecoder implements MessageDecoder {
     return value.asArrayValue().list().stream().map((it) -> it.asStringValue().asString()).toList();
   }
 
-  protected static @Nullable Map<String, String> unpackStringMapOrNull(
-      Map<Value, Value> map, String key) {
+  protected static <T> @Nullable Map<String, T> unpackMapOrNull(
+      Map<Value, Value> map, String key, Function<Value, T> mapper) {
     var value = getNullable(map, key);
     if (value == null) {
       return null;
@@ -176,8 +176,7 @@ public abstract class AbstractMessagePackDecoder implements MessageDecoder {
     return value.asMapValue().entrySet().stream()
         .collect(
             Collectors.toMap(
-                (e) -> e.getKey().asStringValue().asString(),
-                (e) -> e.getValue().asStringValue().asString()));
+                (e) -> e.getKey().asStringValue().asString(), (e) -> mapper.apply(e.getValue())));
   }
 
   protected static <T> @Nullable List<T> unpackStringListOrNull(
@@ -202,19 +201,5 @@ public abstract class AbstractMessagePackDecoder implements MessageDecoder {
       result.add(mapper.apply(value));
     }
     return result;
-  }
-
-  protected static <T> @Nullable Map<String, T> unpackStringMapOrNull(
-      Map<Value, Value> map, String key, Function<Map<Value, Value>, T> mapper) {
-    var value = getNullable(map, key);
-    if (value == null) {
-      return null;
-    }
-
-    return value.asMapValue().entrySet().stream()
-        .collect(
-            Collectors.toMap(
-                (e) -> e.getKey().asStringValue().asString(),
-                (e) -> mapper.apply(e.getValue().asMapValue().map())));
   }
 }

--- a/pkl-core/src/main/java/org/pkl/core/messaging/AbstractMessagePackEncoder.java
+++ b/pkl-core/src/main/java/org/pkl/core/messaging/AbstractMessagePackEncoder.java
@@ -94,7 +94,8 @@ public abstract class AbstractMessagePackEncoder implements MessageEncoder {
       @Nullable Object valueD,
       @Nullable Object valueE,
       @Nullable Object valueF,
-      @Nullable Object valueG)
+      @Nullable Object valueG,
+      @Nullable Object valueH)
       throws IOException {
     packer.packMapHeader(
         size
@@ -113,7 +114,8 @@ public abstract class AbstractMessagePackEncoder implements MessageEncoder {
             + (valueD != null ? 1 : 0)
             + (valueE != null ? 1 : 0)
             + (valueF != null ? 1 : 0)
-            + (valueG != null ? 1 : 0));
+            + (valueG != null ? 1 : 0)
+            + (valueH != null ? 1 : 0));
   }
 
   protected void packKeyValue(String name, @Nullable Integer value) throws IOException {

--- a/pkl-core/src/main/java/org/pkl/core/project/Project.java
+++ b/pkl-core/src/main/java/org/pkl/core/project/Project.java
@@ -221,7 +221,8 @@ public final class Project {
             builder.getModuleCacheDir(),
             builder.getProjectDependencies(),
             builder.getHttpClient(),
-            builder.getTraceMode());
+            builder.getTraceMode(),
+            builder.getFeatureFlags());
     var importGraph = analyzer.importGraph(moduleSource.getUri());
     var ret = ImportGraphUtils.findImportCycles(importGraph);
     // we only care about cycles in the same scheme as `moduleSource`
@@ -562,7 +563,8 @@ public final class Project {
               null,
               null,
               null,
-              traceMode);
+              traceMode,
+              Map.of());
     }
 
     @Deprecated(forRemoval = true)

--- a/pkl-core/src/main/java/org/pkl/core/repl/ReplServer.java
+++ b/pkl-core/src/main/java/org/pkl/core/repl/ReplServer.java
@@ -91,7 +91,8 @@ public class ReplServer implements AutoCloseable {
       Path workingDir,
       StackFrameTransformer frameTransformer,
       boolean color,
-      TraceMode traceMode) {
+      TraceMode traceMode,
+      Map<FeatureFlag, Boolean> featureFlags) {
 
     this.workingDir = workingDir;
     this.securityManager = securityManager;
@@ -127,7 +128,8 @@ public class ReplServer implements AutoCloseable {
                       packageResolver,
                       projectDependenciesManager,
                       traceMode,
-                      true));
+                      true,
+                      featureFlags));
             });
     language = languageRef.get();
   }

--- a/pkl-core/src/main/java/org/pkl/core/runtime/StdLibModule.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/StdLibModule.java
@@ -21,6 +21,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import org.pkl.core.FeatureFlag;
 import org.pkl.core.Loggers;
 import org.pkl.core.SecurityManagers;
 import org.pkl.core.StackFrameTransformers;
@@ -33,6 +34,8 @@ import org.pkl.core.resource.ResourceReader;
 import org.pkl.core.resource.ResourceReaders;
 
 public abstract class StdLibModule {
+  private static final Map<FeatureFlag, Boolean> stdLibFeatureFlags = Map.of();
+
   @TruffleBoundary
   protected static void loadModule(URI uri, VmTyped instance) {
     doLoad(uri, instance);
@@ -64,7 +67,8 @@ public abstract class StdLibModule {
                       null,
                       null,
                       TraceMode.COMPACT,
-                      false));
+                      false,
+                      stdLibFeatureFlags));
               var language = VmLanguage.get(null);
               var moduleKey = ModuleKeys.standardLibrary(uri);
               var source = VmUtils.loadSource((ResolvedModuleKey) moduleKey);

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmContext.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmContext.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import org.pkl.core.FeatureFlag;
 import org.pkl.core.Logger;
 import org.pkl.core.SecurityManager;
 import org.pkl.core.StackFrameTransformer;
@@ -61,6 +62,7 @@ public final class VmContext {
     private final @Nullable ProjectDependenciesManager projectDependenciesManager;
     private final TraceMode traceMode;
     private final boolean powerAssertions;
+    private final Map<FeatureFlag, Boolean> featureFlags;
 
     public Holder(
         StackFrameTransformer frameTransformer,
@@ -76,7 +78,8 @@ public final class VmContext {
         @Nullable PackageResolver packageResolver,
         @Nullable ProjectDependenciesManager projectDependenciesManager,
         TraceMode traceMode,
-        boolean powerAssertions) {
+        boolean powerAssertions,
+        Map<FeatureFlag, Boolean> featureFlags) {
 
       this.frameTransformer = frameTransformer;
       this.securityManager = securityManager;
@@ -99,6 +102,7 @@ public final class VmContext {
       this.projectDependenciesManager = projectDependenciesManager;
       this.traceMode = traceMode;
       this.powerAssertions = powerAssertions;
+      this.featureFlags = featureFlags;
     }
   }
 
@@ -170,5 +174,9 @@ public final class VmContext {
 
   public VmValueTrackerFactory getValueTrackerFactory() {
     return valueTrackerFactory;
+  }
+
+  public boolean getFeatureFlag(FeatureFlag flag) {
+    return holder.featureFlags.getOrDefault(flag, flag.defaultValue());
   }
 }

--- a/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/AnalyzerTest.kt
@@ -39,6 +39,7 @@ class AnalyzerTest {
       null,
       HttpClient.dummyClient(),
       TraceMode.COMPACT,
+      emptyMap(),
     )
 
   @Test
@@ -118,6 +119,7 @@ class AnalyzerTest {
         null,
         HttpClient.dummyClient(),
         TraceMode.COMPACT,
+        emptyMap(),
       )
     PackageServer.populateCacheDir(tempDir.resolve("packages"))
     val file1 =
@@ -194,6 +196,7 @@ class AnalyzerTest {
         project.dependencies,
         HttpClient.dummyClient(),
         TraceMode.COMPACT,
+        emptyMap(),
       )
     val file1 =
       tempDir
@@ -307,6 +310,7 @@ class AnalyzerTest {
         project.dependencies,
         HttpClient.dummyClient(),
         TraceMode.COMPACT,
+        emptyMap(),
       )
     val result = analyzer.importGraph(mainPkl.toUri())
     val birdUri = URI("projectpackage://localhost:0/birds@1.0.0#/bird.pkl")

--- a/pkl-core/src/test/kotlin/org/pkl/core/ReplServerTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/ReplServerTest.kt
@@ -47,6 +47,7 @@ class ReplServerTest {
       StackFrameTransformers.defaultTransformer,
       false,
       TraceMode.COMPACT,
+      emptyMap(),
     )
 
   @Test
@@ -214,6 +215,7 @@ class ReplServerTest {
         StackFrameTransformers.defaultTransformer,
         true,
         TraceMode.COMPACT,
+        emptyMap(),
       )
     val responses = server.handleRequest(ReplRequest.Eval("id", "5.ms", false, false))
     assertThat(responses).hasSize(1)

--- a/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/project/ProjectTest.kt
@@ -76,6 +76,7 @@ class ProjectTest {
         null,
         null,
         null,
+        null,
       )
     val expectedAnnotations =
       listOf(
@@ -197,6 +198,7 @@ class ProjectTest {
           listOf(Path.of("/path/to/modulepath1/"), Path.of("/path/to/modulepath2/")),
           null,
           Path.of("/path/to"),
+          null,
           null,
           null,
           null,

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/BasePklTask.java
@@ -179,6 +179,10 @@ public abstract class BasePklTask extends DefaultTask {
   @Nested
   public abstract MapProperty<String, ExternalReaderSpec> getExternalResourceReaders();
 
+  @Input
+  @Optional
+  public abstract MapProperty<String, Boolean> getFeatureFlags();
+
   /**
    * There are issues with using native libraries in Gradle plugins. As a workaround for now, make
    * Truffle use an un-optimized runtime.
@@ -236,7 +240,8 @@ public abstract class BasePklTask extends DefaultTask {
         toExternalReaderMap(getExternalModuleReaders().get().values()),
         toExternalReaderMap(getExternalResourceReaders().get().values()),
         null,
-        getPowerAssertions().getOrElse(false));
+        getPowerAssertions().getOrElse(false),
+        getFeatureFlags().getOrNull());
   }
 
   @Internal

--- a/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
+++ b/pkl-gradle/src/main/java/org/pkl/gradle/task/ModulesTask.java
@@ -170,6 +170,7 @@ public abstract class ModulesTask extends BasePklTask {
         toExternalReaderMap(getExternalModuleReaders().get().values()),
         toExternalReaderMap(getExternalResourceReaders().get().values()),
         null,
-        getPowerAssertions().getOrElse(false));
+        getPowerAssertions().getOrElse(false),
+        getFeatureFlags().getOrNull());
   }
 }

--- a/pkl-server/src/main/kotlin/org/pkl/server/ClientLogger.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ClientLogger.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,17 @@
 package org.pkl.server
 
 import org.pkl.core.Logger
-import org.pkl.core.StackFrame
 import org.pkl.core.messaging.MessageTransport
 
 internal class ClientLogger(
   private val evaluatorId: Long,
   private val transport: MessageTransport,
 ) : Logger {
-  override fun trace(message: String, frame: StackFrame) {
-    transport.send(LogMessage(evaluatorId, 0, message, frame.moduleUri))
+  override fun trace(message: String, frameUri: String) {
+    transport.send(LogMessage(evaluatorId, 0, message, frameUri))
   }
 
-  override fun warn(message: String, frame: StackFrame) {
-    transport.send(LogMessage(evaluatorId, 1, message, frame.moduleUri))
+  override fun warn(message: String, frameUri: String) {
+    transport.send(LogMessage(evaluatorId, 1, message, frameUri))
   }
 }

--- a/pkl-server/src/main/kotlin/org/pkl/server/Server.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/Server.kt
@@ -228,6 +228,13 @@ class Server(private val transport: MessageTransport) : AutoCloseable {
         }
         outputFormat = message.outputFormat
         message.traceMode?.let { traceMode = it }
+        message.featureFlags?.forEach { name, value ->
+          FeatureFlag.parse(name)?.let {
+            addFeatureFlag(it, value)
+            return@forEach
+          }
+          logger.warn("Unrecognized feature flag named `${name}`", "pkl:#server")
+        }
         build()
       }
     } catch (e: IllegalArgumentException) {

--- a/pkl-server/src/main/kotlin/org/pkl/server/ServerMessagePackDecoder.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ServerMessagePackDecoder.kt
@@ -34,6 +34,8 @@ class ServerMessagePackDecoder(unpacker: MessageUnpacker) : BaseMessagePackDecod
   override fun decodeMessage(msgType: Message.Type, map: Map<Value, Value>): Message? {
     return when (msgType) {
       Message.Type.CREATE_EVALUATOR_REQUEST ->
+        // Changes here should be reflected in
+        // docs/modules/bindings-specification/pages/message-passing-api.adoc
         CreateEvaluatorRequest(
           get(map, "requestId").asIntegerValue().asLong(),
           unpackStringListOrNull(map, "allowedModules"),
@@ -41,17 +43,22 @@ class ServerMessagePackDecoder(unpacker: MessageUnpacker) : BaseMessagePackDecod
           unpackListOrNull(map, "clientModuleReaders") { unpackModuleReaderSpec(it)!! },
           unpackListOrNull(map, "clientResourceReaders") { unpackResourceReaderSpec(it)!! },
           unpackStringListOrNull(map, "modulePaths", Path::of),
-          unpackStringMapOrNull(map, "env"),
-          unpackStringMapOrNull(map, "properties"),
+          unpackMapOrNull(map, "env") { it.asStringValue().asString() },
+          unpackMapOrNull(map, "properties") { it.asStringValue().asString() },
           unpackLongOrNull(map, "timeoutSeconds", Duration::ofSeconds),
           unpackStringOrNull(map, "rootDir", Path::of),
           unpackStringOrNull(map, "cacheDir", Path::of),
           unpackStringOrNull(map, "outputFormat"),
           map.unpackProject(),
           map.unpackHttp(),
-          unpackStringMapOrNull(map, "externalModuleReaders", ::unpackExternalReader),
-          unpackStringMapOrNull(map, "externalResourceReaders", ::unpackExternalReader),
+          unpackMapOrNull(map, "externalModuleReaders") {
+            unpackExternalReader(it.asMapValue().map())
+          },
+          unpackMapOrNull(map, "externalResourceReaders") {
+            unpackExternalReader(it.asMapValue().map())
+          },
           unpackStringOrNull(map, "traceMode") { TraceMode.valueOf(it.uppercase()) },
+          unpackMapOrNull(map, "featureFlags") { it.asBooleanValue().boolean },
         )
       Message.Type.CREATE_EVALUATOR_RESPONSE ->
         CreateEvaluatorResponse(

--- a/pkl-server/src/main/kotlin/org/pkl/server/ServerMessagePackEncoder.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ServerMessagePackEncoder.kt
@@ -127,6 +127,7 @@ class ServerMessagePackEncoder(packer: MessagePacker) : BaseMessagePackEncoder(p
           msg.externalModuleReaders,
           msg.externalResourceReaders,
           msg.traceMode,
+          msg.featureFlags,
         )
         packKeyValue("requestId", msg.requestId())
         packKeyValue("allowedModules", msg.allowedModules)
@@ -178,6 +179,14 @@ class ServerMessagePackEncoder(packer: MessagePacker) : BaseMessagePackEncoder(p
         }
         if (msg.traceMode != null) {
           packKeyValue("traceMode", msg.traceMode.toString())
+        }
+        if (msg.featureFlags != null) {
+          packer.packString("featureFlags")
+          packer.packMapHeader(msg.featureFlags.size)
+          for ((flag, value) in msg.featureFlags) {
+            packer.packString(flag)
+            packer.packBoolean(value)
+          }
         }
         return
       }

--- a/pkl-server/src/main/kotlin/org/pkl/server/ServerMessages.kt
+++ b/pkl-server/src/main/kotlin/org/pkl/server/ServerMessages.kt
@@ -42,6 +42,7 @@ data class CreateEvaluatorRequest(
   val externalModuleReaders: Map<String, ExternalReader>?,
   val externalResourceReaders: Map<String, ExternalReader>?,
   val traceMode: TraceMode?,
+  val featureFlags: Map<String, Boolean>?,
 ) : Message.Client.Request {
 
   override fun type(): Message.Type = Message.Type.CREATE_EVALUATOR_REQUEST

--- a/pkl-server/src/test/kotlin/org/pkl/server/ServerMessagePackCodecTest.kt
+++ b/pkl-server/src/test/kotlin/org/pkl/server/ServerMessagePackCodecTest.kt
@@ -103,6 +103,7 @@ class ServerMessagePackCodecTest {
         externalModuleReaders = mapOf("external" to externalReader, "external2" to externalReader),
         externalResourceReaders = mapOf("external" to externalReader),
         traceMode = TraceMode.PRETTY,
+        featureFlags = mapOf("foo" to true, "bar" to false),
       )
     )
   }

--- a/stdlib/EvaluatorSettings.pkl
+++ b/stdlib/EvaluatorSettings.pkl
@@ -122,6 +122,19 @@ externalResourceReaders: Mapping<String, ExternalReader>?
 @Since { version = "0.30.0" }
 traceMode: ("compact" | "pretty")?
 
+/// Feature flags controlling Pkl evaluation behavior.
+///
+/// Accepted flags and their default values may vary between Pkl releases.
+/// Unrecognized flags will result in a warning.
+@Since { version = "0.33.0" }
+featureFlags: Mapping<KnownFeatureFlags | String, Boolean>?
+
+/// Feature flag names known to the current version of Pkl.
+///
+/// Provided for informational purposes and enhanced editor completion for [featureFlags].
+@Since { version = "0.33.0" }
+typealias KnownFeatureFlags = nothing
+
 /// These evaluator settings, whose settings are resolved against [enclosingUri] using OS rules for
 /// [os].
 @Since { version = "0.32.0" }


### PR DESCRIPTION
Adds:
* New CLI flag `--feature=<name>=[true|false]`
* Pkl API
  * Property `pkl.EvaluatorSettings#featureFlags: Mapping<KnownFeatureFlags | String, Boolean>`
  * Typealias `pkl.EvaluatorSettings#FeatureFlags = nothing` (no feature flags yet, but this will be a string literal union)
* Java API
  * `org.pkl.core.FeatureFlags` - enum to document feature flags and their default values.
  * `org.pkl.core.evaluatorSettings.PklEvaluatorSettings.featureFlags`
  * `org.pkl.core.Analyzer` now requires constructor argument `Map<FeatureFlag, Boolean> featureFlags`
  * `org.pkl.core.EvaluatorBuilder`
    * `addFeatureFlag`, `addFeatureFlags`, `setFeatureFlags`, `getFeatureFlags`
    * `applyFromProject(Project, Logger)` (for capturing string->`FeatureFlag` conversion warnings)
      * The overload without the `Logger` argument now passes `Loggers.noop()` to this API
  * `org.pkl.config.java.ConfigEvaluatorBuilder.applyFromProject(Project, Logger)` (for capturing string->`FeatureFlag` conversion warnings)
    * The overload without the `Logger` argument now passes `Loggers.noop()` to this API
  * `org.pkl.core.Logger` (changes to assist with warnings not from Pkl code)
    * `trace(String message, String frameUri)` (now called by `trace(String, StackFrame)`)
    * `warn(String message, String frameUri)` (now called by `warn(String, StackFrame)`)
* Gradle tasks now accept `featureFlags` (as a `MapProperty<String, Boolean>`)
* Message passing API `CreateEvaluatorRequest` now accepts a map property `featureFlags`, which is a map of string to boolean values.

Feature flag lifecycle:
1. Feature flags are added by adding a case to `org.pkl.core.FeatureFlags`.
2. Flags may change default values as the language evolves.
3. Prior to removal, enum cases should be marked `@Deprecated` for at least one release to provide Java API users an opportunity to discontinue usage.
4. Finally, a flag is retired by removing its enum case and any code accessing its value.

Notably, because Pkl's stdlib is statically initialized with a separate `VmContext`, it can set its own feature flags independently of each user-initiated evaluation!