### PR TITLE
Respect fixed and const properties when converting Map or Dynamic to Typed

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
@@ -553,9 +553,10 @@ public final class VmClass extends VmValue {
       // Dynamic/Map->Typed conversion: Overall it seems more useful for the typed object
       // to inherit its prototype's value for the hidden property (e.g., Module.output).
       if (property.isHidden()) continue;
-      // Dynamic/Map->Typed conversion: a `fixed` property's value is fixed by its declaration,
-      // so it must not be overridden by whatever value happens to be in the source Dynamic/Map.
-      if (isConversionToTyped && property.isFixed()) continue;
+      // Dynamic/Map->Typed conversion: a `fixed` or `const` property's value is fixed by its
+      // declaration, so it must not be overridden by whatever value happens to be in the source
+      // Dynamic/Map.
+      if (isConversionToTyped && property.isConstOrFixed()) continue;
 
       var name = cursor.getKey();
       var member =

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmClass.java
@@ -497,6 +497,7 @@ public final class VmClass extends VmValue {
       if (__typedToDynamicMembers == null) {
         __typedToDynamicMembers =
             createDelegatingMembers(
+                false,
                 (member) ->
                     new UntypedObjectMemberNode(
                         null, new FrameDescriptor(), member, new DelegateToExtraStorageObjNode()));
@@ -512,6 +513,7 @@ public final class VmClass extends VmValue {
       if (__dynamicToTypedMembers == null) {
         __dynamicToTypedMembers =
             createDelegatingMembers(
+                true,
                 (member) ->
                     TypeCheckedPropertyNodeGen.create(
                         null,
@@ -530,6 +532,7 @@ public final class VmClass extends VmValue {
       if (__mapToTypedMembers == null) {
         __mapToTypedMembers =
             createDelegatingMembers(
+                true,
                 (member) ->
                     TypeCheckedPropertyNodeGen.create(
                         null,
@@ -542,7 +545,7 @@ public final class VmClass extends VmValue {
   }
 
   private EconomicMap<Object, ObjectMember> createDelegatingMembers(
-      Function<ObjectMember, MemberNode> memberNodeFactory) {
+      boolean isConversionToTyped, Function<ObjectMember, MemberNode> memberNodeFactory) {
     var result = EconomicMaps.<Object, ObjectMember>create();
     for (var cursor = getAllProperties().getEntries(); cursor.advance(); ) {
       var property = cursor.getValue();
@@ -550,6 +553,9 @@ public final class VmClass extends VmValue {
       // Dynamic/Map->Typed conversion: Overall it seems more useful for the typed object
       // to inherit its prototype's value for the hidden property (e.g., Module.output).
       if (property.isHidden()) continue;
+      // Dynamic/Map->Typed conversion: a `fixed` property's value is fixed by its declaration,
+      // so it must not be overridden by whatever value happens to be in the source Dynamic/Map.
+      if (isConversionToTyped && property.isFixed()) continue;
 
       var name = cursor.getKey();
       var member =

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/dynamic.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/dynamic.pkl
@@ -58,6 +58,7 @@ examples {
     module.catch(() -> obj.toTyped(Pair)) // Pair is not a Typed
     module.catch(() -> obj.toTyped(ValueRenderer)) // ValueRenderer is abstract
     (new Dynamic { name = "Pigeon"; id = 99 }).toTyped(FixedPerson)
+    (new Dynamic { name = "Pigeon"; id = 99 }).toTyped(ConstPerson)
   }
 }
 
@@ -94,4 +95,9 @@ local class Person {
 local class FixedPerson {
   name: String = "Default"
   fixed id: Int = 1
+}
+
+local class ConstPerson {
+  name: String = "Default"
+  const id: Int = 1
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/dynamic.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/dynamic.pkl
@@ -57,6 +57,7 @@ examples {
     module.catch(() -> new Dynamic { name = "Pigeon" }.toTyped(Person).age)
     module.catch(() -> obj.toTyped(Pair)) // Pair is not a Typed
     module.catch(() -> obj.toTyped(ValueRenderer)) // ValueRenderer is abstract
+    (new Dynamic { name = "Pigeon"; id = 99 }).toTyped(FixedPerson)
   }
 }
 
@@ -88,4 +89,9 @@ local futurePigeon = (pigeon) {
 local class Person {
   name: String = "Default"
   age: UInt
+}
+
+local class FixedPerson {
+  name: String = "Default"
+  fixed id: Int = 1
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/map.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/map.pkl
@@ -137,8 +137,10 @@ examples {
     module.catch(() -> Map("name", "Pigeon").toTyped(Person).age)
     module.catch(() -> Map().toTyped(Int))
     module.catch(() -> Map().toTyped(Abstract))
+    Map("name", "Pigeon", "id", 99).toTyped(FixedPerson)
   }
 }
 
 local class Person { name: String = "Default"; age: Int }
 local abstract class Abstract
+local class FixedPerson { name: String = "Default"; fixed id: Int = 1 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/map.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/map.pkl
@@ -138,9 +138,11 @@ examples {
     module.catch(() -> Map().toTyped(Int))
     module.catch(() -> Map().toTyped(Abstract))
     Map("name", "Pigeon", "id", 99).toTyped(FixedPerson)
+    Map("name", "Pigeon", "id", 99).toTyped(ConstPerson)
   }
 }
 
 local class Person { name: String = "Default"; age: Int }
 local abstract class Abstract
 local class FixedPerson { name: String = "Default"; fixed id: Int = 1 }
+local class ConstPerson { name: String = "Default"; const id: Int = 1 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/dynamic.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/dynamic.pcf
@@ -57,5 +57,9 @@ examples {
     "Tried to read property `age` but its value is undefined."
     "Class `Pair` is not a subtype of `Typed`."
     "Cannot instantiate abstract class `ValueRenderer`."
+    new {
+      name = "Pigeon"
+      id = 1
+    }
   }
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/dynamic.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/dynamic.pcf
@@ -61,5 +61,9 @@ examples {
       name = "Pigeon"
       id = 1
     }
+    new {
+      name = "Pigeon"
+      id = 1
+    }
   }
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/map.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/map.pcf
@@ -133,5 +133,9 @@ examples {
       name = "Pigeon"
       id = 1
     }
+    new {
+      name = "Pigeon"
+      id = 1
+    }
   }
 }

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/map.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/map.pcf
@@ -129,5 +129,9 @@ examples {
     "Tried to read property `age` but its value is undefined."
     "Class `Int` is not a subtype of `Typed`."
     "Cannot instantiate abstract class `map#Abstract`."
+    new {
+      name = "Pigeon"
+      id = 1
+    }
   }
 }


### PR DESCRIPTION
Reopens #1733. I accidentally closed that PR permanently by deleting my fork while cleaning up old repos, sorry for the churn. Same two commits, rebased onto current main (VmClass.java had not changed upstream, so the rebase was clean).

Recap of where the review stood:

- `.toTyped()` copied whatever value the source Dynamic/Map happened to contain into `fixed` properties, silently overriding the class declaration. Fixed by skipping such properties during conversion in `VmClass.createDelegatingMembers`, so the class's own value wins.
- @HT154 then showed the same bug applies to `const` properties. The second commit switches the check to the existing `Member.isConstOrFixed()`, matching how `GeneratorMemberNode` and `SpecializedObjectLiteralNode` already treat const and fixed as one category for override protection. Snippet tests cover both cases in `map.pkl` and `dynamic.pkl`.
- Open question from the review, unchanged: whether an override attempt should silently drop (current behavior of this PR) or hard-error like typed literal assignment does. @HT154 wanted input from other maintainers on that, and I'm happy to switch to erroring if that's the consensus.

Re-verified after the rebase: `./gradlew :pkl-core:test --tests "*LanguageSnippetTests*"` passes, the api input dir reports 158 tests, 0 failures.

DCO sign-off is on both commits.