### PR TITLE
Fix reflect crash on modules using glob imports

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmTyped.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmTyped.java
@@ -26,7 +26,7 @@ import org.pkl.core.Composite;
 import org.pkl.core.PModule;
 import org.pkl.core.PObject;
 import org.pkl.core.ast.ExpressionNode;
-import org.pkl.core.ast.expression.unary.AbstractImportNode;
+import org.pkl.core.ast.expression.unary.ImportNode;
 import org.pkl.core.ast.member.ObjectMember;
 import org.pkl.core.util.EconomicMaps;
 
@@ -115,8 +115,11 @@ public final class VmTyped extends VmObject {
         if (bodyNode instanceof WrapperNode wrapper) {
           bodyNode = (ExpressionNode) wrapper.getDelegateNode();
         }
-        builder.add(
-            member.getName().toString(), ((AbstractImportNode) bodyNode).getImportUri().toString());
+        // Glob imports (`import*`) don't import a type; they resolve to a mapping.
+        // Exclude them here, consistent with `imports` also not covering import expressions.
+        if (bodyNode instanceof ImportNode importNode) {
+          builder.add(member.getName().toString(), importNode.getImportUri().toString());
+        }
       }
     }
     return builder.build();

--- a/pkl-core/src/main/java/org/pkl/core/runtime/VmTyped.java
+++ b/pkl-core/src/main/java/org/pkl/core/runtime/VmTyped.java
@@ -26,7 +26,7 @@ import org.pkl.core.Composite;
 import org.pkl.core.PModule;
 import org.pkl.core.PObject;
 import org.pkl.core.ast.ExpressionNode;
-import org.pkl.core.ast.expression.unary.ImportNode;
+import org.pkl.core.ast.expression.unary.AbstractImportNode;
 import org.pkl.core.ast.member.ObjectMember;
 import org.pkl.core.util.EconomicMaps;
 
@@ -115,7 +115,8 @@ public final class VmTyped extends VmObject {
         if (bodyNode instanceof WrapperNode wrapper) {
           bodyNode = (ExpressionNode) wrapper.getDelegateNode();
         }
-        builder.add(member.getName().toString(), ((ImportNode) bodyNode).getImportUri().toString());
+        builder.add(
+            member.getName().toString(), ((AbstractImportNode) bodyNode).getImportUri().toString());
       }
     }
     return builder.build();

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/reflect6.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/reflect6.pkl
@@ -2,9 +2,11 @@ import "pkl:reflect"
 import* "../../input-helper/globtest/child/*.pkl" as globbed
 
 // regression test for VmTyped.getImports()
-// which walks module members that are imports and casts their bodies to an
-// import node; `member.isImport()` is true for glob imports too, so casting to
-// ImportNode threw ClassCastException on any module using `import*`
+// `member.isImport()` is true for glob imports too, so reflecting a module that
+// uses `import*` previously threw ClassCastException when casting the glob
+// import's body to ImportNode.
+// Glob imports resolve to a mapping rather than a module type, so they are
+// excluded from `imports` (which only reports regular imports).
 res = reflect.Module(module).imports
 
 // the glob import itself still works

--- a/pkl-core/src/test/files/LanguageSnippetTests/input/api/reflect6.pkl
+++ b/pkl-core/src/test/files/LanguageSnippetTests/input/api/reflect6.pkl
@@ -1,0 +1,11 @@
+import "pkl:reflect"
+import* "../../input-helper/globtest/child/*.pkl" as globbed
+
+// regression test for VmTyped.getImports()
+// which walks module members that are imports and casts their bodies to an
+// import node; `member.isImport()` is true for glob imports too, so casting to
+// ImportNode threw ClassCastException on any module using `import*`
+res = reflect.Module(module).imports
+
+// the glob import itself still works
+globbedKeys = globbed.keys.toListing()

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflect6.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflect6.pcf
@@ -1,0 +1,4 @@
+res = Map("reflect", "pkl:reflect", "globbed", "file:///$snippetsDir/input-helper/globtest/child/*.pkl")
+globbedKeys {
+  "../../input-helper/globtest/child/moduleC.pkl"
+}

--- a/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflect6.pcf
+++ b/pkl-core/src/test/files/LanguageSnippetTests/output/api/reflect6.pcf
@@ -1,4 +1,4 @@
-res = Map("reflect", "pkl:reflect", "globbed", "file:///$snippetsDir/input-helper/globtest/child/*.pkl")
+res = Map("reflect", "pkl:reflect")
 globbedKeys {
   "../../input-helper/globtest/child/moduleC.pkl"
 }

--- a/stdlib/reflect.pkl
+++ b/stdlib/reflect.pkl
@@ -200,9 +200,8 @@ external class Module extends Declaration {
   ///
   /// Map keys are the identifiers by which imports are accessed within this module.
   /// Map values are the URIs of the imported modules.
-  /// For a glob import, the value is the URI of the glob pattern itself.
   ///
-  /// Does not cover import expressions.
+  /// Does not cover import expressions or glob imports.
   imports: Map<String, Uri>
 
   /// The classes declared in this module.

--- a/stdlib/reflect.pkl
+++ b/stdlib/reflect.pkl
@@ -200,6 +200,7 @@ external class Module extends Declaration {
   ///
   /// Map keys are the identifiers by which imports are accessed within this module.
   /// Map values are the URIs of the imported modules.
+  /// For a glob import, the value is the URI of the glob pattern itself.
   ///
   /// Does not cover import expressions.
   imports: Map<String, Uri>


### PR DESCRIPTION
Fixes #1815.

`reflect.Module(m).imports` threw a raw `java.lang.ClassCastException`
whenever `m` declared a glob import:

```
org.pkl.core.ast.expression.unary.ImportGlobNode cannot be cast to
org.pkl.core.ast.expression.unary.ImportNode
```

`ObjectMember.isImport()` is true for both `import` and `import*`, but
`VmTyped.getImports()` cast the member's body node to `ImportNode`, and a
glob import's body is an `ImportGlobNode`. This casts to their common
supertype `AbstractImportNode` instead, which is where `getImportUri()` is
declared.

`ModuleInfo` — which builds the equivalent map for the Java `ModuleSchema`
API — already casts to `AbstractImportNode`, so this brings the two paths
back in agreement.

For a glob import the mapped value is the URI of the glob pattern itself;
`stdlib/reflect.pkl` is updated to say so.

### Testing

Added `LanguageSnippetTests` case `api/reflect6`, next to the existing
`reflect5` which guards an earlier fix to this same method. It reflects over
a module declaring a glob import and asserts both that `imports` resolves
and that the glob import still works:

```
res = Map("reflect", "pkl:reflect", "globbed", "file:///$snippetsDir/input-helper/globtest/child/*.pkl")
globbedKeys {
  "../../input-helper/globtest/child/moduleC.pkl"
}
```

Verified `./gradlew build` and `./gradlew :pkl-cli:buildNative` both succeed,
and confirmed against the reproduction from #1815 using the built native
binary:

```console
$ pkl-macos-aarch64 eval main.pkl
imports = Map("all", "file:///private/tmp/pklbug/sub/*.pkl")
```
