### PR TITLE
Make generator nodes more PE friendly

### DIFF
--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/generator/GeneratorForNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/generator/GeneratorForNode.java
@@ -149,13 +149,14 @@ public abstract class GeneratorForNode extends GeneratorMemberNode {
   }
 
   private void doEvalObject(VirtualFrame frame, VmObject iterable, Object parent, ObjectData data) {
+    var materializedFrame = frame.materialize();
     iterable.forceAndIterateMemberValues(
         (key, member, value) -> {
           var convertedKey = member.isProp() ? key.toString() : key;
           // TODO: Executing iteration behind a Truffle boundary is bad for performance.
           // This and similar cases will be fixed in an upcoming PR that replaces method
           // `(forceAnd)iterateMemberValues` with cursor-based external iterators.
-          executeIteration(frame, parent, data, convertedKey, value);
+          executeIteration(materializedFrame, parent, data, convertedKey, value);
           return true;
         });
   }

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/generator/GeneratorSpreadNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/generator/GeneratorSpreadNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -189,47 +189,51 @@ public abstract class GeneratorSpreadNode extends GeneratorMemberNode {
   }
 
   protected void doEvalDynamic(VirtualFrame frame, ObjectData data, VmObject iterable) {
+    var materializedFrame = frame.materialize();
     iterable.forceAndIterateMemberValues(
         (key, member, value) -> {
           if (member.isElement()) {
-            data.addElement(frame, createMember(member, value), this);
+            data.addElement(materializedFrame, createMember(member, value), this);
           } else {
-            data.addMember(frame, key, createMember(member, value), this);
+            data.addMember(materializedFrame, key, createMember(member, value), this);
           }
           return true;
         });
   }
 
   private void doEvalMapping(VirtualFrame frame, ObjectData data, VmObject iterable) {
+    var materializedFrame = frame.materialize();
     iterable.forceAndIterateMemberValues(
         (key, member, value) -> {
           if (member.isElement() || member.isProp()) {
             cannotHaveMember(BaseModule.getMappingClass(), member);
           }
-          data.addMember(frame, key, createMember(member, value), this);
+          data.addMember(materializedFrame, key, createMember(member, value), this);
           return true;
         });
   }
 
   private void doEvalListing(VirtualFrame frame, ObjectData data, VmObject iterable) {
+    var materializedFrame = frame.materialize();
     iterable.forceAndIterateMemberValues(
         (key, member, value) -> {
           if (member.isEntry() || member.isProp()) {
             cannotHaveMember(getListingClass(), member);
           }
-          data.addElement(frame, createMember(member, value), this);
+          data.addElement(materializedFrame, createMember(member, value), this);
           return true;
         });
   }
 
   private void doEvalTyped(VirtualFrame frame, VmClass clazz, ObjectData data, VmObject iterable) {
+    var materializedFrame = frame.materialize();
     iterable.forceAndIterateMemberValues(
         (key, member, value) -> {
           if (member.isElement() || member.isEntry()) {
             cannotHaveMember(clazz, member);
           }
           checkIsValidTypedProperty(clazz, member);
-          data.addProperty(frame, createMember(member, value), this);
+          data.addProperty(materializedFrame, createMember(member, value), this);
           return true;
         });
   }

--- a/pkl-core/src/main/java/org/pkl/core/ast/expression/generator/GeneratorWhenNode.java
+++ b/pkl-core/src/main/java/org/pkl/core/ast/expression/generator/GeneratorWhenNode.java
@@ -16,6 +16,7 @@
 package org.pkl.core.ast.expression.generator;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
@@ -41,7 +42,6 @@ public final class GeneratorWhenNode extends GeneratorMemberNode {
   }
 
   @Override
-  @ExplodeLoop
   public void execute(VirtualFrame frame, Object parent, ObjectData data) {
     boolean condition;
     try {
@@ -53,7 +53,18 @@ public final class GeneratorWhenNode extends GeneratorMemberNode {
           .withSourceSection(conditionNode.getSourceSection())
           .build();
     }
-    for (var node : condition ? thenNodes : elseNodes) {
+    if (condition) {
+      executeNodes(thenNodes, frame, parent, data);
+    } else {
+      executeNodes(elseNodes, frame, parent, data);
+    }
+  }
+
+  @ExplodeLoop
+  private void executeNodes(
+      GeneratorMemberNode[] nodes, VirtualFrame frame, Object parent, ObjectData data) {
+    for (var node : nodes) {
+      TruffleSafepoint.poll(this);
       node.execute(frame, parent, data);
     }
   }


### PR DESCRIPTION
* In GeneratorWhenNode, need to move individual iterations into their own methods so that the @ExplodeLoop sees a constant number of iterations based on call site.
* In the other nodes, the lambda passed to `forceAndIterateMemberValues` needs to capture the materialized frame, not the virtual frame.