### PR TITLE
Fix negative caret width rendering multi-line expression errors

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/StackTraceRenderer.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/StackTraceRenderer.java
@@ -128,16 +128,12 @@ public final class StackTraceRenderer {
       sourceLine = sourceLine.substring(PREAMBLE_LENGTH);
       hasPreamble = true;
     }
-    var startColumn = frame.getStartColumn() - leadingWhitespace;
+    var preambleOffset = hasPreamble ? PREAMBLE_LENGTH : 0;
+    var startColumn = frame.getStartColumn() - leadingWhitespace - preambleOffset;
     var endColumn =
         frame.getStartLine() == frame.getEndLine()
-            ? frame.getEndColumn() - leadingWhitespace
+            ? frame.getEndColumn() - leadingWhitespace - preambleOffset
             : sourceLine.length();
-
-    if (hasPreamble) {
-      startColumn -= PREAMBLE_LENGTH;
-      endColumn -= PREAMBLE_LENGTH;
-    }
 
     var prefix = frame.getStartLine() + " | ";
     out.append(AnsiTheme.STACK_TRACE_MARGIN, leftMargin)

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluateExpressionTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluateExpressionTest.kt
@@ -166,6 +166,34 @@ class EvaluateExpressionTest {
   }
 
   @Test
+  fun `evaluate throwing multi-line expression renders without crashing`() {
+    val error =
+      assertThrows<PklException> {
+        evaluate("x = 1", "let (_a = 1)\n    let (_b = 2)\n        throw(\"boom\")")
+      }
+
+    // A multi-line frame used to throw `IllegalArgumentException: count is negative` while
+    // rendering.
+    assertThat(error.message)
+      .isEqualTo(
+        """
+        –– Pkl Error ––
+        boom
+
+        3 | throw("boom")
+            ^^^^^^^^^^^^^
+        at  (repl:text)
+
+        1 | let (_a = 1)
+            ^^^^^^^^^^^^
+        at repl:text.<let expr> (repl:text)
+
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
   fun `evaluate import`() {
     val result = evaluate("import \"pkl:base\"", "base")
 

--- a/pkl-core/src/test/kotlin/org/pkl/core/EvaluateExpressionTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/EvaluateExpressionTest.kt
@@ -169,11 +169,17 @@ class EvaluateExpressionTest {
   fun `evaluate throwing multi-line expression renders without crashing`() {
     val error =
       assertThrows<PklException> {
-        evaluate("x = 1", "let (_a = 1)\n    let (_b = 2)\n        throw(\"boom\")")
+        evaluate(
+          "x = 1",
+          """
+          let (_a = 1)
+          let (_b = 2)
+            throw("boom")
+          """
+            .trimIndent(),
+        )
       }
 
-    // A multi-line frame used to throw `IllegalArgumentException: count is negative` while
-    // rendering.
     assertThat(error.message)
       .isEqualTo(
         """


### PR DESCRIPTION
  If you evaluate a multi-line expression that fails, you don't get the error — you get a crash:

```java  
  Evaluator ev = Evaluator.preconfigured();
  ev.evaluateExpressionString(
      ModuleSource.text("x = 1"),
      "let (_a = 1)\n    let (_b = 2)\n        throw(\"boom\")");
  // java.lang.IllegalArgumentException: count is negative: -11
```

  A single-line expression renders fine, so this crept in with the preamble handling from #1760: the preamble length gets subtracted from endColumn even when endColumn is the already-stripped sourceLine.length(). On a multi-line frame that double-counts and the caret width goes negative, so String.repeat
  throws instead of the renderer drawing the ^^^.

  Fix is to apply the offset only to the frame-derived columns. Added a regression test; build and buildNative pass.

