### PR TITLE
Fix bug in `force`

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmObject.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmObject.java
@@ -156,7 +156,10 @@ public abstract class VmObject extends VmObjectLike {
   public final void force(boolean allowUndefinedValues, boolean recurse) {
     if (forced) return;
 
+    // set eagerly to break reference cycles
     if (recurse) forced = true;
+
+    var fullyForced = true;
 
     try {
       for (VmObjectLike owner = this; owner != null; owner = owner.getParent()) {
@@ -177,6 +180,7 @@ public abstract class VmObject extends VmObjectLike {
               memberValue = VmUtils.doReadMember(this, owner, memberKey, member);
             } catch (VmUndefinedValueException e) {
               if (!allowUndefinedValues) throw e;
+              fullyForced = false;
               continue;
             }
           }
@@ -190,6 +194,9 @@ public abstract class VmObject extends VmObjectLike {
       forced = false;
       throw t;
     }
+
+    // make sure uncached values are not marked as forced
+    if (recurse && !fullyForced) forced = false;
   }
 
   @Override

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/errors/traceThenIterateUndefinedMember.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/errors/traceThenIterateUndefinedMember.pkl
@@ -1,0 +1,21 @@
+undefinedValue: String
+
+items = new Listing {
+  undefinedValue
+}
+
+lookup = new Mapping {
+  ["x"] = 1
+}
+
+result =
+  let (_ = trace(items))
+    new Listing {
+      for (item in items) {
+        lookup.containsKey(item)
+      }
+    }
+
+output {
+  value = result
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/errors/traceThenIterateUndefinedMember.err
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/errors/traceThenIterateUndefinedMember.err
@@ -1,0 +1,27 @@
+–– Pkl Error ––
+Tried to read property `undefinedValue` but its value is undefined.
+
+x | undefinedValue: String
+    ^^^^^^^^^^^^^^
+at traceThenIterateUndefinedMember#undefinedValue (file:///$snippetsDir/input/errors/traceThenIterateUndefinedMember.pkl)
+
+x | undefinedValue
+    ^^^^^^^^^^^^^^
+at traceThenIterateUndefinedMember#items[#1] (file:///$snippetsDir/input/errors/traceThenIterateUndefinedMember.pkl)
+
+xx | let (_ = trace(items))
+     ^^^^^^^^^^^^^^^^^^^^^^
+at traceThenIterateUndefinedMember#result.<let expr> (file:///$snippetsDir/input/errors/traceThenIterateUndefinedMember.pkl)
+
+xx | value = result
+             ^^^^^^
+at traceThenIterateUndefinedMember#output.value (file:///$snippetsDir/input/errors/traceThenIterateUndefinedMember.pkl)
+
+xxx | renderer.renderDocument(value)
+                              ^^^^^
+at pkl.base#Module.output.text (pkl:base)
+
+xxx | if (renderer is BytesRenderer) renderer.renderDocument(value) else text.encodeToBytes("UTF-8")
+                                                                         ^^^^
+at pkl.base#Module.output.bytes (pkl:base)
+pkl: TRACE: items = new Listing { ? } (file:///$snippetsDir/input/errors/traceThenIterateUndefinedMember.pkl)


### PR DESCRIPTION
The bug manifests when we have `allowUndefinedValues = true` and leave unforced values marked as forced, breaking our own invariant:
```java
// iterateAlreadyForcedMemberValues
Object cachedValue = getCachedValue(key);
assert cachedValue != null; // forced
```

Closes #1786 