### PR TITLE
Enforce that abstract methods are implemented

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/member/ClassNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/member/ClassNode.java
@@ -123,37 +123,45 @@ public final class ClassNode extends ExpressionNode {
             typeParameters,
             prototype);
 
-    if (unresolvedSupertypeNode != null) {
-      var supertypeNode = unresolvedSupertypeNode.execute(frame);
-      var superclass = supertypeNode.getVmClass();
+    var localContext = VmLanguage.get(this).localContext.get();
+    localContext.beginClassInit(cachedClass);
 
-      checkSupertype(supertypeNode, superclass);
-      cachedClass.initSupertype(supertypeNode, superclass);
+    try {
+      if (unresolvedSupertypeNode != null) {
+        var supertypeNode = unresolvedSupertypeNode.execute(frame);
+        var superclass = supertypeNode.getVmClass();
+
+        checkSupertype(supertypeNode, superclass);
+        cachedClass.initSupertype(supertypeNode, superclass);
+      }
+
+      // The superclass resolved above may not itself have completed the below initializations yet.
+      // That's because these initializations may have indirectly or directly triggered
+      // resolution of this class, in which case the `resolveSuperclass()` call above
+      // will have returned the partially initialized `cachedClass` of the superclass.
+      // As a consequence, initializations that require a fully initialized class hierarchy
+      // are done lazily in VmClass rather than here.
+      // A fully initialized class hierarchy is only required for initialization of internal caches,
+      // which is guaranteed to succeed (no impact on eager vs. lazy error reporting) and easy to
+      // defer.
+
+      VmUtils.evaluateAnnotations(frame, annotationNodes, annotations);
+
+      for (var node : unresolvedPropertyNodes) {
+        cachedClass.addProperty(node.execute(frame, cachedClass));
+      }
+
+      for (var node : unresolvedMethodNodes) {
+        cachedClass.addMethod(node.execute(frame, cachedClass));
+      }
+
+      cachedClass.onOwnClassInitialized();
+      localContext.endClassInit();
+      return cachedClass;
+    } catch (Throwable e) {
+      localContext.clearClassInitState();
+      throw e;
     }
-
-    // The superclass resolved above may not itself have completed the below initializations yet.
-    // That's because these initializations may have indirectly or directly triggered
-    // resolution of this class, in which case the `resolveSuperclass()` call above
-    // will have returned the partially initialized `cachedClass` of the superclass.
-    // As a consequence, initializations that require a fully initialized class hierarchy
-    // are done lazily in VmClass rather than here.
-    // A fully initialized class hierarchy is only required for initialization of internal caches,
-    // which is guaranteed to succeed (no impact on eager vs. lazy error reporting) and easy to
-    // defer.
-
-    VmUtils.evaluateAnnotations(frame, annotationNodes, annotations);
-
-    for (var node : unresolvedPropertyNodes) {
-      cachedClass.addProperty(node.execute(frame, cachedClass));
-    }
-
-    for (var node : unresolvedMethodNodes) {
-      cachedClass.addMethod(node.execute(frame, cachedClass));
-    }
-
-    cachedClass.notifyInitialized();
-
-    return cachedClass;
   }
 
   private void checkSupertype(TypeNode supertypeNode, @Nullable VmClass superclass) {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
@@ -153,16 +153,16 @@ public final class VmClass extends VmValue {
 
   @TruffleBoundary
   private void checkAbstractMethods() {
-    if (this.isAbstract()) return;
+    if (isAbstract()) return;
     // minimize allocations in the non-error case
-    if (!hasAbstractMethod()) return;
     var abstractMethods = getAbstractMethods();
+    if (abstractMethods.isEmpty()) return;
     if (abstractMethods.size() == 1) {
       throw new VmExceptionBuilder()
           .evalError(
               "noImplementationForAbstractMethod",
               getDisplayName(),
-              abstractMethods.get(0).getName().toString())
+              abstractMethods.get(0).getCallSignature())
           .withSourceSection(getHeaderSection())
           .build();
     }
@@ -175,17 +175,6 @@ public final class VmClass extends VmValue {
             "noImplementationForAbstractMethods", getDisplayName(), MultilineValue.of(methodList))
         .withSourceSection(getHeaderSection())
         .build();
-  }
-
-  private boolean hasAbstractMethod() {
-    var methodCursor = getAllMethods().getEntries();
-    while (methodCursor.advance()) {
-      var method = methodCursor.getValue();
-      if (method.isAbstract()) {
-        return true;
-      }
-    }
-    return false;
   }
 
   private List<ClassMethod> getAbstractMethods() {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
@@ -22,6 +22,7 @@ import com.oracle.truffle.api.dsl.Idempotent;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.source.SourceSection;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.*;
 import org.graalvm.collections.*;
 import org.jspecify.annotations.Nullable;
@@ -33,6 +34,7 @@ import org.pkl.core.TypeParameter;
 import org.pkl.core.ast.*;
 import org.pkl.core.ast.member.*;
 import org.pkl.core.ast.type.TypeNode;
+import org.pkl.core.runtime.VmExceptionBuilder.MultilineValue;
 import org.pkl.core.util.CollectionUtils;
 import org.pkl.core.util.EconomicMaps;
 import org.pkl.core.util.LateInit;
@@ -83,6 +85,13 @@ public final class VmClass extends VmValue {
   private @Nullable UnmodifiableEconomicSet<Object> __allHiddenPropertyNames;
 
   private final Object allHiddenPropertyNamesLock = new Object();
+
+  @GuardedBy("finalizersLock")
+  private @Nullable List<Runnable> __finalizers = null;
+
+  private final Object finalizersLock = new Object();
+
+  private final AtomicInteger uninitializedSuperclassCount = new AtomicInteger(0);
 
   // Helps to overcome recursive initialization issues
   // between classes and annotations in pkl.base.
@@ -151,6 +160,56 @@ public final class VmClass extends VmValue {
   }
 
   @TruffleBoundary
+  private void checkAbstractMethods() {
+    if (this.isAbstract()) return;
+    // minimize allocations in the non-error case
+    if (!hasAbstractMethod()) return;
+    var abstractMethods = getAbstractMethods();
+    if (abstractMethods.size() == 1) {
+      throw new VmExceptionBuilder()
+          .evalError(
+              "noImplementationForAbstractMethod",
+              getDisplayName(),
+              abstractMethods.get(0).getName().toString())
+          .withSourceSection(getHeaderSection())
+          .build();
+    }
+    var methodList = new ArrayList<String>(abstractMethods.size());
+    for (var method : abstractMethods) {
+      methodList.add(method.getCallSignature());
+    }
+    throw new VmExceptionBuilder()
+        .evalError(
+            "noImplementationForAbstractMethods", getDisplayName(), MultilineValue.of(methodList))
+        .withSourceSection(getHeaderSection())
+        .build();
+  }
+
+  private boolean hasAbstractMethod() {
+    var methodCursor = getAllMethods().getEntries();
+    while (methodCursor.advance()) {
+      var method = methodCursor.getValue();
+      if (method.isAbstract()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private List<ClassMethod> getAbstractMethods() {
+    assert this.superclass != null;
+    var result = new ArrayList<ClassMethod>();
+    var methodCursor = getAllMethods().getEntries();
+    while (methodCursor.advance()) {
+      var method = methodCursor.getValue();
+      if (method.isAbstract()) {
+        result.add(method);
+      }
+    }
+    return result;
+  }
+
+  @TruffleBoundary
   public void addProperty(ClassProperty property) {
     prototype.addProperty(property.getInitializer());
     EconomicMaps.put(declaredProperties, property.getName(), property);
@@ -190,8 +249,46 @@ public final class VmClass extends VmValue {
     }
   }
 
+  private void onInitialized(Runnable runnable) {
+    synchronized (finalizersLock) {
+      if (this.__finalizers == null) {
+        this.__finalizers = new ArrayList<>();
+      }
+      this.__finalizers.add(runnable);
+    }
+  }
+
   // Note: Superclasses may not have finished their initialization when this method is called.
   public void notifyInitialized() {
+    var sc = superclass;
+    var isAllInitialized = true;
+    var uninitializedCount = 0;
+    while (sc != null) {
+      if (!sc.isInitialized) {
+        sc.onInitialized(
+            () -> {
+              var count = uninitializedSuperclassCount.decrementAndGet();
+              if (count == 0) {
+                checkAbstractMethods();
+              }
+            });
+        uninitializedCount++;
+        isAllInitialized = false;
+      }
+      sc = sc.superclass;
+    }
+    uninitializedSuperclassCount.set(uninitializedCount);
+    if (isAllInitialized) {
+      checkAbstractMethods();
+    }
+    lock:
+    synchronized (finalizersLock) {
+      if (__finalizers == null) break lock;
+      for (var finalizer : __finalizers) {
+        finalizer.run();
+      }
+      this.__finalizers = null;
+    }
     isInitialized = true;
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
@@ -22,7 +22,6 @@ import com.oracle.truffle.api.dsl.Idempotent;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.source.SourceSection;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.*;
 import org.graalvm.collections.*;
 import org.jspecify.annotations.Nullable;
@@ -85,13 +84,6 @@ public final class VmClass extends VmValue {
   private @Nullable UnmodifiableEconomicSet<Object> __allHiddenPropertyNames;
 
   private final Object allHiddenPropertyNamesLock = new Object();
-
-  @GuardedBy("finalizersLock")
-  private @Nullable List<Runnable> __finalizers = null;
-
-  private final Object finalizersLock = new Object();
-
-  private final AtomicInteger uninitializedSuperclassCount = new AtomicInteger(0);
 
   // Helps to overcome recursive initialization issues
   // between classes and annotations in pkl.base.
@@ -249,47 +241,18 @@ public final class VmClass extends VmValue {
     }
   }
 
-  private void onInitialized(Runnable runnable) {
-    synchronized (finalizersLock) {
-      if (this.__finalizers == null) {
-        this.__finalizers = new ArrayList<>();
-      }
-      this.__finalizers.add(runnable);
-    }
+  /**
+   * Called when this class itself has been initialized.
+   *
+   * <p>Superclasses may not have been initialized yet.
+   */
+  public void onOwnClassInitialized() {
+    isInitialized = true;
   }
 
-  // Note: Superclasses may not have finished their initialization when this method is called.
-  public void notifyInitialized() {
-    var sc = superclass;
-    var isAllInitialized = true;
-    var uninitializedCount = 0;
-    while (sc != null) {
-      if (!sc.isInitialized) {
-        sc.onInitialized(
-            () -> {
-              var count = uninitializedSuperclassCount.decrementAndGet();
-              if (count == 0) {
-                checkAbstractMethods();
-              }
-            });
-        uninitializedCount++;
-        isAllInitialized = false;
-      }
-      sc = sc.superclass;
-    }
-    uninitializedSuperclassCount.set(uninitializedCount);
-    if (isAllInitialized) {
-      checkAbstractMethods();
-    }
-    lock:
-    synchronized (finalizersLock) {
-      if (__finalizers == null) break lock;
-      for (var finalizer : __finalizers) {
-        finalizer.run();
-      }
-      this.__finalizers = null;
-    }
-    isInitialized = true;
+  /** Called when the entire class hierarchy is completely initialized, including superclasses. */
+  public void onFullyInitialized() {
+    checkAbstractMethods();
   }
 
   public int getTypeParameterCount() {

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmLocalContext.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmLocalContext.java
@@ -15,12 +15,21 @@
  */
 package org.pkl.core.runtime;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 /** A per-context thread-local value that can be used to influence execution. */
 public class VmLocalContext {
   private boolean shouldEagerTypecheck = false;
 
   /** Whether we are currently inside a type test ({@code is} check). */
   private boolean inTypeTest = false;
+
+  /** The number of classes currently being initialized. */
+  private int classDepth = 0;
+
+  /** The classes currently being initialized. */
+  private final Deque<VmClass> pendingClasses = new ArrayDeque<>();
 
   /**
    * Number of active {@link VmValueTracker} instances. Used to determine if instrumentation is
@@ -46,6 +55,27 @@ public class VmLocalContext {
 
   public boolean isInTypeTest() {
     return inTypeTest;
+  }
+
+  public void beginClassInit(VmClass vmClass) {
+    classDepth++;
+    pendingClasses.add(vmClass);
+  }
+
+  public void endClassInit() {
+    classDepth--;
+    if (classDepth > 0) {
+      return;
+    }
+    while (!pendingClasses.isEmpty()) {
+      var clazz = pendingClasses.pop();
+      clazz.onFullyInitialized();
+    }
+  }
+
+  public void clearClassInitState() {
+    pendingClasses.clear();
+    classDepth = 0;
   }
 
   public void enterTracker() {

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -1208,3 +1208,10 @@ invalidReferenceTypeAnnotationWithConstraint=\
 
 cannotInstallPackageWithNoCache=\
 Cannot install package to module cache dir when module cache is disabled.
+
+noImplementationForAbstractMethod=\
+Class `{0}` should either be declared `abstract`, or should implement method `{1}`.
+
+noImplementationForAbstractMethods=\
+Class `{0}` should either be declared `abstract`, or implement the following methods:\n\
+{1}

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -1213,5 +1213,5 @@ noImplementationForAbstractMethod=\
 Class `{0}` should either be declared `abstract`, or should implement method `{1}`.
 
 noImplementationForAbstractMethods=\
-Class `{0}` should either be declared `abstract`, or implement the following methods:\n\
+Class `{0}` should either be declared `abstract`, or should implement the following methods:\n\
 {1}

--- a/pkl-core/src/test/files/LanguageSnippetTests/input-helper/classes/AbstractModule.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input-helper/classes/AbstractModule.pkl
@@ -1,0 +1,3 @@
+abstract module Foo
+
+abstract function bar(): Int

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented1.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented1.pkl
@@ -1,0 +1,9 @@
+abstract class AbstractMethod {
+  abstract function foo(): Int
+}
+
+class MyClass extends AbstractMethod {
+}
+
+foo: MyClass
+

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented1.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented1.pkl
@@ -6,4 +6,3 @@ class MyClass extends AbstractMethod {
 }
 
 foo: MyClass
-

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented2.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented2.pkl
@@ -1,0 +1,9 @@
+abstract class AbstractMethods {
+  abstract function foo(): Int
+  abstract function bar(): Int
+}
+
+class MyClass extends AbstractMethods {
+}
+
+foo: MyClass

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented3.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented3.pkl
@@ -1,0 +1,1 @@
+extends "../../input-helper/classes/AbstractModule.pkl"

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented4.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/abstractMethodNotImplemented4.pkl
@@ -1,0 +1,10 @@
+abstract class AbstractMethod {
+  abstract function foo(): Int
+}
+
+abstract class AbstractIntermediate extends AbstractMethod
+
+class MyClass extends AbstractIntermediate {
+}
+
+foo: MyClass

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented1.err
@@ -1,0 +1,10 @@
+–– Pkl Error ––
+Class `abstractMethodNotImplemented1#MyClass` should either be declared `abstract`, or should implement method `foo`.
+
+x | class MyClass extends AbstractMethod {
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at abstractMethodNotImplemented1#MyClass (file:///$snippetsDir/input/errors/abstractMethodNotImplemented1.pkl)
+
+x | foo: MyClass
+         ^^^^^^^
+at abstractMethodNotImplemented1 (file:///$snippetsDir/input/errors/abstractMethodNotImplemented1.pkl)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented1.err
@@ -1,5 +1,5 @@
 –– Pkl Error ––
-Class `abstractMethodNotImplemented1#MyClass` should either be declared `abstract`, or should implement method `foo`.
+Class `abstractMethodNotImplemented1#MyClass` should either be declared `abstract`, or should implement method `foo()`.
 
 x | class MyClass extends AbstractMethod {
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented1.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented1.err
@@ -3,8 +3,4 @@ Class `abstractMethodNotImplemented1#MyClass` should either be declared `abstrac
 
 x | class MyClass extends AbstractMethod {
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-at abstractMethodNotImplemented1#MyClass (file:///$snippetsDir/input/errors/abstractMethodNotImplemented1.pkl)
-
-x | foo: MyClass
-         ^^^^^^^
 at abstractMethodNotImplemented1 (file:///$snippetsDir/input/errors/abstractMethodNotImplemented1.pkl)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented2.err
@@ -1,0 +1,12 @@
+–– Pkl Error ––
+Class `abstractMethodNotImplemented2#MyClass` should either be declared `abstract`, or implement the following methods:
+foo()
+bar()
+
+x | class MyClass extends AbstractMethods {
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at abstractMethodNotImplemented2#MyClass (file:///$snippetsDir/input/errors/abstractMethodNotImplemented2.pkl)
+
+x | foo: MyClass
+         ^^^^^^^
+at abstractMethodNotImplemented2 (file:///$snippetsDir/input/errors/abstractMethodNotImplemented2.pkl)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented2.err
@@ -1,5 +1,5 @@
 –– Pkl Error ––
-Class `abstractMethodNotImplemented2#MyClass` should either be declared `abstract`, or implement the following methods:
+Class `abstractMethodNotImplemented2#MyClass` should either be declared `abstract`, or should implement the following methods:
 foo()
 bar()
 

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented2.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented2.err
@@ -5,8 +5,4 @@ bar()
 
 x | class MyClass extends AbstractMethods {
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-at abstractMethodNotImplemented2#MyClass (file:///$snippetsDir/input/errors/abstractMethodNotImplemented2.pkl)
-
-x | foo: MyClass
-         ^^^^^^^
 at abstractMethodNotImplemented2 (file:///$snippetsDir/input/errors/abstractMethodNotImplemented2.pkl)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented3.err
@@ -1,0 +1,6 @@
+–– Pkl Error ––
+Class `abstractMethodNotImplemented3` should either be declared `abstract`, or should implement method `bar`.
+
+x | extends "../../input-helper/classes/AbstractModule.pkl"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at abstractMethodNotImplemented3 (file:///$snippetsDir/input/errors/abstractMethodNotImplemented3.pkl)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented3.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented3.err
@@ -1,5 +1,5 @@
 –– Pkl Error ––
-Class `abstractMethodNotImplemented3` should either be declared `abstract`, or should implement method `bar`.
+Class `abstractMethodNotImplemented3` should either be declared `abstract`, or should implement method `bar()`.
 
 x | extends "../../input-helper/classes/AbstractModule.pkl"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented4.err
@@ -3,8 +3,4 @@ Class `abstractMethodNotImplemented4#MyClass` should either be declared `abstrac
 
 x | class MyClass extends AbstractIntermediate {
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-at abstractMethodNotImplemented4#MyClass (file:///$snippetsDir/input/errors/abstractMethodNotImplemented4.pkl)
-
-xx | foo: MyClass
-          ^^^^^^^
 at abstractMethodNotImplemented4 (file:///$snippetsDir/input/errors/abstractMethodNotImplemented4.pkl)

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented4.err
@@ -1,5 +1,5 @@
 –– Pkl Error ––
-Class `abstractMethodNotImplemented4#MyClass` should either be declared `abstract`, or should implement method `foo`.
+Class `abstractMethodNotImplemented4#MyClass` should either be declared `abstract`, or should implement method `foo()`.
 
 x | class MyClass extends AbstractIntermediate {
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented4.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/abstractMethodNotImplemented4.err
@@ -1,0 +1,10 @@
+–– Pkl Error ––
+Class `abstractMethodNotImplemented4#MyClass` should either be declared `abstract`, or should implement method `foo`.
+
+x | class MyClass extends AbstractIntermediate {
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at abstractMethodNotImplemented4#MyClass (file:///$snippetsDir/input/errors/abstractMethodNotImplemented4.pkl)
+
+xx | foo: MyClass
+          ^^^^^^^
+at abstractMethodNotImplemented4 (file:///$snippetsDir/input/errors/abstractMethodNotImplemented4.pkl)

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -3549,6 +3549,18 @@ external class Set<out Element> extends Collection<Element> {
 
   /// The difference of this set and [other].
   external function difference(other: Set): Set<Element>
+
+  function indexOf(_): Int = throw("Set does not implement `indexOf`")
+  function indexOfOrNull(_): Int? = throw("Set does not implement `indexOfOrNull`")
+
+  function lastIndexOf(_): Int = throw("Set does not implement `lastIndexOf`")
+  function lastIndexOfOrNull(_): Int? = throw("Set does not implement `lastIndexOfOrNull`")
+
+  function findIndex(_): Int = throw("Set does not implement `findIndex`")
+  function findIndexOrNull(_): Int? = throw("Set does not implement `findIndexOrNull`")
+
+  function findLastIndex(_): Int = throw("Set does not implement `findLastIndex`")
+  function findLastIndexOrNull(_): Int? = throw("Set does not implement `findLastIndexOrNull`")
 }
 
 /// Creates a map containing the given alternating [keysAndValues].

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -3549,18 +3549,6 @@ external class Set<out Element> extends Collection<Element> {
 
   /// The difference of this set and [other].
   external function difference(other: Set): Set<Element>
-
-  function indexOf(_): Int = throw("Set does not implement `indexOf`")
-  function indexOfOrNull(_): Int? = throw("Set does not implement `indexOfOrNull`")
-
-  function lastIndexOf(_): Int = throw("Set does not implement `lastIndexOf`")
-  function lastIndexOfOrNull(_): Int? = throw("Set does not implement `lastIndexOfOrNull`")
-
-  function findIndex(_): Int = throw("Set does not implement `findIndex`")
-  function findIndexOrNull(_): Int? = throw("Set does not implement `findIndexOrNull`")
-
-  function findLastIndex(_): Int = throw("Set does not implement `findLastIndex`")
-  function findLastIndexOrNull(_): Int? = throw("Set does not implement `findLastIndexOrNull`")
 }
 
 /// Creates a map containing the given alternating [keysAndValues].


### PR DESCRIPTION
This adds a check that abstract methods must be implemented. If any members lack an implementation, an error is thrown describing the missing methods.

Supersedes #1690
Fixes #1262 