### PR TITLE
Suppress pkl-gradle POM metadata warning

### DIFF
--- a/pkl-gradle/pkl-gradle.gradle.kts
+++ b/pkl-gradle/pkl-gradle.gradle.kts
@@ -123,6 +123,10 @@ tasks.test {
 publishing {
   publications {
     withType<MavenPublication>().configureEach {
+      if (name == "pluginMaven") {
+        // Maven cannot express the shadowed bundling attribute on the pkl-tools dependency.
+        suppressPomMetadataWarningsFor("runtimeElements")
+      }
       pom {
         name = "pkl-gradle plugin"
         url = "https://github.com/apple/pkl/tree/main/pkl-gradle"


### PR DESCRIPTION
Fixes #1743

## Summary

The `pkl-gradle` plugin intentionally requests the shadowed `pkl-tools` runtime variant. Gradle module metadata preserves that bundling attribute, but Maven POM metadata cannot represent it fully, so Gradle reports a compatibility warning when generating the `pluginMaven` POM.

Suppress the warning only for the `runtimeElements` variant of `pluginMaven`. Other publications and variants are unaffected.

## Verification

- Reproduced the warning from a clean, current `upstream/main` checkout.
- Repeated the same POM-generation command after the change and confirmed the warning is absent.
- Ran `:pkl-gradle:validatePom`, `:pkl-gradle:spotlessCheck`, and `:pkl-gradle:build` successfully.
- Compared the generated POM and Gradle module metadata with the baseline; both files are byte-for-byte identical.
- Published the plugin and plugin marker to an isolated Maven-local repository using a temporary test signing key, then verified the POM, module metadata, JARs, marker, and signatures.
- Ran the Sonatype publication path with `--dry-run`; no artifacts were uploaded.
- Ran `git diff --check`.