### PR TITLE
Fix deploy build

### DIFF
--- a/.github/jobs/BuildJavaExecutableJob.pkl
+++ b/.github/jobs/BuildJavaExecutableJob.pkl
@@ -25,7 +25,7 @@ steps {
   (catalog.`actions/upload-artifact@v5`) {
     name = "Upload executable artifacts"
     with {
-      name = "executable-java"
+      name = "deploy-artifacts-java-executables"
       path = "*/build/executable/**/*"
     }
   }

--- a/.github/jobs/BuildNativeJob.pkl
+++ b/.github/jobs/BuildNativeJob.pkl
@@ -60,9 +60,9 @@ steps {
     with {
       name =
         if (musl)
-          "artifacts-\(project)-alpine-\(module.os)-\(module.arch)"
+          "deploy-artifacts-\(project)-alpine-\(module.os)-\(module.arch)"
         else
-          "artifacts-\(project)-\(module.os)-\(module.arch)"
+          "deploy-artifacts-\(project)-\(module.os)-\(module.arch)"
       // Need to insert a wildcard to make actions/upload-artifact preserve the folder hierarchy.
       // See https://github.com/actions/upload-artifact/issues/206
       path = module.buildDir

--- a/.github/jobs/DeployJob.pkl
+++ b/.github/jobs/DeployJob.pkl
@@ -16,7 +16,7 @@ steps {
   catalog.`actions/checkout@v6`
   (catalog.`actions/download-artifact@v6`) {
     with {
-      pattern = "executable-**"
+      pattern = "deploy-artifacts-**"
       `merge-multiple` = true
     }
   }

--- a/.github/jobs/GithubRelease.pkl
+++ b/.github/jobs/GithubRelease.pkl
@@ -14,7 +14,7 @@ fixed job {
   steps {
     (catalog.`actions/download-artifact@v6`) {
       with {
-        pattern = "executable-**"
+        pattern = "deploy-artifacts-**"
         `merge-multiple` = true
       }
     }
@@ -29,15 +29,12 @@ fixed job {
       // language=bash
       run =
         #"""
-        # exclude build_artifacts.txt from publish
-        rm -f */build/executable/*.build_artifacts.txt
-        find */build/executable/* -type d | xargs rm -rf
         gh release create ${TAG_NAME} \
           --title "${TAG_NAME}" \
           --target "${GIT_SHA}" \
           --verify-tag \
           --notes "Release notes: https://pkl-lang.org/main/current/release-notes/changelog.html#release-${TAG_NAME}" \
-          */build/executable/*
+          */build/executable/* */build/distributions/*
         """#
     }
   }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: executable-java
+        name: deploy-artifacts-java-executables
         path: '*/build/executable/**/*'
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -242,7 +242,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-amd64
+        name: deploy-artifacts-pkl-cli-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -292,7 +292,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-aarch64
+        name: deploy-artifacts-pkl-cli-linux-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -341,7 +341,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-macOS-aarch64
+        name: deploy-artifacts-pkl-cli-macOS-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -458,7 +458,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-alpine-linux-amd64
+        name: deploy-artifacts-pkl-cli-alpine-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -503,7 +503,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-windows-amd64
+        name: deploy-artifacts-pkl-cli-windows-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -551,7 +551,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-amd64
+        name: deploy-artifacts-pkl-doc-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -601,7 +601,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-aarch64
+        name: deploy-artifacts-pkl-doc-linux-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -650,7 +650,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-macOS-aarch64
+        name: deploy-artifacts-pkl-doc-macOS-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -767,7 +767,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-alpine-linux-amd64
+        name: deploy-artifacts-pkl-doc-alpine-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -812,7 +812,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-windows-amd64
+        name: deploy-artifacts-pkl-doc-windows-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -860,7 +860,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-amd64
+        name: deploy-artifacts-libpkl-linux-amd64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -910,7 +910,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-aarch64
+        name: deploy-artifacts-libpkl-linux-aarch64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -959,7 +959,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-macOS-aarch64
+        name: deploy-artifacts-libpkl-macOS-aarch64
         path: libpkl*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1076,7 +1076,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-alpine-linux-amd64
+        name: deploy-artifacts-libpkl-alpine-linux-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1123,7 +1123,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-windows-amd64
+        name: deploy-artifacts-libpkl-windows-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,7 +192,7 @@ jobs:
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: executable-java
+        name: deploy-artifacts-java-executables
         path: '*/build/executable/**/*'
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -240,7 +240,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-amd64
+        name: deploy-artifacts-pkl-cli-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -290,7 +290,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-aarch64
+        name: deploy-artifacts-pkl-cli-linux-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -339,7 +339,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-macOS-aarch64
+        name: deploy-artifacts-pkl-cli-macOS-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -456,7 +456,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-alpine-linux-amd64
+        name: deploy-artifacts-pkl-cli-alpine-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -501,7 +501,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-windows-amd64
+        name: deploy-artifacts-pkl-cli-windows-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -549,7 +549,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-amd64
+        name: deploy-artifacts-pkl-doc-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -599,7 +599,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-aarch64
+        name: deploy-artifacts-pkl-doc-linux-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -648,7 +648,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-macOS-aarch64
+        name: deploy-artifacts-pkl-doc-macOS-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -765,7 +765,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-alpine-linux-amd64
+        name: deploy-artifacts-pkl-doc-alpine-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -810,7 +810,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-windows-amd64
+        name: deploy-artifacts-pkl-doc-windows-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -858,7 +858,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-amd64
+        name: deploy-artifacts-libpkl-linux-amd64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -908,7 +908,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-aarch64
+        name: deploy-artifacts-libpkl-linux-aarch64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -957,7 +957,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-macOS-aarch64
+        name: deploy-artifacts-libpkl-macOS-aarch64
         path: libpkl*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1074,7 +1074,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-alpine-linux-amd64
+        name: deploy-artifacts-libpkl-alpine-linux-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1121,7 +1121,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-windows-amd64
+        name: deploy-artifacts-libpkl-windows-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1186,7 +1186,7 @@ jobs:
         persist-credentials: false
     - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
       with:
-        pattern: executable-**
+        pattern: deploy-artifacts-**
         merge-multiple: true
     - env:
         ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-amd64
+        name: deploy-artifacts-pkl-cli-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -178,7 +178,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-aarch64
+        name: deploy-artifacts-pkl-cli-linux-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -228,7 +228,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-macOS-aarch64
+        name: deploy-artifacts-pkl-cli-macOS-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -347,7 +347,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-alpine-linux-amd64
+        name: deploy-artifacts-pkl-cli-alpine-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -394,7 +394,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-windows-amd64
+        name: deploy-artifacts-pkl-cli-windows-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -444,7 +444,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-amd64
+        name: deploy-artifacts-pkl-doc-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -496,7 +496,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-aarch64
+        name: deploy-artifacts-pkl-doc-linux-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -546,7 +546,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-macOS-aarch64
+        name: deploy-artifacts-pkl-doc-macOS-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -665,7 +665,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-alpine-linux-amd64
+        name: deploy-artifacts-pkl-doc-alpine-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -712,7 +712,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-windows-amd64
+        name: deploy-artifacts-pkl-doc-windows-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -762,7 +762,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-amd64
+        name: deploy-artifacts-libpkl-linux-amd64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -814,7 +814,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-aarch64
+        name: deploy-artifacts-libpkl-linux-aarch64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -864,7 +864,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-macOS-aarch64
+        name: deploy-artifacts-libpkl-macOS-aarch64
         path: libpkl*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -983,7 +983,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-alpine-linux-amd64
+        name: deploy-artifacts-libpkl-alpine-linux-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1032,7 +1032,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-windows-amd64
+        name: deploy-artifacts-libpkl-windows-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -192,7 +192,7 @@ jobs:
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: executable-java
+        name: deploy-artifacts-java-executables
         path: '*/build/executable/**/*'
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -240,7 +240,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-amd64
+        name: deploy-artifacts-pkl-cli-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -290,7 +290,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-aarch64
+        name: deploy-artifacts-pkl-cli-linux-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -339,7 +339,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-macOS-aarch64
+        name: deploy-artifacts-pkl-cli-macOS-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -456,7 +456,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-alpine-linux-amd64
+        name: deploy-artifacts-pkl-cli-alpine-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -501,7 +501,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-windows-amd64
+        name: deploy-artifacts-pkl-cli-windows-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -549,7 +549,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-amd64
+        name: deploy-artifacts-pkl-doc-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -599,7 +599,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-aarch64
+        name: deploy-artifacts-pkl-doc-linux-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -648,7 +648,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-macOS-aarch64
+        name: deploy-artifacts-pkl-doc-macOS-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -765,7 +765,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-alpine-linux-amd64
+        name: deploy-artifacts-pkl-doc-alpine-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -810,7 +810,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-windows-amd64
+        name: deploy-artifacts-pkl-doc-windows-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -858,7 +858,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-amd64
+        name: deploy-artifacts-libpkl-linux-amd64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -908,7 +908,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-aarch64
+        name: deploy-artifacts-libpkl-linux-aarch64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -957,7 +957,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-macOS-aarch64
+        name: deploy-artifacts-libpkl-macOS-aarch64
         path: libpkl*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1074,7 +1074,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-alpine-linux-amd64
+        name: deploy-artifacts-libpkl-alpine-linux-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1121,7 +1121,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-windows-amd64
+        name: deploy-artifacts-libpkl-windows-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
     - name: Upload executable artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: executable-java
+        name: deploy-artifacts-java-executables
         path: '*/build/executable/**/*'
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -242,7 +242,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-amd64
+        name: deploy-artifacts-pkl-cli-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -293,7 +293,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-linux-aarch64
+        name: deploy-artifacts-pkl-cli-linux-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -343,7 +343,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-macOS-aarch64
+        name: deploy-artifacts-pkl-cli-macOS-aarch64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -461,7 +461,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-alpine-linux-amd64
+        name: deploy-artifacts-pkl-cli-alpine-linux-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -507,7 +507,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-cli-windows-amd64
+        name: deploy-artifacts-pkl-cli-windows-amd64
         path: pkl-cli*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -556,7 +556,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-amd64
+        name: deploy-artifacts-pkl-doc-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -607,7 +607,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-linux-aarch64
+        name: deploy-artifacts-pkl-doc-linux-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -657,7 +657,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-macOS-aarch64
+        name: deploy-artifacts-pkl-doc-macOS-aarch64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -775,7 +775,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-alpine-linux-amd64
+        name: deploy-artifacts-pkl-doc-alpine-linux-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -821,7 +821,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-pkl-doc-windows-amd64
+        name: deploy-artifacts-pkl-doc-windows-amd64
         path: pkl-doc*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -870,7 +870,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-amd64
+        name: deploy-artifacts-libpkl-linux-amd64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -921,7 +921,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-linux-aarch64
+        name: deploy-artifacts-libpkl-linux-aarch64
         path: libpkl/build/native-libs/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -971,7 +971,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-macOS-aarch64
+        name: deploy-artifacts-libpkl-macOS-aarch64
         path: libpkl*/build/executable/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1089,7 +1089,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-alpine-linux-amd64
+        name: deploy-artifacts-libpkl-alpine-linux-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1137,7 +1137,7 @@ jobs:
     - name: Upload built artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: artifacts-libpkl-windows-amd64
+        name: deploy-artifacts-libpkl-windows-amd64
         path: libpkl*/build/distributions/**/*
     - name: Upload Test Result XML
       if: '!cancelled()'
@@ -1203,7 +1203,7 @@ jobs:
         persist-credentials: false
     - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
       with:
-        pattern: executable-**
+        pattern: deploy-artifacts-**
         merge-multiple: true
     - env:
         ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
@@ -1220,7 +1220,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
       with:
-        pattern: executable-**
+        pattern: deploy-artifacts-**
         merge-multiple: true
     - name: Publish release on GitHub
       env:
@@ -1229,15 +1229,12 @@ jobs:
         GIT_SHA: ${{ github.sha }}
         GH_REPO: ${{ github.repository }}
       run: |-
-        # exclude build_artifacts.txt from publish
-        rm -f */build/executable/*.build_artifacts.txt
-        find */build/executable/* -type d | xargs rm -rf
         gh release create ${TAG_NAME} \
           --title "${TAG_NAME}" \
           --target "${GIT_SHA}" \
           --verify-tag \
           --notes "Release notes: https://pkl-lang.org/main/current/release-notes/changelog.html#release-${TAG_NAME}" \
-          */build/executable/*
+          */build/executable/* */build/distributions/*
   publish-test-results:
     if: '!cancelled()'
     needs:

--- a/build-logic/src/main/kotlin/NativeImageBuild.kt
+++ b/build-logic/src/main/kotlin/NativeImageBuild.kt
@@ -13,8 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import javax.inject.Inject
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
@@ -165,14 +170,20 @@ abstract class NativeImageBuild : DefaultTask() {
   }
 
   @TaskAction
-  @Suppress("unused")
   protected fun run() {
-    execOperations.exec {
+    val workingDir =
+      project.layout.buildDirectory
+        .dir("tmp/native-image-build/${name}")
+        .get()
+        .asFile
+        .toPath()
+        .also { it.createDirectories() }
+    val execResult = execOperations.exec {
       val exclusions =
         listOf(buildInfo.libs.findLibrary("graalSdk").get()).map { it.get().module.name }
 
       executable = nativeImageExecutable.get()
-      workingDir(outputDir)
+      workingDir(workingDir)
 
       args = buildList {
         add("--color=always")
@@ -239,6 +250,18 @@ abstract class NativeImageBuild : DefaultTask() {
         addAll(environment.keys.filter { it.startsWith("HOMEBREW_") }.map { "-E$it" })
         addAll(extraNativeImageArgs.get())
         addAll(extraArgsFromProperties)
+      }
+    }
+
+    if (execResult.exitValue == 0) {
+      val outputFileNames = getEffectiveOutputFiles().files.map { it.name }
+      for (fileName in outputFileNames) {
+        val sourceFile = workingDir.resolve(fileName)
+        val targetFile = outputDir.get().asFile.toPath().resolve(fileName)
+        if (!sourceFile.exists()) {
+          throw GradleException("Expected to find $fileName in the working dir but didn't")
+        }
+        Files.copy(sourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING)
       }
     }
   }


### PR DESCRIPTION
* Fix issue where the DeployJob and GithubRelease jobs download artifacts using a glob that only matches one artifact
* Make NativeImageBuild task only produce outputs as declared by build; ensure there's no build_artifacts.txt, sources/ dir, etc.