### PR TITLE
Fix block comment at EOF without trailing newline

### DIFF
--- a/pkl-parser/src/main/java/org/pkl/parser/Lexer.java
+++ b/pkl-parser/src/main/java/org/pkl/parser/Lexer.java
@@ -625,11 +625,11 @@ public final class Lexer {
     while (lookahead != EOF) {
       if (prev == '*' && lookahead == '/') {
         nextChar();
-        break;
+        return;
       }
       prev = nextChar();
     }
-    if (lookahead == EOF) throw unexpectedEndOfFile();
+    throw unexpectedEndOfFile();
   }
 
   private void lexHexNumber() {

--- a/pkl-parser/src/test/kotlin/org/pkl/parser/LexerTest.kt
+++ b/pkl-parser/src/test/kotlin/org/pkl/parser/LexerTest.kt
@@ -114,34 +114,35 @@ class LexerTest {
   }
 
   @Test
-  fun blockCommentAtEndOfFileWithoutTrailingNewline() {
+  fun `block comment at EOF without trailing newline`() {
     // A block comment that is the last thing in the file, with no trailing
     // newline, must lex correctly and not be mistaken for an unterminated comment.
     val lexer = Lexer("/*\nbar\n*/")
     assertThat(lexer.next()).isEqualTo(Token.BLOCK_COMMENT)
     assertThat(lexer.next()).isEqualTo(Token.EOF)
-
-    // Preceding code followed by the trailing block comment.
-    val withCode = Lexer("foo = 123\n/*\nbar\n*/")
-    assertThat(withCode.next()).isEqualTo(Token.IDENTIFIER)
-    assertThat(withCode.next()).isEqualTo(Token.ASSIGN)
-    assertThat(withCode.next()).isEqualTo(Token.INT)
-    assertThat(withCode.next()).isEqualTo(Token.BLOCK_COMMENT)
-    assertThat(withCode.next()).isEqualTo(Token.EOF)
-
-    // Empty block comment at end of file.
-    val empty = Lexer("/**/")
-    assertThat(empty.next()).isEqualTo(Token.BLOCK_COMMENT)
-    assertThat(empty.next()).isEqualTo(Token.EOF)
   }
 
   @Test
-  fun plainCodeAtEndOfFileWithoutTrailingNewline() {
-    // Guard/boundary test — NOT a regression test for the block-comment EOF
-    // bug. Plain code never enters the block-comment path, so this passes with
-    // or without that fix. It documents that code whose final line has no
-    // trailing newline lexes cleanly and terminates with EOF rather than
-    // erroring.
+  fun `block comment after code at EOF without trailing newline`() {
+    val lexer = Lexer("foo = 123\n/*\nbar\n*/")
+    assertThat(lexer.next()).isEqualTo(Token.IDENTIFIER)
+    assertThat(lexer.next()).isEqualTo(Token.ASSIGN)
+    assertThat(lexer.next()).isEqualTo(Token.INT)
+    assertThat(lexer.next()).isEqualTo(Token.BLOCK_COMMENT)
+    assertThat(lexer.next()).isEqualTo(Token.EOF)
+  }
+
+  @Test
+  fun `empty block comment at EOF without trailing newline`() {
+    val lexer = Lexer("/**/")
+    assertThat(lexer.next()).isEqualTo(Token.BLOCK_COMMENT)
+    assertThat(lexer.next()).isEqualTo(Token.EOF)
+  }
+
+  @Test
+  fun `plain code at EOF without trailing newline`() {
+    // Documents that code whose final line has no trailing newline lexes
+    // cleanly and terminates with EOF rather than erroring.
     val lexer = Lexer("foo = 123")
     assertThat(lexer.next()).isEqualTo(Token.IDENTIFIER)
     assertThat(lexer.next()).isEqualTo(Token.ASSIGN)
@@ -150,7 +151,7 @@ class LexerTest {
   }
 
   @Test
-  fun unterminatedBlockCommentFails() {
+  fun `unterminated block comment fails`() {
     val thrown = assertThrows<ParserError> { Lexer("/* bar").next() }
     assertThat(thrown).hasMessageContaining("Unexpected end of file")
 

--- a/pkl-parser/src/test/kotlin/org/pkl/parser/LexerTest.kt
+++ b/pkl-parser/src/test/kotlin/org/pkl/parser/LexerTest.kt
@@ -114,6 +114,51 @@ class LexerTest {
   }
 
   @Test
+  fun blockCommentAtEndOfFileWithoutTrailingNewline() {
+    // A block comment that is the last thing in the file, with no trailing
+    // newline, must lex correctly and not be mistaken for an unterminated comment.
+    val lexer = Lexer("/*\nbar\n*/")
+    assertThat(lexer.next()).isEqualTo(Token.BLOCK_COMMENT)
+    assertThat(lexer.next()).isEqualTo(Token.EOF)
+
+    // Preceding code followed by the trailing block comment.
+    val withCode = Lexer("foo = 123\n/*\nbar\n*/")
+    assertThat(withCode.next()).isEqualTo(Token.IDENTIFIER)
+    assertThat(withCode.next()).isEqualTo(Token.ASSIGN)
+    assertThat(withCode.next()).isEqualTo(Token.INT)
+    assertThat(withCode.next()).isEqualTo(Token.BLOCK_COMMENT)
+    assertThat(withCode.next()).isEqualTo(Token.EOF)
+
+    // Empty block comment at end of file.
+    val empty = Lexer("/**/")
+    assertThat(empty.next()).isEqualTo(Token.BLOCK_COMMENT)
+    assertThat(empty.next()).isEqualTo(Token.EOF)
+  }
+
+  @Test
+  fun plainCodeAtEndOfFileWithoutTrailingNewline() {
+    // Guard/boundary test — NOT a regression test for the block-comment EOF
+    // bug. Plain code never enters the block-comment path, so this passes with
+    // or without that fix. It documents that code whose final line has no
+    // trailing newline lexes cleanly and terminates with EOF rather than
+    // erroring.
+    val lexer = Lexer("foo = 123")
+    assertThat(lexer.next()).isEqualTo(Token.IDENTIFIER)
+    assertThat(lexer.next()).isEqualTo(Token.ASSIGN)
+    assertThat(lexer.next()).isEqualTo(Token.INT)
+    assertThat(lexer.next()).isEqualTo(Token.EOF)
+  }
+
+  @Test
+  fun unterminatedBlockCommentFails() {
+    val thrown = assertThrows<ParserError> { Lexer("/* bar").next() }
+    assertThat(thrown).hasMessageContaining("Unexpected end of file")
+
+    val justOpener = assertThrows<ParserError> { Lexer("/*").next() }
+    assertThat(justOpener).hasMessageContaining("Unexpected end of file")
+  }
+
+  @Test
   fun acceptsAllUnicodeCodepointsInComments() {
     // Test valid Unicode codepoints can appear literally
     // without being misinterpreted as EOF.


### PR DESCRIPTION
## What

A `/* ... */` block comment that is the last content in a file **with no trailing newline** was rejected as unterminated and failed with `Unexpected end of file.` The identical source with a trailing newline parsed fine.

This is not specific to having code before the comment — a file containing only `/*\nbar\n*/` (no trailing newline), or even just `/**/`, failed the same way. It reproduces on the latest release (0.32.1) and on `main`.

## Why

In `Lexer.lexBlockComment()`, after the closing `*/` is consumed, `lookahead` becomes `EOF` when `/` is the final character of the file. The trailing `if (lookahead == EOF) throw unexpectedEndOfFile();` then fired even though the comment was correctly terminated. The check could not distinguish "found `*/` exactly at EOF" from "reached EOF without finding `*/`".

## How

Return as soon as `*/` is consumed, and report unterminated input only when the scan loop reaches EOF without finding `*/`. Added `LexerTest` regression cases for a trailing block comment (with and without preceding code, and the empty `/**/` case), plus genuinely unterminated comments (`/* bar`, `/*`).

Fixes #1827.