### PR TITLE
Enforce trust levels on resource reads

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/SecurityManager.java
+++ b/pkl-core/src/main/java/org/pkl/core/SecurityManager.java
@@ -35,8 +35,8 @@ public interface SecurityManager {
   /** Checks if the given importing module may import the given imported module. */
   void checkImportModule(URI importingModule, URI importedModule) throws SecurityManagerException;
 
-  /** Checks if the given resource may be read. */
-  void checkReadResource(URI resource) throws SecurityManagerException;
+  /** Checks if the given reading module may read the given resource . */
+  void checkReadResource(URI readingModule, URI resource) throws SecurityManagerException;
 
   /**
    * Checks if the given resource may be resolved. This check is required before any attempt is made

--- a/pkl-core/src/main/java/org/pkl/core/SecurityManagers.java
+++ b/pkl-core/src/main/java/org/pkl/core/SecurityManagers.java
@@ -155,19 +155,29 @@ public final class SecurityManagers {
     }
 
     @Override
-    public void checkReadResource(URI uri) throws SecurityManagerException {
+    public void checkReadResource(URI readingModule, URI uri) throws SecurityManagerException {
+      var importingTrustLevel = trustLevels.apply(readingModule);
+      var importedTrustLevel = trustLevels.apply(uri);
+
+      if (importingTrustLevel < importedTrustLevel) {
+        var message =
+            ErrorMessages.create(
+                "insufficientTrustLevel", uri, readingModule, "read resource", "reading");
+        throw new SecurityManagerException(message);
+      }
+
       checkRead(uri, allowedResources, true);
     }
 
     @Override
-    public void checkImportModule(URI importingModule, URI importedModule)
-        throws SecurityManagerException {
+    public void checkImportModule(URI importingModule, URI uri) throws SecurityManagerException {
       var importingTrustLevel = trustLevels.apply(importingModule);
-      var importedTrustLevel = trustLevels.apply(importedModule);
+      var importedTrustLevel = trustLevels.apply(uri);
 
       if (importingTrustLevel < importedTrustLevel) {
         var message =
-            ErrorMessages.create("insufficientModuleTrustLevel", importedModule, importingModule);
+            ErrorMessages.create(
+                "insufficientTrustLevel", uri, importingModule, "import module", "importing");
         throw new SecurityManagerException(message);
       }
     }

--- a/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/builder/AstBuilder.java
@@ -1957,16 +1957,15 @@ public class AstBuilder extends AbstractAstBuilder<Object> {
                         scope.getName(),
                         scope.getConstLevel() == ConstLevel.ALL));
           } else { // no value given
-            if (isLocal) {
-              assert typeAnnotation != null;
-              throw missingLocalPropertyValue(typeAnnotation);
-            }
             if (VmModifier.isExternal(modifiers)) {
               bodyNode =
                   externalMemberRegistry.getPropertyBody(scope.getQualifiedName(), headerSection);
               if (bodyNode instanceof LanguageAwareNode languageAwareNode) {
                 languageAwareNode.initLanguage(language);
               }
+            } else if (isLocal) {
+              assert typeAnnotation != null;
+              throw missingLocalPropertyValue(typeAnnotation);
             } else {
               bodyNode = null; // will be given a default by UnresolvedPropertyNode
             }

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/unary/AbstractReadNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/unary/AbstractReadNode.java
@@ -53,7 +53,10 @@ public abstract class AbstractReadNode extends UnaryExpressionNode {
   @TruffleBoundary
   protected final @Nullable Object doRead(String resourceUri, VmContext context, Node readNode) {
     var resolvedUri = resolveResource(currentModule, resourceUri);
-    return context.getResourceManager().read(resolvedUri, readNode).orElse(null);
+    return context
+        .getResourceManager()
+        .read(currentModule.getUri(), resolvedUri, readNode)
+        .orElse(null);
   }
 
   private URI resolveResource(ModuleKey moduleKey, String resourceUri) {

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/unary/ReadGlobMemberBodyNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/unary/ReadGlobMemberBodyNode.java
@@ -20,6 +20,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 import java.util.Map;
 import org.pkl.core.ast.ExpressionNode;
+import org.pkl.core.module.ModuleKey;
 import org.pkl.core.runtime.VmContext;
 import org.pkl.core.runtime.VmObjectLike;
 import org.pkl.core.runtime.VmUtils;
@@ -27,8 +28,11 @@ import org.pkl.core.util.GlobResolver.ResolvedGlobElement;
 
 /** Used by {@link ReadGlobNode}. */
 public class ReadGlobMemberBodyNode extends ExpressionNode {
-  public ReadGlobMemberBodyNode(SourceSection sourceSection) {
+  private final ModuleKey currentModule;
+
+  public ReadGlobMemberBodyNode(SourceSection sourceSection, ModuleKey currentModule) {
     super(sourceSection);
+    this.currentModule = currentModule;
   }
 
   @Override
@@ -44,7 +48,11 @@ public class ReadGlobMemberBodyNode extends ExpressionNode {
     var globElement = VmUtils.getMapValue(globElements, path);
     assert globElement != null;
     var resourceUri = globElement.uri();
-    var resource = VmContext.get(this).getResourceManager().read(resourceUri, this).orElse(null);
+    var resource =
+        VmContext.get(this)
+            .getResourceManager()
+            .read(currentModule.getUri(), resourceUri, this)
+            .orElse(null);
     if (resource == null) {
       CompilerDirectives.transferToInterpreter();
       throw exceptionBuilder().evalError("cannotFindResource", resourceUri).build();

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/unary/ReadGlobNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/unary/ReadGlobNode.java
@@ -58,7 +58,7 @@ public abstract class ReadGlobNode extends AbstractReadNode {
               "",
               language,
               new FrameDescriptor(),
-              new ReadGlobMemberBodyNode(sourceSection));
+              new ReadGlobMemberBodyNode(sourceSection, currentModule));
     }
     return memberNode;
   }

--- a/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
+++ b/pkl-core/src/main/java/org/pkl/core/packages/PackageResolvers.java
@@ -198,13 +198,13 @@ final class PackageResolvers {
       }
 
       // treat package assets as resources instead of modules
-      securityManager.checkReadResource(uri);
+      securityManager.checkResolveResource(uri);
       var request = HttpRequest.newBuilder(uri).build();
       HttpResponse<InputStream> response;
       try {
         response =
             httpClient.send(
-                request, BodyHandlers.ofInputStream(), securityManager::checkReadResource);
+                request, BodyHandlers.ofInputStream(), securityManager::checkResolveResource);
       } catch (IOException e) {
         throw new PackageLoadError(e, "ioErrorMakingHttpGet", uri, e.getMessage());
       }

--- a/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaders.java
+++ b/pkl-core/src/main/java/org/pkl/core/resource/ResourceReaders.java
@@ -357,7 +357,7 @@ public final class ResourceReaders {
         var request = HttpRequest.newBuilder(uri).build();
         var response =
             httpClient.send(
-                request, BodyHandlers.ofByteArray(), securityManager::checkReadResource);
+                request, BodyHandlers.ofByteArray(), securityManager::checkResolveResource);
         if (response.statusCode() == 404) return Optional.empty();
         HttpUtils.checkHasStatusCode200(response);
         return Optional.of(new Resource(uri, response.body()));
@@ -550,7 +550,7 @@ public final class ResourceReaders {
       if (local != null) {
         var resourceManager = VmContext.get(null).getResourceManager();
         var securityManager = VmContext.get(null).getSecurityManager();
-        securityManager.checkReadResource(local);
+        securityManager.checkResolveResource(local);
         var reader = resourceManager.getResourceReader(local);
         if (reader == null) {
           throw new VmExceptionBuilder()

--- a/pkl-core/src/main/java/org/pkl/core/runtime/CommandModule.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/CommandModule.java
@@ -59,6 +59,10 @@ public final class CommandModule extends StdLibModule {
     return ImportClass.instance;
   }
 
+  public static VmClass getReadClass() {
+    return ReadClass.instance;
+  }
+
   private static final class CommandInfoClass {
     static final VmClass instance = loadClass("CommandInfo");
   }
@@ -85,6 +89,10 @@ public final class CommandModule extends StdLibModule {
 
   private static final class ImportClass {
     static final VmClass instance = loadClass("Import");
+  }
+
+  private static final class ReadClass {
+    static final VmClass instance = loadClass("Read");
   }
 
   @TruffleBoundary

--- a/pkl-core/src/main/java/org/pkl/core/runtime/CommandSpecParser.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/CommandSpecParser.java
@@ -60,6 +60,7 @@ import org.pkl.core.ast.member.ObjectMember;
 import org.pkl.core.ast.type.TypeNode;
 import org.pkl.core.ast.type.UnresolvedTypeNode;
 import org.pkl.core.externalreader.ExternalReaderProcessException;
+import org.pkl.core.http.HttpClientException;
 import org.pkl.core.module.ModuleKeys;
 import org.pkl.core.module.ResolvedModuleKey;
 import org.pkl.core.util.EconomicMaps;
@@ -487,14 +488,17 @@ public final class CommandSpecParser {
               ? null
               : VmUtils.readMember(annotation, Identifier.CONVERT) instanceof VmFunction func
                   ? (rawValue, workingDirUri) ->
-                      handleBadValue(() -> handleImports(func.apply(rawValue), workingDirUri))
+                      handleBadValue(
+                          () -> handleImportsAndReads(func.apply(rawValue), workingDirUri))
                   : null,
           annotation == null
               ? null
               : VmUtils.readMember(annotation, Identifier.TRANSFORM_ALL) instanceof VmFunction func
                   ? (values, workingDirUri) ->
                       handleBadValue(
-                          () -> handleImports(func.apply(VmList.create(values)), workingDirUri))
+                          () ->
+                              handleImportsAndReads(
+                                  func.apply(VmList.create(values)), workingDirUri))
                   : null,
           annotation == null
               ? null
@@ -1061,15 +1065,12 @@ public final class CommandSpecParser {
   }
 
   // endregion
-  // region dynamic import handling
+  // region dynamic import/read handling
 
-  private static boolean isImport(VmTyped value) {
-    return value.getVmClass() == CommandModule.getImportClass();
-  }
-
-  private static boolean isImport(Object value) {
+  private static boolean isImportOrRead(Object value) {
     return value instanceof VmTyped vmTyped
-        && vmTyped.getVmClass() == CommandModule.getImportClass();
+        && (vmTyped.getVmClass() == CommandModule.getImportClass()
+            || vmTyped.getVmClass() == CommandModule.getReadClass());
   }
 
   // handle errors from convert/transformAll and correctly format them for the CLI
@@ -1101,79 +1102,83 @@ public final class CommandSpecParser {
     }
   }
 
+  private Object handleImportOrRead(Object val, URI workingDirUri) {
+    if (!(val instanceof VmTyped vmTyped)) return val;
+    if (vmTyped.getVmClass() == CommandModule.getImportClass()) {
+      return handleImport(vmTyped, workingDirUri);
+    }
+    if (vmTyped.getVmClass() == CommandModule.getReadClass()) {
+      return handleRead(vmTyped, workingDirUri);
+    }
+    return val;
+  }
+
   // for convert, handle imports by replacing Command.Import values
   // with imported module or Mapping<String, Module> values
   // Command.Import instances in returned Pair, List, Set, or Map values are replaced as well
   // other types or nested instances of the above are not affected
-  private Object handleImports(Object result, URI workingDirUri) {
-    if (result instanceof VmTyped vmTyped && isImport(vmTyped)) {
-      return handleImport(vmTyped, workingDirUri);
-    } else if (result instanceof VmPair vmPair) {
-      if (!isImport(vmPair.getFirst()) && !isImport(vmPair.getSecond())) {
+  private Object handleImportsAndReads(Object result, URI workingDirUri) {
+    if (result instanceof VmPair vmPair) {
+      if (!isImportOrRead(vmPair.getFirst()) && !isImportOrRead(vmPair.getSecond())) {
         return vmPair;
       }
       return new VmPair(
-          isImport(vmPair.getFirst())
-              ? handleImport((VmTyped) vmPair.getFirst(), workingDirUri)
-              : vmPair.getFirst(),
-          isImport(vmPair.getSecond())
-              ? handleImport((VmTyped) vmPair.getSecond(), workingDirUri)
-              : vmPair.getSecond());
+          handleImportOrRead(vmPair.getFirst(), workingDirUri),
+          handleImportOrRead(vmPair.getSecond(), workingDirUri));
     } else if (result instanceof VmCollection vmCollection) {
       for (var elem : vmCollection) {
-        if (isImport(elem)) {
+        if (isImportOrRead(elem)) {
           var builder = vmCollection.builder();
-          vmCollection.forEach(
-              it -> builder.add(isImport(it) ? handleImport((VmTyped) it, workingDirUri) : it));
+          vmCollection.forEach(it -> builder.add(handleImportOrRead(it, workingDirUri)));
           return builder.build();
         }
       }
       return vmCollection;
     } else if (result instanceof VmMap vmMap) {
       for (var entry : vmMap) {
-        if (isImport(entry.getKey()) || isImport(entry.getValue())) {
+        if (isImportOrRead(entry.getKey()) || isImportOrRead(entry.getValue())) {
           var builder = VmMap.builder();
           vmMap.forEach(
               it ->
                   builder.add(
-                      isImport(it.getKey())
-                          ? handleImport((VmTyped) it.getKey(), workingDirUri)
-                          : it.getKey(),
-                      isImport(it.getValue())
-                          ? handleImport((VmTyped) it.getValue(), workingDirUri)
-                          : it.getValue()));
+                      handleImportOrRead(it.getKey(), workingDirUri),
+                      handleImportOrRead(it.getValue(), workingDirUri)));
           return builder.build();
         }
       }
     }
-    return result;
+    return handleImportOrRead(result, workingDirUri);
   }
 
-  private Object handleImport(VmTyped mport, URI workingDirUri) {
-    var moduleName = (String) VmUtils.readMember(mport, Identifier.URI);
-    String uriString;
+  private URI getModuleUriString(
+      VmTyped directive, URI workingDirUri, String errorKey, boolean checkTripleDot) {
+    var name = (String) VmUtils.readMember(directive, Identifier.URI);
+
+    if (checkTripleDot && name.startsWith("...")) {
+      throw exceptionBuilder().evalError("cannotGlobTripleDots").build();
+    }
+
     // Ported from org.pkl.cli.commons.cli.commands.BaseOptions:
     try {
       // Can't just use URI constructor, because URI(null, null, "C:/foo/bar", null) turns
       // into `URI("C", null, "/foo/bar", null)`.
       @SuppressWarnings("DuplicateExpressions")
       var uri =
-          IoUtils.isUriLike(moduleName)
-              ? new URI(moduleName)
-              : IoUtils.isWindows() && IoUtils.isWindowsAbsolutePath(moduleName)
-                  ? Path.of(moduleName).toUri()
-                  : new URI(null, null, IoUtils.toNormalizedPathString(Path.of(moduleName)), null);
-      uriString =
-          uri.isAbsolute() ? uri.toString() : IoUtils.resolve(workingDirUri, uri).toString();
+          IoUtils.isUriLike(name)
+              ? new URI(name)
+              : IoUtils.isWindows() && IoUtils.isWindowsAbsolutePath(name)
+                  ? Path.of(name).toUri()
+                  : new URI(null, null, IoUtils.toNormalizedPathString(Path.of(name)), null);
+      return uri.isAbsolute() ? uri : IoUtils.resolve(workingDirUri, uri);
     } catch (URISyntaxException e) {
-      throw exceptionBuilder()
-          .evalError("invalidModuleUri", moduleName)
-          .withHint(e.getReason())
-          .build();
+      throw exceptionBuilder().evalError(errorKey, name).withHint(e.getReason()).build();
     }
+  }
 
+  private Object handleImport(VmTyped mport, URI workingDirUri) {
+    var importUri = getModuleUriString(mport, workingDirUri, "invalidModuleUri", false);
+    var uriString = importUri.toString();
     var isGlob = (Boolean) VmUtils.readMember(mport, Identifier.GLOB);
-    var importUri = URI.create(uriString);
     var language = VmLanguage.get(null);
 
     // non-glob
@@ -1211,6 +1216,51 @@ public final class CommandSpecParser {
           .evalError("invalidGlobPattern", uriString)
           .withHint(e.getMessage())
           .build();
+    }
+  }
+
+  private Object handleRead(VmTyped read, URI workingDirUri) {
+    var type = (String) VmUtils.readMember(read, Identifier.TYPE);
+    var isGlob = "glob".equals(type);
+    var uri = getModuleUriString(read, workingDirUri, "invalidResourceUri", isGlob);
+    var uriString = uri.toString();
+    var context = VmContext.get(null);
+
+    // non-glob
+    if (!isGlob) {
+      var resource = context.getResourceManager().read(REPL_TEXT_URI, uri, null);
+      if ("nullable".equals(type)) return resource.orElse(VmNull.withoutDefault());
+      if (resource.isEmpty()) {
+        throw exceptionBuilder().evalError("cannotFindResource", uriString).build();
+      }
+      return resource.get();
+    }
+
+    // glob
+    try {
+      var reader = context.getResourceManager().getReader(uri, null);
+      if (!reader.isGlobbable()) {
+        throw exceptionBuilder().evalError("cannotGlobUri", uri, uri.getScheme()).build();
+      }
+      var resolvedElements =
+          GlobResolver.resolveGlob(context.getSecurityManager(), reader, null, null, uriString);
+
+      var builder = new VmObjectBuilder(resolvedElements.size());
+      for (var entry : resolvedElements.entrySet()) {
+        builder.addEntry(entry.getKey(), reader.read(entry.getValue().uri()));
+      }
+      return builder.toMapping(resolvedElements);
+    } catch (IOException e) {
+      throw exceptionBuilder().evalError("ioErrorResolvingGlob", uriString).withCause(e).build();
+    } catch (SecurityManagerException | HttpClientException | URISyntaxException e) {
+      throw exceptionBuilder().withCause(e).build();
+    } catch (InvalidGlobPatternException e) {
+      throw exceptionBuilder()
+          .evalError("invalidGlobPattern", uriString)
+          .withHint(e.getMessage())
+          .build();
+    } catch (ExternalReaderProcessException e) {
+      throw exceptionBuilder().evalError("externalReaderFailure").withCause(e).build();
     }
   }
 

--- a/pkl-core/src/main/java/org/pkl/core/runtime/Identifier.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/Identifier.java
@@ -161,6 +161,7 @@ public final class Identifier implements Comparable<Identifier> {
   public static final Identifier CONVERT = get("convert");
   public static final Identifier TRANSFORM_ALL = get("transformAll");
   public static final Identifier GLOB = get("glob");
+  public static final Identifier TYPE = get("type");
   public static final Identifier COMPLETION_CANDIDATES = get("completionCandidates");
 
   public static final Identifier ILLEGAL = get("`");

--- a/pkl-core/src/main/java/org/pkl/core/runtime/ResourceManager.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/ResourceManager.java
@@ -58,11 +58,11 @@ public final class ResourceManager {
   }
 
   @TruffleBoundary
-  public ResourceReader getReader(URI resourceUri, Node readNode) {
+  public ResourceReader getReader(URI resourceUri, @Nullable Node readNode) {
     var reader = resourceReaders.get(resourceUri.getScheme());
     if (reader == null) {
       throw new VmExceptionBuilder()
-          .withLocation(readNode)
+          .withOptionalLocation(readNode)
           .evalError("noResourceReaderRegistered", resourceUri.getScheme())
           .build();
     }
@@ -95,7 +95,7 @@ public final class ResourceManager {
   }
 
   @TruffleBoundary
-  public Optional<Object> read(URI resourceUri, @Nullable Node readNode) {
+  public Optional<Object> read(URI readingModule, URI resourceUri, @Nullable Node readNode) {
     return resources.computeIfAbsent(
         resourceUri.normalize(),
         (uri) -> {
@@ -105,7 +105,7 @@ public final class ResourceManager {
           if (!(reader instanceof ResourceReaders.HttpResource)
               && !(reader instanceof ResourceReaders.HttpsResource)) {
             try {
-              securityManager.checkReadResource(uri);
+              securityManager.checkReadResource(readingModule, uri);
             } catch (SecurityManagerException e) {
               throw new VmExceptionBuilder().withCause(e).withOptionalLocation(readNode).build();
             }

--- a/pkl-core/src/main/java/org/pkl/core/stdlib/base/ModuleClassNodes.java
+++ b/pkl-core/src/main/java/org/pkl/core/stdlib/base/ModuleClassNodes.java
@@ -21,6 +21,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import java.net.URI;
 import org.pkl.core.runtime.*;
 import org.pkl.core.stdlib.ExternalMethod1Node;
+import org.pkl.core.stdlib.ExternalPropertyNode;
 import org.pkl.core.stdlib.PklName;
 
 @PklName("Module")
@@ -57,6 +58,16 @@ public final class ModuleClassNodes {
       throw exceptionBuilder()
           .evalError("noDescendentPathBetweenModules", selfUri, otherUri)
           .build();
+    }
+  }
+
+  /** Bypass resource trust level check when determining the output format */
+  public abstract static class outputFormat extends ExternalPropertyNode {
+    @Specialization
+    protected Object eval(VmObjectLike self) {
+      var context = VmContext.get(this);
+      var outputFormat = context.getExternalProperties().get("pkl.outputFormat");
+      return outputFormat != null ? outputFormat : VmNull.withoutDefault();
     }
   }
 }

--- a/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
+++ b/pkl-core/src/main/resources/org/pkl/core/errorMessages.properties
@@ -727,8 +727,8 @@ Refusing to read resource `{0}` because it is not within the root directory (`--
 modulePastRootDir=\
 Refusing to load module `{0}` because it is not within the root directory (`--root-dir`).
 
-insufficientModuleTrustLevel=\
-Refusing to import module `{0}` because importing module `{1}` has an insufficient trust level.
+insufficientTrustLevel=\
+Refusing to {2} `{0}` because {3} module `{1}` has an insufficient trust level.
 
 invalidRegexSyntax=\
 Syntax error in regex `{0}`: {1}

--- a/pkl-core/src/test/kotlin/org/pkl/core/SecurityManagersTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/SecurityManagersTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,30 +63,32 @@ class SecurityManagersTest {
   }
 
   @Test
-  fun `checkReadResource() - complete match`() {
-    val e = catchThrowable { manager.checkReadResource(URI("env:FOO_BAR")) }
+  fun `checkResolveResource - complete match`() {
+    val e = catchThrowable { manager.checkResolveResource(URI("env:FOO_BAR")) }
     assertThat(e).doesNotThrowAnyException()
   }
 
   @Test
-  fun `checkReadResource() - partial match from start`() {
-    val e = catchThrowable { manager.checkReadResource(URI("env:FOO_BAR_BAZ")) }
+  fun `checkResolveResource - partial match from start`() {
+    val e = catchThrowable { manager.checkResolveResource(URI("env:FOO_BAR_BAZ")) }
     assertThat(e).doesNotThrowAnyException()
   }
 
   @Test
-  fun `checkReadResource() - partial match not from start`() {
-    assertThrows<SecurityManagerException> { manager.checkReadResource(URI("other:env:FOO_BAR")) }
+  fun `checkResolveResource - partial match not from start`() {
+    assertThrows<SecurityManagerException> {
+      manager.checkResolveResource(URI("other:env:FOO_BAR"))
+    }
   }
 
   @Test
-  fun `checkReadResource() - no match`() {
-    assertThrows<SecurityManagerException> { manager.checkReadResource(URI("other:uri")) }
+  fun `checkResolveResource - no match`() {
+    assertThrows<SecurityManagerException> { manager.checkResolveResource(URI("other:uri")) }
   }
 
   @Test
-  fun `checkReadResource() - no match #2`() {
-    assertThrows<SecurityManagerException> { manager.checkReadResource(URI("env:FOO_BAZ")) }
+  fun `checkResolveResource - no match #2`() {
+    assertThrows<SecurityManagerException> { manager.checkResolveResource(URI("env:FOO_BAZ")) }
   }
 
   @Test
@@ -148,10 +150,10 @@ class SecurityManagersTest {
     val path = rootDir.resolve("baz.pkl")
     Files.createFile(path)
     manager.checkResolveModule(path.toUri())
-    manager.checkReadResource(path.toUri())
+    manager.checkResolveResource(path.toUri())
 
     manager.checkResolveModule(rootDir.toUri().resolve("qux/../baz.pkl"))
-    manager.checkReadResource(rootDir.toUri().resolve("qux/../baz.pkl"))
+    manager.checkResolveResource(rootDir.toUri().resolve("qux/../baz.pkl"))
   }
 
   @Test
@@ -167,10 +169,10 @@ class SecurityManagersTest {
       )
 
     manager.checkResolveModule(Path.of("/foo/bar/baz.pkl").toUri())
-    manager.checkReadResource(Path.of("/foo/bar/baz.pkl").toUri())
+    manager.checkResolveResource(Path.of("/foo/bar/baz.pkl").toUri())
 
     manager.checkResolveModule(Path.of("/foo/bar/qux/../baz.pkl").toUri())
-    manager.checkReadResource(Path.of("/foo/bar/qux/../baz.pkl").toUri())
+    manager.checkResolveResource(Path.of("/foo/bar/qux/../baz.pkl").toUri())
   }
 
   @Test
@@ -191,14 +193,14 @@ class SecurityManagersTest {
     val path = rootDir.resolve("../baz.pkl")
     Files.createFile(path)
     assertThrows<SecurityManagerException> { manager.checkResolveModule(path.toUri()) }
-    assertThrows<SecurityManagerException> { manager.checkReadResource(path.toUri()) }
+    assertThrows<SecurityManagerException> { manager.checkResolveResource(path.toUri()) }
 
     val symlink = rootDir.resolve("qux")
     Files.createSymbolicLink(symlink, tempDir)
     val path2 = symlink.resolve("baz2.pkl")
     Files.createFile(path2)
     assertThrows<SecurityManagerException> { manager.checkResolveModule(path2.toUri()) }
-    assertThrows<SecurityManagerException> { manager.checkReadResource(path2.toUri()) }
+    assertThrows<SecurityManagerException> { manager.checkResolveResource(path2.toUri()) }
   }
 
   @Test
@@ -217,14 +219,14 @@ class SecurityManagersTest {
       manager.checkResolveModule(Path.of("/foo/baz.pkl").toUri())
     }
     assertThrows<SecurityManagerException> {
-      manager.checkReadResource(Path.of("/foo/baz.pkl").toUri())
+      manager.checkResolveResource(Path.of("/foo/baz.pkl").toUri())
     }
 
     assertThrows<SecurityManagerException> {
       manager.checkResolveModule(Path.of("/foo/bar/../baz.pkl").toUri())
     }
     assertThrows<SecurityManagerException> {
-      manager.checkReadResource(Path.of("/foo/bar/../baz.pkl").toUri())
+      manager.checkResolveResource(Path.of("/foo/bar/../baz.pkl").toUri())
     }
   }
 }

--- a/pkl-core/src/test/kotlin/org/pkl/core/util/IoUtilsTest.kt
+++ b/pkl-core/src/test/kotlin/org/pkl/core/util/IoUtilsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class IoUtilsTest {
 
     override fun checkImportModule(importingModule: URI, importedModule: URI) {}
 
-    override fun checkReadResource(resource: URI) {}
+    override fun checkReadResource(readingModule: URI, resource: URI) {}
 
     override fun checkResolveResource(resource: URI) {}
   }

--- a/stdlib/Command.pkl
+++ b/stdlib/Command.pkl
@@ -259,6 +259,9 @@ class Argument extends Annotation {
 
 /// A value used in [Flag.convert], [Flag.transformAll], [Argument.convert], and
 /// [Argument.transformAll] functions to trigger a dynamic module import.
+///
+/// Imports are evaluated as if running in the Pkl REPL, so typical restrictions on remote modules
+/// importing local modules do not apply.
 class Import {
   /// The URI of the module to import.
   ///
@@ -270,6 +273,25 @@ class Import {
   /// When `false`, the replacement value is the value of the specified module.
   /// When `true`, the replacement value is a [Mapping] from [String] keys to matched module values. 
   glob: Boolean = false
+}
+
+/// A value used in [Flag.convert], [Flag.transformAll], [Argument.convert], and
+/// [Argument.transformAll] functions to trigger a dynamic resource read.
+///
+/// Reads are evaluated as if running in the Pkl REPL, so typical restrictions on remote modules
+/// reading local resources do not apply.
+class Read {
+  /// The URI of the resource to read.
+  ///
+  /// Relative paths are resolved relative to the current working directory.
+  uri: String
+
+  /// Resource read behavior.
+  ///
+  /// When `null`, the replacement is a [Resource] or [String]. Replacement fails if the resource does not exist.
+  /// When `"nullable"`, the replacement is a [Resource] or [String] if the resource exists and `null` if it does not.
+  /// When `"glob"`, the replacement value is a [Mapping] from [String] keys to matched [Resource] or [String] values.
+  type: ("glob" | "nullable")?
 }
 
 local const quantityRegex = Regex(#"([0-9]+(?:\.[0-9]+)?)\.?([A-Za-z]+)"#)

--- a/stdlib/base.pkl
+++ b/stdlib/base.pkl
@@ -95,6 +95,8 @@ abstract external class Module {
   /// path = rootModule.relativePathTo(module)
   /// ```
   external function relativePathTo(other: Module): List<String>
+  
+  external local outputFormat: String?
 
   /// The output of this module.
   ///
@@ -103,7 +105,7 @@ abstract external class Module {
   hidden output: ModuleOutput = new {
     value = outer
     renderer =
-      let (format = read?("prop:pkl.outputFormat") ?? "pcf")
+      let (format = outputFormat ?? "pcf")
         if (format == "json")
           new JsonRenderer {}
         else if (format == "jsonnet")


### PR DESCRIPTION
* Add `pkl.Command#Read` class to trigger dynamic reads not subject to trust level checks during command option parsing.
* Switch `pkl.Base#Module` to read the `pkl.outputFormat` property via a local external property since this is otherwise a trust level violation.

TODO:
- [ ] test that untrusted reads fail
- [ ] test that `pkl.Command#Read` works as expected
- [ ] consider feature flagging and/or warn/enforce strategy/timing for this change
- [ ] address existing problematic (converter) modules in pkl-pantry

Resolves #1645