### PR TITLE
Add AGENTS.md with PR guidelines for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Guidelines for AI agents
+
+Quick notes for automated contributors. They do not replace the human docs:
+**read `CONTRIBUTING.adoc` and `DEVELOPMENT.adoc` before opening a pull
+request**, and follow them.
+
+## Pull requests
+
+The essentials from `CONTRIBUTING.adoc`:
+
+- Imitate the conventions of the surrounding code.
+- Format with `./gradlew spotlessApply` (an unformatted build fails).
+- Verify both `./gradlew build` (JVM) and `./gradlew buildNative` (native) pass.
+- Write a Git commit message that follows the seven rules: a capitalized,
+  imperative subject line, a blank line, then a body explaining what and why.
+
+**Do not edit the changelog or release notes.** The files under
+`docs/modules/release-notes/` are curated by maintainers at release time;
+contributor PRs leave them unchanged. Put context in the pull request
+description and reference the relevant issue instead.
+
+## Tests
+
+- Add tests beside the existing ones and run the smallest relevant task, for
+  example `./gradlew :pkl-parser:test`.
+- Name Kotlin (JUnit) test methods in backtick "space case", not camelCase:
+  `` fun `rejects sentinel between tokens`() { ... } ``.


### PR DESCRIPTION
## What

Adds a root-level `AGENTS.md` — the vendor-neutral, auto-discovered
conventions file that GitHub Copilot, Codex, Cursor, and other coding
agents read — with brief guidance for opening pull requests in this repo.

## Why

Agents (and new contributors) otherwise rediscover the process per change,
and sometimes go off on tangents. The file keeps it short and points at the
authoritative docs:

- Read `CONTRIBUTING.adoc` and `DEVELOPMENT.adoc` first, and follow their
  PR checklist (spotless, JVM + native build, seven-rules commit message).
- **Do not edit the changelog or release notes** — those under
  `docs/modules/release-notes/` are maintainer-curated at release time, so
  contributor PRs should leave them untouched.
- Name Kotlin (JUnit) test methods in backtick "space case", matching the
  convention maintainers asked for in review.

Nothing here changes build or runtime behavior; it is documentation only.
